### PR TITLE
README.adoc: update Travis and Appveyor badges

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,8 @@
 = Address Book (Level 4)
 ifdef::env-github,env-browser[:relfileprefix: docs/]
 
-https://travis-ci.org/se-edu/addressbook-level4[image:https://travis-ci.org/se-edu/addressbook-level4.svg?branch=master[Build Status]]
-https://ci.appveyor.com/project/damithc/addressbook-level4[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
+https://travis-ci.org/CS2103-AY1819S1-T16-4/main[image:https://travis-ci.org/CS2103-AY1819S1-T16-4/main.svg?branch=master[Build Status]]
+https://ci.appveyor.com/project/rongjiecomputer/main[image:https://ci.appveyor.com/api/projects/status/bh9l24v9mrpvixel?svg=true[Build status]]
 https://coveralls.io/github/se-edu/addressbook-level4?branch=master[image:https://coveralls.io/repos/github/se-edu/addressbook-level4/badge.svg?branch=master[Coverage Status]]
 https://www.codacy.com/app/damith/addressbook-level4?utm_source=github.com&utm_medium=referral&utm_content=se-edu/addressbook-level4&utm_campaign=Badge_Grade[image:https://api.codacy.com/project/badge/Grade/fc0b7775cf7f4fdeaf08776f3d8e364a[Codacy Badge]]
 https://gitter.im/se-edu/Lobby[image:https://badges.gitter.im/se-edu/Lobby.svg[Gitter chat]]


### PR DESCRIPTION
Point the badge URLs to the new Travis and Appveyor accounts.

Tracking bug: #1