### PR TITLE
Expose Model.getModuleInfo()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ preferences.json
 .DS_Store
 ./screenshot*.png
 classes/
-/data/
+/data/addressbook.xml
 /bin/
 src/main/resources/docs/
 out/

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation group: 'org.controlsfx', name: 'controlsfx', version: '8.40.11'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
-    implementation group: 'com.google.guava', name: 'guava', version: '19.0'
+    implementation group: 'com.google.guava', name: 'guava', version: '21.0'
     implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.8'
     implementation group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.0'
     implementation group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.3.0'

--- a/data/moduleInfo.json
+++ b/data/moduleInfo.json
@@ -4,7 +4,6 @@
     "name": "Financial Accounting",
     "creditCount": 4.0,
     "preclusions": [
-      "FNA1002",
       "ACC1002"
     ],
     "prerequisites": []
@@ -14,15 +13,10 @@
     "name": "Financial Accounting",
     "creditCount": 4.0,
     "preclusions": [
-      "CS1304",
       "EC3212",
-      "BK1003",
       "BZ1002",
-      "BH1002",
       "BZ1002E",
-      "BH1002E",
       "FNA1002E",
-      "FNA1002X",
       "ACC1002X"
     ],
     "prerequisites": []
@@ -32,11 +26,9 @@
     "name": "Accounting Information Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "FNA1006",
       "ACC1006"
     ],
     "prerequisites": [
-      "FNA1002",
       "ACC1002"
     ]
   },
@@ -66,24 +58,17 @@
     "name": "Managerial Accounting",
     "creditCount": 4.0,
     "preclusions": [
-      "BH2002",
       "BZ3102",
-      "BK2001",
       "FNA2002",
       "IE4242"
     ],
     "prerequisites": [
-      "BK1003",
       "BZ1002",
-      "BH1002",
       "FNA1002",
-      "FNA1002X",
       "FNA1002E",
       "ACC1002",
       "ACC1002X",
-      "BH1002E",
       "CS1304",
-      "EC3212",
       "EG1422",
       "ACC2002"
     ]
@@ -112,7 +97,6 @@
       "ACC1701",
       "ACC1701X",
       "EC2204",
-      "AC1002",
       "ACC1002X"
     ]
   },
@@ -145,13 +129,10 @@
     "name": "Corporate Accounting and Reporting",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3111",
       "BZ3101",
-      "BK3106",
       "FNA3111"
     ],
     "prerequisites": [
-      "FNA1002",
       "ACC1002"
     ]
   },
@@ -160,13 +141,10 @@
     "name": "Assurance and Attestation",
     "creditCount": 4.0,
     "preclusions": [
-      "FNA3121",
       "ACC3603"
     ],
     "prerequisites": [
-      "FNA1002",
-      "ACC1002",
-      "FNA2002"
+      "ACC1002"
     ]
   },
   {
@@ -174,7 +152,6 @@
     "name": "Corporate and Securities Law",
     "creditCount": 4.0,
     "preclusions": [
-      "FNA3122",
       "LL4055",
       "ACC3604"
     ],
@@ -187,12 +164,10 @@
     "name": "Taxation",
     "creditCount": 4.0,
     "preclusions": [
-      "FNA3127",
       "LL4056",
       "ACC3605"
     ],
     "prerequisites": [
-      "FNA1002",
       "ACC1002",
       "BSP1004"
     ]
@@ -202,11 +177,9 @@
     "name": "Advanced Corporate Accounting and Reporting",
     "creditCount": 4.0,
     "preclusions": [
-      "FNA3123",
       "ACC3606"
     ],
     "prerequisites": [
-      "FNA3111",
       "ACC3601"
     ]
   },
@@ -215,11 +188,9 @@
     "name": "Valuation",
     "creditCount": 4.0,
     "preclusions": [
-      "FNA3126",
       "ACC3614"
     ],
     "prerequisites": [
-      "FNA2004",
       "FIN2004"
     ]
   },
@@ -228,9 +199,7 @@
     "name": "Corporate Governance and Risk Management",
     "creditCount": 4.0,
     "preclusions": [
-      "ACC3611",
-      "ACC3612",
-      "AY2014"
+      "ACC3612"
     ],
     "prerequisites": [
       "ACC1002",
@@ -262,8 +231,7 @@
     "name": "Taxation",
     "creditCount": 4.0,
     "preclusions": [
-      "ACC3605",
-      "LL4056"
+      "ACC3605"
     ],
     "prerequisites": [
       "ACC1701",
@@ -278,7 +246,6 @@
     "name": "Advanced Taxation",
     "creditCount": 4.0,
     "preclusions": [
-      "FNA4114",
       "ACC4611"
     ],
     "prerequisites": []
@@ -292,7 +259,6 @@
       "ACC3603",
       "ACC3616",
       "ACC3603",
-      "ACC3611",
       "ACC3612"
     ]
   },
@@ -308,12 +274,10 @@
     "name": "Advanced Assurance and Attestation",
     "creditCount": 4.0,
     "preclusions": [
-      "FNA3128",
       "ACC3613",
       "ACC4615"
     ],
     "prerequisites": [
-      "FNA3121",
       "ACC3603"
     ]
   },
@@ -619,9 +583,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "AR1326",
       "AR1731",
-      "AR2326",
       "AR2723"
     ]
   },
@@ -1139,11 +1101,8 @@
     "creditCount": 2.0,
     "preclusions": [],
     "prerequisites": [
-      "AUD5102",
       "AUD5103",
-      "AUD5106",
-      "AUD5107",
-      "AUD5108"
+      "AUD5107"
     ]
   },
   {
@@ -1152,9 +1111,7 @@
     "creditCount": 3.0,
     "preclusions": [],
     "prerequisites": [
-      "AUD5102",
-      "AUD5103",
-      "AUD5110"
+      "AUD5103"
     ]
   },
   {
@@ -1163,11 +1120,8 @@
     "creditCount": 3.0,
     "preclusions": [],
     "prerequisites": [
-      "AUD5101",
       "AUD5104",
-      "AUD5105",
       "AUD5111",
-      "AUD5106",
       "AUD5112"
     ]
   },
@@ -1177,13 +1131,9 @@
     "creditCount": 3.0,
     "preclusions": [],
     "prerequisites": [
-      "AUD5105",
       "AUD5111",
-      "AUD5106",
       "AUD5112",
-      "AUD5107",
       "AUD5113",
-      "AUD5108",
       "AUD5114"
     ]
   },
@@ -1193,11 +1143,8 @@
     "creditCount": 3.0,
     "preclusions": [],
     "prerequisites": [
-      "AUD5105",
       "AUD5111",
-      "AUD5107",
       "AUD5113",
-      "AUD5108",
       "AUD5114"
     ]
   },
@@ -1206,9 +1153,7 @@
     "name": "Independent Studies in Audiology (Research project - part 1)",
     "creditCount": 8.0,
     "preclusions": [],
-    "prerequisites": [
-      "AUD5115"
-    ]
+    "prerequisites": []
   },
   {
     "code": "AUD5221",
@@ -1216,11 +1161,8 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "AUD5101",
       "AUD5104",
-      "AUD5105",
       "AUD5111",
-      "AUD5106",
       "AUD5112"
     ]
   },
@@ -1230,7 +1172,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "AUD5105",
       "AUD5218"
     ]
   },
@@ -1240,7 +1181,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "AUD5105",
       "AUD5218"
     ]
   },
@@ -1295,9 +1235,7 @@
     "name": "Seminar in Innovation and Entrepreneurship",
     "creditCount": 2.0,
     "preclusions": [],
-    "prerequisites": [
-      "BBP6781"
-    ]
+    "prerequisites": []
   },
   {
     "code": "BDC5101",
@@ -1310,18 +1248,14 @@
     "code": "BDC6111",
     "name": "Foundations of Optimization",
     "creditCount": 4.0,
-    "preclusions": [
-      "IE6001"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "BDC6112",
     "name": "Stochastic Processes I",
     "creditCount": 4.0,
-    "preclusions": [
-      "IE6004"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -1330,8 +1264,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "BDC6111",
-      "IE6001"
+      "BDC6111"
     ]
   },
   {
@@ -1349,8 +1282,7 @@
       "IE6505"
     ],
     "prerequisites": [
-      "BDC6112",
-      "IE6004"
+      "BDC6112"
     ]
   },
   {
@@ -1442,7 +1374,6 @@
     "name": "Work Experience Internship",
     "creditCount": 4.0,
     "preclusions": [
-      "BI3001",
       "BI3002",
       "BI3003"
     ],
@@ -1453,7 +1384,6 @@
     "name": "Work Experience Internship",
     "creditCount": 4.0,
     "preclusions": [
-      "BI3001",
       "BI3002",
       "BI3003"
     ],
@@ -1464,7 +1394,6 @@
     "name": "Work Experience Internship",
     "creditCount": 4.0,
     "preclusions": [
-      "BI3001",
       "BI3002",
       "BI3003"
     ],
@@ -1475,7 +1404,6 @@
     "name": "Work Experience Internship",
     "creditCount": 4.0,
     "preclusions": [
-      "BI3001",
       "BI3002",
       "BI3003"
     ],
@@ -1486,7 +1414,6 @@
     "name": "Work Experience Internship",
     "creditCount": 4.0,
     "preclusions": [
-      "BI3001",
       "BI3002",
       "BI3003"
     ],
@@ -1705,10 +1632,8 @@
     "creditCount": 2.0,
     "preclusions": [],
     "prerequisites": [
-      "MNO1706",
       "MNO1706X",
-      "PL3239",
-      "MNO2705"
+      "PL3239"
     ]
   },
   {
@@ -1717,10 +1642,8 @@
     "creditCount": 2.0,
     "preclusions": [],
     "prerequisites": [
-      "MNO1706",
       "MNO1706X",
-      "PL3239",
-      "MNO2705"
+      "PL3239"
     ]
   },
   {
@@ -1729,10 +1652,8 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MNO1706",
       "MNO1706X",
-      "PL3239",
-      "MNO2705"
+      "PL3239"
     ]
   },
   {
@@ -2448,9 +2369,7 @@
     "code": "BMK5006",
     "name": "Consumer Culture Theory",
     "creditCount": 4.0,
-    "preclusions": [
-      "MKT3423"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -2669,7 +2588,6 @@
     "name": "International Financial Management",
     "creditCount": 4.0,
     "preclusions": [
-      "FIN3115",
       "BMA5301"
     ],
     "prerequisites": []
@@ -2679,7 +2597,6 @@
     "name": "Financial Markets and Institutions",
     "creditCount": 4.0,
     "preclusions": [
-      "FIN3103",
       "FIN3701"
     ],
     "prerequisites": []
@@ -2689,8 +2606,7 @@
     "name": "Personal Finance and Wealth Management",
     "creditCount": 4.0,
     "preclusions": [
-      "FIN4113",
-      "FIN4713"
+      "FIN4113"
     ],
     "prerequisites": []
   },
@@ -2719,9 +2635,7 @@
     "code": "BMS5406",
     "name": "Asian Leadership",
     "creditCount": 4.0,
-    "preclusions": [
-      "BMA5420"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -2737,9 +2651,7 @@
     "code": "BMS5504",
     "name": "Marketing Analysis and Decision Making",
     "creditCount": 4.0,
-    "preclusions": [
-      "MKT3421"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -2747,7 +2659,6 @@
     "name": "Marketing in the Digital Age",
     "creditCount": 4.0,
     "preclusions": [
-      "MKT3415",
       "BMA5533"
     ],
     "prerequisites": []
@@ -2756,18 +2667,14 @@
     "code": "BMS5900",
     "name": "Block Seminar (with emphasis on Asian context)",
     "creditCount": 2.0,
-    "preclusions": [
-      "BMO5000"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "BMS5901",
     "name": "Business Project",
     "creditCount": 10.0,
-    "preclusions": [
-      "BMO5002"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -2862,9 +2769,7 @@
     "name": "Bioengineering Data Analysis",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "MA1506"
-    ]
+    "prerequisites": []
   },
   {
     "code": "BN2201",
@@ -2872,7 +2777,6 @@
     "creditCount": 4.0,
     "preclusions": [
       "LSM3212",
-      "PY1105",
       "PY1106"
     ],
     "prerequisites": []
@@ -2883,8 +2787,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MA1505",
-      "MA1506"
+      "MA1505"
     ]
   },
   {
@@ -2892,7 +2795,6 @@
     "name": "Fundamentals of Biomechanics",
     "creditCount": 4.0,
     "preclusions": [
-      "EG1109",
       "EG1109M"
     ],
     "prerequisites": [
@@ -2914,9 +2816,7 @@
     "code": "BN2403",
     "name": "Fundamentals of Biosignals and Bioinstrumentation",
     "creditCount": 4.0,
-    "preclusions": [
-      "EG1108"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PC1432",
       "BN1102"
@@ -2933,9 +2833,7 @@
     "code": "BN3202",
     "name": "Musculoskeletal Biomechanics",
     "creditCount": 4.0,
-    "preclusions": [
-      "BN3201"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "BN2204"
     ]
@@ -2948,9 +2846,7 @@
     "prerequisites": [
       "CM1121",
       "CM1501",
-      "LSM1101",
       "LSM1401",
-      "MLE1101",
       "MLE3104"
     ]
   },
@@ -2959,9 +2855,7 @@
     "name": "Biomedical Electronics & Systems",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "BN2402"
-    ]
+    "prerequisites": []
   },
   {
     "code": "BN3402",
@@ -2971,7 +2865,6 @@
     "prerequisites": [
       "CM1121",
       "CM1501",
-      "LSM1101",
       "LSM1401"
     ]
   },
@@ -2981,7 +2874,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MA1506",
       "PC1432",
       "CN2122",
       "ME2134",
@@ -3027,9 +2919,7 @@
     "name": "Rehabilitation Engineering",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "BN3201"
-    ]
+    "prerequisites": []
   },
   {
     "code": "BN4301",
@@ -3046,7 +2936,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "EG1108",
       "PC1432"
     ]
   },
@@ -3055,9 +2944,7 @@
     "name": "Cellular Bioengineering",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "LSM2103"
-    ]
+    "prerequisites": []
   },
   {
     "code": "BN4404",
@@ -3071,9 +2958,7 @@
     "name": "Biophotonics And Bioimaging",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "BN2401"
-    ]
+    "prerequisites": []
   },
   {
     "code": "BN4501",
@@ -3082,7 +2967,6 @@
     "preclusions": [],
     "prerequisites": [
       "MA1505",
-      "MA1506",
       "LSM1401"
     ]
   },
@@ -3139,9 +3023,7 @@
     "code": "BN5207",
     "name": "Medical Imaging Systems",
     "creditCount": 4.0,
-    "preclusions": [
-      "MDG5225"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -3149,9 +3031,7 @@
     "name": "Biomedical Quality and Regulatory Systems",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "BN5401"
-    ]
+    "prerequisites": []
   },
   {
     "code": "BN5210",
@@ -3256,7 +3136,6 @@
     "name": "Integrated Building Design",
     "creditCount": 4.0,
     "preclusions": [
-      "BPS5101",
       "BPS5111"
     ],
     "prerequisites": []
@@ -3273,7 +3152,6 @@
     "name": "Microclimate Design",
     "creditCount": 4.0,
     "preclusions": [
-      "BPS5102",
       "BPS5221"
     ],
     "prerequisites": []
@@ -3283,7 +3161,6 @@
     "name": "Indoor Environmental Quality",
     "creditCount": 4.0,
     "preclusions": [
-      "BPS5201",
       "BPS5202",
       "BPS5222"
     ],
@@ -3294,7 +3171,6 @@
     "name": "Building Energy Performance - Passive Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "BPS5204",
       "BPS5223"
     ],
     "prerequisites": []
@@ -3304,7 +3180,6 @@
     "name": "Building Energy Performance - Active Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "BPS5204",
       "BPS5224"
     ],
     "prerequisites": []
@@ -3328,7 +3203,6 @@
     "name": "Maintainability and Green Facilities Management",
     "creditCount": 4.0,
     "preclusions": [
-      "BPS5205",
       "BPS5227"
     ],
     "prerequisites": []
@@ -3387,14 +3261,10 @@
     "name": "Legal Environment Of Business",
     "creditCount": 4.0,
     "preclusions": [
-      "SSB2212",
       "BH1004",
-      "BZ1004",
       "BK1006",
-      "GEK1009",
       "GEM1009",
       "SSD1203",
-      "BSP1004A",
       "BSP1004B"
     ],
     "prerequisites": []
@@ -3404,14 +3274,10 @@
     "name": "Legal Environment Of Business",
     "creditCount": 4.0,
     "preclusions": [
-      "SSB2212",
       "BH1004",
-      "BZ1004",
       "BK1006",
-      "GEK1009",
       "GEM1009",
       "SSD1203",
-      "BSP1004A",
       "BSP1004B"
     ],
     "prerequisites": []
@@ -3421,9 +3287,7 @@
     "name": "Managerial Economics",
     "creditCount": 4.0,
     "preclusions": [
-      "BH1005",
-      "BZ1006",
-      "BK1008"
+      "BZ1006"
     ],
     "prerequisites": []
   },
@@ -3466,21 +3330,15 @@
     "name": "Macro And International Economics",
     "creditCount": 4.0,
     "preclusions": [
-      "BH2001",
       "BZ2001",
-      "EC1101",
       "EC1101E",
-      "EC1310",
       "EC1301",
-      "EC3341",
       "EC4102",
       "EC2102"
     ],
     "prerequisites": [
       "BSP1005",
-      "BH1005",
-      "BZ1006",
-      "BK1008"
+      "BZ1006"
     ]
   },
   {
@@ -3488,7 +3346,6 @@
     "name": "Asian Business Environments",
     "creditCount": 4.0,
     "preclusions": [
-      "BH2005",
       "BZ2005"
     ],
     "prerequisites": [
@@ -3502,7 +3359,6 @@
     "preclusions": [],
     "prerequisites": [
       "BSP1703",
-      "BSP1707",
       "EC1101E",
       "EC1301"
     ]
@@ -3512,11 +3368,8 @@
     "name": "Strategic Management",
     "creditCount": 4.0,
     "preclusions": [
-      "BSP3001A",
       "BSP3001B",
-      "BSP3001C",
-      "BSP3001D",
-      "BSP3001E"
+      "BSP3001D"
     ],
     "prerequisites": []
   },
@@ -3602,7 +3455,6 @@
     "prerequisites": [
       "BT2101",
       "CS1020",
-      "CS2020",
       "CS2030",
       "CS2103",
       "CS2113"
@@ -3692,7 +3544,6 @@
       "BT2101",
       "BT2102",
       "CS2010",
-      "CS2020",
       "CS2040"
     ]
   },
@@ -3713,11 +3564,8 @@
     "code": "BT4240",
     "name": "Machine Learning for Predictive Data Analytics",
     "creditCount": 4.0,
-    "preclusions": [
-      "IS4240"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "MA1311",
       "MA1101R",
       "MA1521",
       "MA1102R",
@@ -3853,9 +3701,7 @@
     "name": "Translational Cancer Research",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "CDM5101"
-    ]
+    "prerequisites": []
   },
   {
     "code": "CDM5103",
@@ -3885,9 +3731,7 @@
     "preclusions": [
       "TCE2112"
     ],
-    "prerequisites": [
-      "EG1109"
-    ]
+    "prerequisites": []
   },
   {
     "code": "CE2134",
@@ -3898,9 +3742,7 @@
       "TCE2134"
     ],
     "prerequisites": [
-      "EG1109FC",
-      "EG1109",
-      "CE1109X"
+      "EG1109"
     ]
   },
   {
@@ -3911,7 +3753,6 @@
       "TCE2155"
     ],
     "prerequisites": [
-      "EG1109FC",
       "EG1109"
     ]
   },
@@ -3928,21 +3769,16 @@
     "code": "CE2407",
     "name": "Engineering & Uncertainty Analyses",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE2407"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "MA1505",
-      "MA1506"
+      "MA1505"
     ]
   },
   {
     "code": "CE2409",
     "name": "Computer Applications in Civil Engineering",
     "creditCount": 4.0,
-    "preclusions": [
-      "CE2408"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -3985,9 +3821,7 @@
     "code": "CE3121",
     "name": "Transportation Engineering",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE3121"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE2407"
     ]
@@ -3996,9 +3830,7 @@
     "code": "CE3132",
     "name": "Water Resources Engineering",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE3132"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE2134"
     ]
@@ -4007,13 +3839,9 @@
     "code": "CE3155",
     "name": "Structural Analysis",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE3155"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "EG1109FC",
-      "EG1109",
-      "CE1109X"
+      "EG1109"
     ]
   },
   {
@@ -4043,27 +3871,21 @@
     "code": "CE4103",
     "name": "Design Project",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE4103"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "CE4104",
     "name": "B. Eng. Dissertation",
     "creditCount": 8.0,
-    "preclusions": [
-      "TCE4104"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "CE4221",
     "name": "Design of Land Transport Infrastructures",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE4221"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE3121"
     ]
@@ -4072,9 +3894,7 @@
     "code": "CE4257",
     "name": "Linear Finite Element Analysis",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE4257"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE3155"
     ]
@@ -4099,9 +3919,7 @@
     "code": "CE4258",
     "name": "Structural Stability & Dynamics",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE4258"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE2407",
       "CE3155"
@@ -4111,9 +3929,7 @@
     "code": "CE4282",
     "name": "Building Information Modeling for Project Management",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE4282"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -4166,9 +3982,7 @@
     "code": "CE5106",
     "name": "Ground Improvement",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE5106"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE2112"
     ]
@@ -4193,9 +4007,7 @@
     "code": "CE5107",
     "name": "Pile Foundations",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE5107"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE2112",
       "CE3116"
@@ -4221,9 +4033,7 @@
     "code": "CE5108",
     "name": "Earth Retaining Structures",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE5108"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE2112"
     ]
@@ -4264,9 +4074,7 @@
     "code": "CE5113",
     "name": "Geotechnical Investigation & Monitoring",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE5113"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -4323,9 +4131,7 @@
     "code": "CE5307",
     "name": "Wave Hydrodynamics",
     "creditCount": 4.0,
-    "preclusions": [
-      "OT5201"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE2134"
     ]
@@ -4367,12 +4173,10 @@
     "name": "Numerical Methods in Mechanics & Envr. Flows",
     "creditCount": 4.0,
     "preclusions": [
-      "CE5311",
       "CE6003",
       "CE6077"
     ],
     "prerequisites": [
-      "EG1109",
       "CE1109",
       "CE2134"
     ]
@@ -4381,9 +4185,7 @@
     "code": "CE5509",
     "name": "Advanced Structural Steel Design",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE5509"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE3166"
     ]
@@ -4406,9 +4208,7 @@
     "code": "CE5510",
     "name": "Advanced Structural Concrete Design",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE5510"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE3165"
     ]
@@ -4433,9 +4233,7 @@
     "code": "CE5513",
     "name": "Plastic Analysis Of Structures",
     "creditCount": 4.0,
-    "preclusions": [
-      "CE5885A"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE2155"
     ]
@@ -4451,9 +4249,7 @@
     "code": "CE5604",
     "name": "Advanced Concrete Technology",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE5604"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE2155"
     ]
@@ -4487,7 +4283,6 @@
     "creditCount": 4.0,
     "preclusions": [
       "CE5610",
-      "AY2008",
       "TCE5611"
     ],
     "prerequisites": []
@@ -4526,9 +4321,7 @@
     "code": "CE5805",
     "name": "DfMA & Productivity Analytics in Construction",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE5805"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE2183"
     ]
@@ -4589,12 +4382,10 @@
     "name": "Advanced Numerical Methods in Mechanics & Envr. Flows",
     "creditCount": 4.0,
     "preclusions": [
-      "CE5311",
       "CE6003",
       "CE5377"
     ],
     "prerequisites": [
-      "EG1109",
       "CE1109",
       "CE2134"
     ]
@@ -4631,9 +4422,7 @@
     "code": "CFG1010",
     "name": "Roots and Wings - Personal and Interpersonal Effectiveness 1.0",
     "creditCount": 2.0,
-    "preclusions": [
-      "CFG1020"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -4641,7 +4430,6 @@
     "name": "Engineering Principles and Practice I",
     "creditCount": 6.0,
     "preclusions": [
-      "CG1108",
       "EG1112"
     ],
     "prerequisites": []
@@ -4664,7 +4452,6 @@
       "EE2023"
     ],
     "prerequisites": [
-      "MA1506",
       "MA1512"
     ]
   },
@@ -4672,12 +4459,9 @@
     "code": "CG2027",
     "name": "Transistor-level Digital Circuits",
     "creditCount": 2.0,
-    "preclusions": [
-      "EE2021"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CG1111",
-      "CG1108",
       "EG1112"
     ]
   },
@@ -4690,8 +4474,7 @@
     ],
     "prerequisites": [
       "CS1010",
-      "EE2026",
-      "EE2020"
+      "EE2026"
     ]
   },
   {
@@ -4711,7 +4494,6 @@
     "name": "Embedded Systems Design Project",
     "creditCount": 6.0,
     "preclusions": [
-      "EE3032",
       "EE3208"
     ],
     "prerequisites": [
@@ -4730,10 +4512,8 @@
     ],
     "prerequisites": [
       "EE2024",
-      "AY2016",
       "CG2028",
-      "EE2028",
-      "AY2017"
+      "EE2028"
     ]
   },
   {
@@ -4774,8 +4554,7 @@
     "name": "General History of China",
     "creditCount": 4.0,
     "preclusions": [
-      "CL2241",
-      "CL2141"
+      "CL2241"
     ],
     "prerequisites": []
   },
@@ -4796,9 +4575,7 @@
     "code": "CH2221",
     "name": "Modern Chinese Literature",
     "creditCount": 4.0,
-    "preclusions": [
-      "CH3226"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -4819,9 +4596,7 @@
     "code": "CH2274",
     "name": "Discovering the Chinese Business Environment",
     "creditCount": 4.0,
-    "preclusions": [
-      "CH2271"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -4835,9 +4610,7 @@
     "code": "CH2293",
     "name": "Introduction to Chinese Art (taught in English)",
     "creditCount": 4.0,
-    "preclusions": [
-      "CH2272"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -4881,9 +4654,7 @@
     "code": "CH3231",
     "name": "Chinese Fiction",
     "creditCount": 4.0,
-    "preclusions": [
-      "CH2223"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -4925,9 +4696,7 @@
     "code": "CH4207",
     "name": "History of Chinese Language",
     "creditCount": 5.0,
-    "preclusions": [
-      "CL3206"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -4971,7 +4740,6 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "CL3281",
       "CL3281"
     ]
   },
@@ -4989,8 +4757,7 @@
     "name": "Independent Study",
     "creditCount": 5.0,
     "preclusions": [
-      "CH4401",
-      "CH4401S"
+      "CH4401"
     ],
     "prerequisites": []
   },
@@ -5287,27 +5054,21 @@
     "code": "CL2101",
     "name": "The Chinese Script : History and Issues",
     "creditCount": 4.0,
-    "preclusions": [
-      "CL2201"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "CL2102",
     "name": "Chinese Phonetics",
     "creditCount": 4.0,
-    "preclusions": [
-      "CL2202"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "CL2103",
     "name": "Chinese Grammar",
     "creditCount": 4.0,
-    "preclusions": [
-      "CL2203"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -5331,8 +5092,7 @@
     "name": "General History of China",
     "creditCount": 4.0,
     "preclusions": [
-      "CH2141",
-      "CL2141"
+      "CH2141"
     ],
     "prerequisites": []
   },
@@ -5378,7 +5138,6 @@
     "name": "Aspects of Chinese Linguistics",
     "creditCount": 4.0,
     "preclusions": [
-      "CL2292",
       "CL2208"
     ],
     "prerequisites": []
@@ -5416,9 +5175,7 @@
     "code": "CLC2101",
     "name": "Engaging and Building Communities",
     "creditCount": 4.0,
-    "preclusions": [
-      "UHB2213"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -5441,7 +5198,6 @@
     "creditCount": 4.0,
     "preclusions": [
       "CM1501",
-      "CM1503",
       "CM1401"
     ],
     "prerequisites": [
@@ -5513,7 +5269,6 @@
     "creditCount": 4.0,
     "preclusions": [
       "CM1121",
-      "CM1503",
       "CM1401"
     ],
     "prerequisites": [
@@ -5526,7 +5281,6 @@
     "name": "General and Physical Chemistry for Engineers",
     "creditCount": 4.0,
     "preclusions": [
-      "CM1502FC",
       "CM1502X"
     ],
     "prerequisites": [
@@ -5539,8 +5293,7 @@
     "name": "General and Physical Chemistry for Engineers",
     "creditCount": 4.0,
     "preclusions": [
-      "CM1502",
-      "CM1502FC"
+      "CM1502"
     ],
     "prerequisites": [
       "CM1417",
@@ -5587,9 +5340,7 @@
     "code": "CM2192",
     "name": "Experiments in Chemistry 3",
     "creditCount": 4.0,
-    "preclusions": [
-      "CM2142"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CM1191"
     ]
@@ -5621,9 +5372,7 @@
     "name": "Principles of Chemical Processes",
     "creditCount": 4.0,
     "preclusions": [
-      "CN1111",
-      "CM1161",
-      "CM2161"
+      "CM1161"
     ],
     "prerequisites": [
       "CM1131",
@@ -5692,7 +5441,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CM2142",
       "CM2192",
       "LSM2191"
     ]
@@ -5711,9 +5459,7 @@
     "name": "Polymer Chemistry 1",
     "creditCount": 4.0,
     "preclusions": [
-      "CM2264",
       "CM3262",
-      "CM3265",
       "CM3266"
     ],
     "prerequisites": [
@@ -5726,7 +5472,6 @@
     "name": "Materials Chemistry 1",
     "creditCount": 4.0,
     "preclusions": [
-      "CM2263",
       "CM3262"
     ],
     "prerequisites": [
@@ -5740,7 +5485,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CM2142",
       "CM2192"
     ]
   },
@@ -5787,7 +5531,6 @@
     "preclusions": [],
     "prerequisites": [
       "CM2101",
-      "CM2142",
       "CM2192"
     ]
   },
@@ -5797,7 +5540,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CM2142",
       "CM2192"
     ]
   },
@@ -5815,9 +5557,7 @@
     "name": "Advanced Forensic Science",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "GEK1542"
-    ]
+    "prerequisites": []
   },
   {
     "code": "CM3302",
@@ -5830,18 +5570,14 @@
     "code": "CM3311",
     "name": "Undergraduate Professional Internship Programme",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3311"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "CM3312",
     "name": "Enhanced Undergraduate Professional Internship Programme",
     "creditCount": 12.0,
-    "preclusions": [
-      "XX3312"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -5859,7 +5595,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CM3211",
       "CM3212"
     ]
   },
@@ -5869,7 +5604,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CM3211",
       "CM3212"
     ]
   },
@@ -5879,7 +5613,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CM3211",
       "CM3212"
     ]
   },
@@ -5896,13 +5629,10 @@
     "code": "CM4227",
     "name": "Chemical Biology",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM4233"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CM1121",
       "CM1401",
-      "LSM1101",
       "LSM1401"
     ]
   },
@@ -5920,7 +5650,6 @@
     "name": "Selected Topics in Physical Chemistry",
     "creditCount": 4.0,
     "preclusions": [
-      "CM4236",
       "CM4237"
     ],
     "prerequisites": [
@@ -5960,9 +5689,7 @@
     "name": "Polymer Chemistry 2",
     "creditCount": 4.0,
     "preclusions": [
-      "CM4264",
       "CM4265",
-      "CM4266",
       "CM4268"
     ],
     "prerequisites": [
@@ -5973,9 +5700,7 @@
     "code": "CM4253",
     "name": "Materials Chemistry 2",
     "creditCount": 4.0,
-    "preclusions": [
-      "CM4266"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CM3253"
     ]
@@ -5984,9 +5709,7 @@
     "code": "CM4254",
     "name": "Chemistry of Semiconductors",
     "creditCount": 4.0,
-    "preclusions": [
-      "CM3263"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CM3232"
     ]
@@ -5995,9 +5718,7 @@
     "code": "CM4258",
     "name": "Advanced Polymer Science",
     "creditCount": 4.0,
-    "preclusions": [
-      "CM4268"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CM3252"
     ]
@@ -6028,9 +5749,7 @@
     "code": "CM4274",
     "name": "The Art and Methodology in Total Synthesis",
     "creditCount": 4.0,
-    "preclusions": [
-      "CM4221"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CM3221"
     ]
@@ -6049,9 +5768,7 @@
     "code": "CM4299",
     "name": "Applied Project in Chemistry",
     "creditCount": 16.0,
-    "preclusions": [
-      "XX4199"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -6076,9 +5793,7 @@
     "code": "CM5101",
     "name": "Advanced Analysis and Characterization Techniques",
     "creditCount": 4.0,
-    "preclusions": [
-      "CM5201"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -6141,9 +5856,7 @@
     "name": "Advanced Organic Synthesis",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "CM4222"
-    ]
+    "prerequisites": []
   },
   {
     "code": "CM5224",
@@ -6205,7 +5918,6 @@
     "preclusions": [],
     "prerequisites": [
       "CM3221",
-      "CM4268",
       "CM3221"
     ]
   },
@@ -6228,7 +5940,6 @@
     "name": "Chemical Engineering Principles",
     "creditCount": 4.0,
     "preclusions": [
-      "TC1101",
       "TCN1111"
     ],
     "prerequisites": []
@@ -6257,9 +5968,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CN1111",
-      "CN1111FC",
-      "CN1111X"
+      "CN1111FC"
     ]
   },
   {
@@ -6267,11 +5976,9 @@
     "name": "Chemical Kinetics And Reactor Design",
     "creditCount": 4.0,
     "preclusions": [
-      "TC2106",
       "TCN2116"
     ],
     "prerequisites": [
-      "TC1101",
       "CN1111E"
     ]
   },
@@ -6281,9 +5988,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CN1111FC",
       "CN1111",
-      "CN1111X",
       "CM1502"
     ]
   },
@@ -6292,7 +5997,6 @@
     "name": "Chemical Engineering Thermodynamics",
     "creditCount": 4.0,
     "preclusions": [
-      "TC2111",
       "TCN2121"
     ],
     "prerequisites": [
@@ -6315,7 +6019,6 @@
     "name": "Fluid Mechanics",
     "creditCount": 4.0,
     "preclusions": [
-      "TC2112",
       "TCN2122"
     ],
     "prerequisites": [
@@ -6336,11 +6039,9 @@
     "name": "Heat And Mass Transfer",
     "creditCount": 4.0,
     "preclusions": [
-      "TC2115",
       "TCN2125"
     ],
     "prerequisites": [
-      "TC2112",
       "CN2122E"
     ]
   },
@@ -6372,8 +6073,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MA1505",
-      "MA1506"
+      "MA1505"
     ]
   },
   {
@@ -6381,7 +6081,6 @@
     "name": "Process Dynamics & Control",
     "creditCount": 4.0,
     "preclusions": [
-      "TC3111",
       "TCN3121"
     ],
     "prerequisites": [
@@ -6400,11 +6099,9 @@
     "name": "Particle Technology",
     "creditCount": 4.0,
     "preclusions": [
-      "TC3114",
       "TCN3124"
     ],
     "prerequisites": [
-      "TC2112",
       "CN2122E"
     ]
   },
@@ -6414,9 +6111,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CN1111FC",
       "CN1111",
-      "CN1111X",
       "CN2125"
     ]
   },
@@ -6425,7 +6120,6 @@
     "name": "Separation Processes",
     "creditCount": 5.0,
     "preclusions": [
-      "TC2113",
       "TCN3132"
     ],
     "prerequisites": [
@@ -6463,9 +6157,7 @@
     "preclusions": [],
     "prerequisites": [
       "MA1505",
-      "MA1506",
       "CN1111",
-      "CN1111FC",
       "CN1111X"
     ]
   },
@@ -6474,7 +6166,6 @@
     "name": "Process Modeling & Numerical Simulation",
     "creditCount": 4.0,
     "preclusions": [
-      "TC3411",
       "TCN3421"
     ],
     "prerequisites": [
@@ -6502,17 +6193,12 @@
     "name": "B.Tech. Dissertation",
     "creditCount": 10.0,
     "preclusions": [
-      "TC4118",
-      "CN4119E",
-      "TCN4119"
+      "CN4119E"
     ],
     "prerequisites": [
-      "TC1401",
       "TC1422",
       "CN1111E",
-      "TC1402",
       "TC2401",
-      "TC2421",
       "CN2121E",
       "CN2122E",
       "CN2116E",
@@ -6521,7 +6207,6 @@
       "CN3421E",
       "CN3121E",
       "CN3132E",
-      "CN4111E",
       "CN3135E"
     ]
   },
@@ -6544,7 +6229,6 @@
     "name": "B.Tech. Dissertation",
     "creditCount": 8.0,
     "preclusions": [
-      "TCN4119",
       "CN4118E"
     ],
     "prerequisites": []
@@ -6658,9 +6342,7 @@
       "TCN4208"
     ],
     "prerequisites": [
-      "TC2106",
       "CN2116E",
-      "TC2112",
       "CN2122E"
     ]
   },
@@ -6669,7 +6351,6 @@
     "name": "Membrane Science And Engineering",
     "creditCount": 4.0,
     "preclusions": [
-      "TC4210",
       "TCN4210"
     ],
     "prerequisites": []
@@ -6689,7 +6370,6 @@
     "name": "Food Technology And Engineering",
     "creditCount": 4.0,
     "preclusions": [
-      "TC4215",
       "TCN4215"
     ],
     "prerequisites": [
@@ -6712,7 +6392,6 @@
     "name": "Electronic Materials Science",
     "creditCount": 4.0,
     "preclusions": [
-      "TC4216",
       "TCN4216"
     ],
     "prerequisites": [
@@ -6724,9 +6403,7 @@
     "name": "Electronic Materials Science",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "MLE1101"
-    ]
+    "prerequisites": []
   },
   {
     "code": "CN4218",
@@ -6751,7 +6428,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MLE1101",
       "EE2004",
       "EE3431C"
     ]
@@ -6761,11 +6437,9 @@
     "name": "Advanced Process Control",
     "creditCount": 4.0,
     "preclusions": [
-      "TC4227",
       "TCN4227"
     ],
     "prerequisites": [
-      "TC3111",
       "CN3121E"
     ]
   },
@@ -6786,7 +6460,6 @@
       "CN4233R",
       "PR2143",
       "PR3145",
-      "PR4206",
       "TCN4233"
     ],
     "prerequisites": [
@@ -6800,8 +6473,7 @@
     "creditCount": 4.0,
     "preclusions": [
       "PR2143",
-      "PR3145",
-      "PR4206"
+      "PR3145"
     ],
     "prerequisites": [
       "LSM1401",
@@ -6814,9 +6486,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CN1111",
-      "CN1111FC",
-      "CN1111X"
+      "CN1111FC"
     ]
   },
   {
@@ -6955,9 +6625,7 @@
     "code": "CN5161",
     "name": "Polymer Processing Engineering",
     "creditCount": 4.0,
-    "preclusions": [
-      "CN4203"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -6971,18 +6639,14 @@
     "code": "CN5172",
     "name": "Biochemical Engineering",
     "creditCount": 4.0,
-    "preclusions": [
-      "CN4208"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "CN5173",
     "name": "Downstream Processing Of Biochemical & Pharmaceutical Products",
     "creditCount": 4.0,
-    "preclusions": [
-      "CN4231"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CN3132"
     ]
@@ -6991,9 +6655,7 @@
     "code": "CN5191",
     "name": "Project Engineering",
     "creditCount": 4.0,
-    "preclusions": [
-      "CN4225"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -7112,15 +6774,10 @@
     "preclusions": [],
     "prerequisites": [
       "CS2102",
-      "CS2102S",
       "CS2105",
-      "CS3214",
       "CS3215",
-      "IS3102",
       "IS4102",
-      "CS3201",
       "CS3281",
-      "CS4201",
       "CS4203"
     ]
   },
@@ -7135,9 +6792,7 @@
     "code": "CP3208",
     "name": "Undergraduate Research in Computing I",
     "creditCount": 4.0,
-    "preclusions": [
-      "CS3208"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -7153,16 +6808,13 @@
     "code": "CP3880",
     "name": "Advanced Technology Attachment Programme",
     "creditCount": 12.0,
-    "preclusions": [
-      "EG3601"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "IS2101",
       "CS2101",
       "CS2103",
       "CS2103T",
       "IS2103",
-      "IS2150",
       "BT2101"
     ]
   },
@@ -7170,9 +6822,7 @@
     "code": "CP4101",
     "name": "B.Comp. Dissertation",
     "creditCount": 12.0,
-    "preclusions": [
-      "CS4101"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -7218,11 +6868,8 @@
     "name": "Programming Methodology",
     "creditCount": 4.0,
     "preclusions": [
-      "CG1101",
       "CS1010E",
-      "CS1010FC",
       "CS1010S",
-      "CS1101",
       "CS1101C",
       "CS1101S"
     ],
@@ -7233,11 +6880,8 @@
     "name": "Programming Methodology",
     "creditCount": 4.0,
     "preclusions": [
-      "CG1101",
       "CS1010",
-      "CS1010FC",
       "CS1010S",
-      "CS1101",
       "CS1101C",
       "CS1101S"
     ],
@@ -7257,12 +6901,9 @@
     "name": "Programming Methodology",
     "creditCount": 4.0,
     "preclusions": [
-      "CG1101",
       "CS1010",
       "CS1010E",
-      "CS1010FC",
       "CS1101",
-      "CS1101C",
       "CS1101S"
     ],
     "prerequisites": []
@@ -7272,8 +6913,7 @@
     "name": "Programming Methodology",
     "creditCount": 4.0,
     "preclusions": [
-      "CS1010",
-      "CS1010FC"
+      "CS1010"
     ],
     "prerequisites": []
   },
@@ -7283,7 +6923,6 @@
     "creditCount": 4.0,
     "preclusions": [
       "CS1020E",
-      "CS2020",
       "CS2030",
       "CS2040",
       "CS2040C"
@@ -7298,7 +6937,6 @@
     "creditCount": 4.0,
     "preclusions": [
       "CS1020",
-      "CS2020",
       "CS2030",
       "CS2040",
       "CS2040C"
@@ -7325,7 +6963,6 @@
     ],
     "prerequisites": [
       "MA1301",
-      "MA1301FC",
       "MA1301X"
     ]
   },
@@ -7334,15 +6971,13 @@
     "name": "Data Structures and Algorithms II",
     "creditCount": 4.0,
     "preclusions": [
-      "CS2020",
       "CS2030",
       "CS2040",
       "CS2040C"
     ],
     "prerequisites": [
       "CS1020",
-      "CS1020E",
-      "CG1103"
+      "CS1020E"
     ]
   },
   {
@@ -7363,7 +6998,6 @@
     "preclusions": [
       "CS1020",
       "CS1020E",
-      "CS2020",
       "CS2010"
     ],
     "prerequisites": [
@@ -7377,7 +7011,6 @@
     "preclusions": [
       "CS1020",
       "CS1020E",
-      "CS2020",
       "CS2010",
       "CS2040"
     ],
@@ -7389,9 +7022,7 @@
     "code": "CS2100",
     "name": "Computer Organisation",
     "creditCount": 4.0,
-    "preclusions": [
-      "CS1104"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CS1010"
     ]
@@ -7417,13 +7048,11 @@
     "name": "Database Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "CS2102S",
       "IT2002"
     ],
     "prerequisites": [
       "CS1020",
       "CS1020E",
-      "CS2020",
       "CS2030",
       "CS2040",
       "CS2040C",
@@ -7436,7 +7065,6 @@
     "name": "Database Systems",
     "creditCount": 1.0,
     "preclusions": [
-      "CS2102S",
       "IT2002"
     ],
     "prerequisites": [
@@ -7457,7 +7085,6 @@
     "prerequisites": [
       "CS1020",
       "CS1020E",
-      "CS2020",
       "CS2030",
       "CS2040",
       "CS2040C"
@@ -7483,7 +7110,6 @@
     "prerequisites": [
       "CS1020",
       "CS1020E",
-      "CS2020",
       "CS2030",
       "CS2040",
       "CS2040C"
@@ -7497,7 +7123,6 @@
     "prerequisites": [
       "CS1020",
       "CS1020E",
-      "CS2020",
       "CS2030",
       "CS2113"
     ]
@@ -7514,14 +7139,12 @@
     "name": "Introduction to Computer Networks",
     "creditCount": 4.0,
     "preclusions": [
-      "IT2001",
       "EE3204",
       "EE4210"
     ],
     "prerequisites": [
       "CS1020",
       "CS1020E",
-      "CS2020",
       "CS2030",
       "CS2040",
       "CS2040C"
@@ -7539,12 +7162,10 @@
     "name": "Introduction to Operating Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "CG2271",
-      "EE4214"
+      "CG2271"
     ],
     "prerequisites": [
       "CS2100",
-      "EE2007",
       "EE2024"
     ]
   },
@@ -7553,8 +7174,7 @@
     "name": "Introduction to Operating Systems",
     "creditCount": 1.0,
     "preclusions": [
-      "CG2271",
-      "EE4214"
+      "CG2271"
     ],
     "prerequisites": []
   },
@@ -7571,13 +7191,10 @@
     "code": "CS2108",
     "name": "Introduction to Media Computing",
     "creditCount": 4.0,
-    "preclusions": [
-      "CS3246"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CS1020",
       "CS1020E",
-      "CS2020",
       "CS2030",
       "CS2113",
       "CS2040",
@@ -7628,7 +7245,6 @@
     "prerequisites": [
       "CS1020",
       "CS1020E",
-      "CS2020",
       "CS2040",
       "CS2040C"
     ]
@@ -7637,12 +7253,9 @@
     "code": "CS2309",
     "name": "CS Research Methodology",
     "creditCount": 4.0,
-    "preclusions": [
-      "CS2305S"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CS2010",
-      "CS2020",
       "CS2030",
       "CS2113",
       "CS2040C",
@@ -7658,7 +7271,6 @@
     "preclusions": [],
     "prerequisites": [
       "CS2105",
-      "EE3204",
       "EE4204"
     ]
   },
@@ -7667,7 +7279,6 @@
     "name": "Software Engineering Project",
     "creditCount": 8.0,
     "preclusions": [
-      "CS3201",
       "CS3202"
     ],
     "prerequisites": [
@@ -7684,7 +7295,6 @@
     "preclusions": [],
     "prerequisites": [
       "CS2100",
-      "CG2007",
       "EE2024"
     ]
   },
@@ -7720,9 +7330,7 @@
     "code": "CS3219",
     "name": "Software Engineering Principles and Patterns",
     "creditCount": 4.0,
-    "preclusions": [
-      "CS3213"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CS2103"
     ]
@@ -7734,7 +7342,6 @@
     "preclusions": [],
     "prerequisites": [
       "CS2010",
-      "CS2020",
       "CS2040",
       "CS2040C",
       "CS2102"
@@ -7747,7 +7354,6 @@
     "preclusions": [],
     "prerequisites": [
       "CS2010",
-      "CS2020",
       "CS2040",
       "CS2040C",
       "CS1231",
@@ -7768,7 +7374,6 @@
     "preclusions": [],
     "prerequisites": [
       "CS2010",
-      "CS2020",
       "CS2030",
       "CS2040"
     ]
@@ -7790,7 +7395,6 @@
     "preclusions": [],
     "prerequisites": [
       "CS2105",
-      "EE3204",
       "EE4204",
       "CS2106",
       "CG2271",
@@ -7825,10 +7429,8 @@
     "preclusions": [],
     "prerequisites": [
       "CS1020",
-      "CS2020",
       "CS2030",
       "CS2113",
-      "NM3209",
       "NM2207"
     ]
   },
@@ -7839,7 +7441,6 @@
     "preclusions": [],
     "prerequisites": [
       "CS2010",
-      "CS2020",
       "CS2030",
       "CS2113",
       "CS2040",
@@ -7857,9 +7458,7 @@
     "code": "CS3242",
     "name": "3D Modeling and Animation",
     "creditCount": 4.0,
-    "preclusions": [
-      "CS4342"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CS3241",
       "PC1221",
@@ -7870,7 +7469,6 @@
       "MA1512",
       "MA1521",
       "MA1101R",
-      "MA1311",
       "MA1506",
       "MA1508E"
     ]
@@ -7882,7 +7480,6 @@
     "preclusions": [],
     "prerequisites": [
       "CS2010",
-      "CS2020",
       "CS2040",
       "CS2040C",
       "CS1231",
@@ -7896,10 +7493,8 @@
     "preclusions": [],
     "prerequisites": [
       "CS2010",
-      "CS2020",
       "CS2040",
       "CS2040C",
-      "ESP1107",
       "ESP2107",
       "ST1232",
       "ST2131",
@@ -7911,7 +7506,6 @@
       "MA1512",
       "MA1521",
       "MA1101R",
-      "MA1311",
       "MA1506",
       "MA1508E"
     ]
@@ -7923,7 +7517,6 @@
     "preclusions": [],
     "prerequisites": [
       "CS2010",
-      "CS2020",
       "CS2030",
       "CS2113",
       "CS2040",
@@ -7941,9 +7534,7 @@
     "code": "CS3247",
     "name": "Game Development",
     "creditCount": 4.0,
-    "preclusions": [
-      "CS4213"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CS3241",
       "PC1221"
@@ -7992,7 +7583,6 @@
     "preclusions": [],
     "prerequisites": [
       "CS2010",
-      "CS2020",
       "CS2040",
       "CS2040C",
       "CS2030",
@@ -8014,8 +7604,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CS2220",
-      "LSM2104"
+      "CS2220"
     ]
   },
   {
@@ -8038,7 +7627,6 @@
     ],
     "prerequisites": [
       "CS2105",
-      "EE3204",
       "EE4204",
       "ST2334",
       "ST2131"
@@ -8053,7 +7641,6 @@
       "CS2106",
       "CG2271",
       "CS3210",
-      "CS3220",
       "CG3207"
     ]
   },
@@ -8084,7 +7671,6 @@
     "preclusions": [],
     "prerequisites": [
       "CS2105",
-      "EE3204",
       "EE4204",
       "ST2334",
       "ST2131"
@@ -8106,8 +7692,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CS1231",
-      "CS1231S"
+      "CS1231"
     ]
   },
   {
@@ -8117,7 +7702,6 @@
     "preclusions": [],
     "prerequisites": [
       "MA1101R",
-      "MA1311",
       "MA1506",
       "MA1508E",
       "CS3230"
@@ -8132,7 +7716,6 @@
       "CS1231",
       "CS2107",
       "CS2010",
-      "CS2020",
       "CS2040",
       "CS2040C"
     ]
@@ -8186,13 +7769,11 @@
     "prerequisites": [
       "CS1020",
       "CS1020E",
-      "CS2020",
       "CS2030",
       "CS2113",
       "CS2040",
       "CS2040C",
       "MA1101R",
-      "MA1311",
       "MA1506",
       "MA1508E",
       "MA1102R",
@@ -8255,8 +7836,7 @@
     "preclusions": [],
     "prerequisites": [
       "CS3240",
-      "NM2213",
-      "NM2216"
+      "NM2213"
     ]
   },
   {
@@ -8278,18 +7858,15 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "ESP1107",
       "ESP2107",
       "ST1232",
       "ST2132",
       "ST2334",
       "CS2010",
-      "CS2020",
       "CS2040",
       "BT2101",
       "CS1231",
       "MA1101R",
-      "MA1311",
       "MA1506",
       "MA1508E"
     ]
@@ -8306,7 +7883,6 @@
       "MA1512",
       "MA1521",
       "MA1101R",
-      "MA1311",
       "MA1506",
       "MA1508E",
       "CS2108"
@@ -8356,7 +7932,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CS3220",
       "CS4223"
     ]
   },
@@ -8403,9 +7978,7 @@
     "code": "CS5230",
     "name": "Computational Complexity",
     "creditCount": 4.0,
-    "preclusions": [
-      "CS4230"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CS4232"
     ]
@@ -8479,7 +8052,6 @@
     "prerequisites": [
       "CS1020",
       "CS1020E",
-      "CS2020",
       "CS2030",
       "CS2113",
       "ST1232",
@@ -8495,7 +8067,6 @@
     "prerequisites": [
       "CS1020",
       "CS1020E",
-      "CS2020",
       "CS2040",
       "CS2040C",
       "MA1102R",
@@ -8504,7 +8075,6 @@
       "MA1512",
       "MA1521",
       "MA1101R",
-      "MA1311",
       "MA1506",
       "MA1508E",
       "ST1232",
@@ -8529,7 +8099,6 @@
     "prerequisites": [
       "CS2103",
       "MA1101R",
-      "MA1311",
       "MA1506",
       "MA1508E",
       "ST1232",
@@ -8603,10 +8172,8 @@
       "CS2040",
       "MA1102R",
       "MA1505",
-      "MA1505C",
       "MA1521",
       "MA1101R",
-      "MA1506",
       "ST1232",
       "ST2131",
       "ST2334"
@@ -8676,7 +8243,6 @@
     ],
     "prerequisites": [
       "CS2105",
-      "EE3204",
       "EE4204",
       "ST2334",
       "ST2131"
@@ -8729,7 +8295,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CS3212",
       "CS4212"
     ]
   },
@@ -8838,7 +8403,6 @@
     "prerequisites": [
       "CS3230",
       "MA1101R",
-      "MA1311",
       "MA1506",
       "MA1508E",
       "ST2131",
@@ -9025,7 +8589,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "UP5101",
       "UD5622"
     ]
   },
@@ -9058,7 +8621,6 @@
     "creditCount": 8.0,
     "preclusions": [],
     "prerequisites": [
-      "UP5101",
       "UD5622"
     ]
   },
@@ -9173,7 +8735,6 @@
       "CS1010S",
       "CS1010X",
       "MA1101R",
-      "MA1104",
       "MA2104",
       "MA2311"
     ]
@@ -9182,9 +8743,7 @@
     "code": "DSA3312",
     "name": "Enhanced Undergraduate Professional Internship Programme",
     "creditCount": 12.0,
-    "preclusions": [
-      "XX3312"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -9219,9 +8778,7 @@
     "name": "Operations Management",
     "creditCount": 4.0,
     "preclusions": [
-      "BH2006",
       "BZ2003",
-      "BK2006",
       "IE3120"
     ],
     "prerequisites": []
@@ -9232,7 +8789,6 @@
     "creditCount": 4.0,
     "preclusions": [
       "ST1131",
-      "ST1131A",
       "ST1232",
       "ST2334"
     ],
@@ -9243,17 +8799,12 @@
     "name": "Supply Chain Management",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3201",
       "BZ3402",
-      "BK3505",
-      "IE4220",
-      "CS5262"
+      "IE4220"
     ],
     "prerequisites": [
       "DSC2006",
-      "BH2006",
-      "BZ2003",
-      "BK2006"
+      "BZ2003"
     ]
   },
   {
@@ -9261,15 +8812,11 @@
     "name": "Purchasing And Materials Management",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3202",
-      "BZ3414",
-      "BK3206"
+      "BZ3414"
     ],
     "prerequisites": [
       "DSC2006",
-      "BH2006",
-      "BZ2003",
-      "BK2006"
+      "BZ2003"
     ]
   },
   {
@@ -9277,15 +8824,11 @@
     "name": "Service Operations Management",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3203",
-      "BZ3404",
-      "BK3501"
+      "BZ3404"
     ],
     "prerequisites": [
       "DSC2006",
-      "BH2006",
-      "BZ2003",
-      "BK2006"
+      "BZ2003"
     ]
   },
   {
@@ -9298,7 +8841,6 @@
     "prerequisites": [
       "DSC1007",
       "MA1101R",
-      "MA1311",
       "MA1521",
       "MA1102R"
     ]
@@ -9466,7 +9008,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "DTS2701",
       "DTS2703"
     ]
   },
@@ -9482,9 +9023,7 @@
     "name": "Systems Design Project",
     "creditCount": 2.0,
     "preclusions": [],
-    "prerequisites": [
-      "DTS5731"
-    ]
+    "prerequisites": []
   },
   {
     "code": "DY5310",
@@ -9533,18 +9072,14 @@
     "name": "Data Analytics",
     "creditCount": 8.0,
     "preclusions": [],
-    "prerequisites": [
-      "EB5001"
-    ]
+    "prerequisites": []
   },
   {
     "code": "EB5104",
     "name": "Decision Making and Optimization",
     "creditCount": 8.0,
     "preclusions": [],
-    "prerequisites": [
-      "EB5001"
-    ]
+    "prerequisites": []
   },
   {
     "code": "EB5105",
@@ -9552,9 +9087,7 @@
     "creditCount": 12.0,
     "preclusions": [],
     "prerequisites": [
-      "EB5001",
-      "EB5002",
-      "EB5003"
+      "EB5002"
     ]
   },
   {
@@ -9562,36 +9095,28 @@
     "name": "Web Analytics",
     "creditCount": 3.0,
     "preclusions": [],
-    "prerequisites": [
-      "EB5001"
-    ]
+    "prerequisites": []
   },
   {
     "code": "EB5204",
     "name": "New Media and Sentiment Mining",
     "creditCount": 3.0,
     "preclusions": [],
-    "prerequisites": [
-      "EB5001"
-    ]
+    "prerequisites": []
   },
   {
     "code": "EB5206",
     "name": "Supply Chain Analytics",
     "creditCount": 3.0,
     "preclusions": [],
-    "prerequisites": [
-      "EB5001"
-    ]
+    "prerequisites": []
   },
   {
     "code": "EB5207",
     "name": "Service Analytics",
     "creditCount": 3.0,
     "preclusions": [],
-    "prerequisites": [
-      "EB5001"
-    ]
+    "prerequisites": []
   },
   {
     "code": "EC1101E",
@@ -9599,11 +9124,9 @@
     "creditCount": 4.0,
     "preclusions": [
       "EC1301",
-      "BH1005",
       "BSP1005",
       "BSP1703",
       "RE1704",
-      "USE2301",
       "EC1101E"
     ],
     "prerequisites": []
@@ -9614,11 +9137,9 @@
     "creditCount": 4.0,
     "preclusions": [
       "EC1101E",
-      "BH1005",
       "BSP1005",
       "BSP1703",
       "RE1704",
-      "USE2301",
       "EC1301"
     ],
     "prerequisites": []
@@ -9631,9 +9152,7 @@
     "prerequisites": [
       "EC1101E",
       "EC1301",
-      "USE2301",
-      "BSP1005",
-      "BH1005"
+      "BSP1005"
     ]
   },
   {
@@ -9641,15 +9160,12 @@
     "name": "Macroeconomic Analysis I",
     "creditCount": 4.0,
     "preclusions": [
-      "BSP2001",
-      "BSE3701"
+      "BSP2001"
     ],
     "prerequisites": [
       "EC1101E",
       "EC1301",
-      "USE2301",
-      "BSP1005",
-      "BH2001"
+      "BSP1005"
     ]
   },
   {
@@ -9657,11 +9173,8 @@
     "name": "Quantitative Methods for Economic Analysis",
     "creditCount": 4.0,
     "preclusions": [
-      "EC3311",
       "MA1301",
-      "MA1301FC",
       "MA1301X",
-      "MA1311",
       "MA1312",
       "MA1421"
     ],
@@ -9713,8 +9226,7 @@
     "prerequisites": [
       "EC1101E",
       "EC1301",
-      "BSP1005",
-      "USE2301"
+      "BSP1005"
     ]
   },
   {
@@ -9726,9 +9238,7 @@
       "EC2101",
       "EC2104",
       "MA1301",
-      "MA1301FC",
       "MA1301X",
-      "MA1311",
       "MA1312",
       "MA1421"
     ]
@@ -9743,9 +9253,7 @@
       "EC2101",
       "EC2104",
       "MA1301",
-      "MA1301FC",
       "MA1301X",
-      "MA1311",
       "MA1312",
       "MA1421"
     ]
@@ -9777,9 +9285,7 @@
       "ST3131",
       "EC2104",
       "MA1301",
-      "MA1301FC",
       "MA1301X",
-      "MA1311",
       "MA1312",
       "MA1421"
     ]
@@ -9804,9 +9310,7 @@
       "EC2101",
       "EC2104",
       "MA1301",
-      "MA1301FC",
       "MA1301X",
-      "MA1311",
       "MA1312",
       "MA1421"
     ]
@@ -9815,17 +9319,13 @@
     "code": "EC3314",
     "name": "Mathematical Economics",
     "creditCount": 4.0,
-    "preclusions": [
-      "EC3311"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EC2104",
       "MA1101R",
       "MA1102R",
       "MA1505",
-      "MA1506",
       "MA1507",
-      "MA1508",
       "EC2101",
       "EC2102"
     ]
@@ -9839,9 +9339,7 @@
       "EC2101",
       "EC2104",
       "MA1301",
-      "MA1301FC",
       "MA1301X",
-      "MA1311",
       "MA1312",
       "MA1421"
     ]
@@ -9855,9 +9353,7 @@
       "EC2102",
       "EC2104",
       "MA1301",
-      "MA1301FC",
       "MA1301X",
-      "MA1311",
       "MA1312",
       "MA1421"
     ]
@@ -9873,9 +9369,7 @@
       "BSP2001",
       "EC2104",
       "MA1301",
-      "MA1301FC",
       "MA1301X",
-      "MA1311",
       "MA1312",
       "MA1421"
     ]
@@ -9884,9 +9378,7 @@
     "code": "EC3342",
     "name": "International Trade I",
     "creditCount": 4.0,
-    "preclusions": [
-      "EC3341"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EC2101",
       "EC2102"
@@ -9896,9 +9388,7 @@
     "code": "EC3343",
     "name": "International Finance I",
     "creditCount": 4.0,
-    "preclusions": [
-      "EC3341"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EC2101",
       "EC2102"
@@ -9913,9 +9403,7 @@
       "EC2101",
       "EC2104",
       "MA1301",
-      "MA1301FC",
       "MA1301X",
-      "MA1311",
       "MA1312",
       "MA1421"
     ]
@@ -9929,9 +9417,7 @@
       "EC2101",
       "EC2104",
       "MA1301",
-      "MA1301FC",
       "MA1301X",
-      "MA1311",
       "MA1312",
       "MA1421",
       "EC3303"
@@ -9946,9 +9432,7 @@
       "EC2101",
       "EC2104",
       "MA1301",
-      "MA1301FC",
       "MA1301X",
-      "MA1311",
       "MA1312",
       "MA1421",
       "EC3303"
@@ -9959,9 +9443,7 @@
     "name": "Asean Economies",
     "creditCount": 4.0,
     "preclusions": [
-      "EC3375",
-      "EC3376",
-      "EU3214"
+      "EC3376"
     ],
     "prerequisites": [
       "EC2101"
@@ -9972,16 +9454,13 @@
     "name": "Urban Economics",
     "creditCount": 4.0,
     "preclusions": [
-      "RE2102",
       "RE2705"
     ],
     "prerequisites": [
       "EC2101",
       "EC2104",
       "MA1301",
-      "MA1301FC",
       "MA1301X",
-      "MA1311",
       "MA1312",
       "MA1421"
     ]
@@ -10026,24 +9505,18 @@
     "code": "EC4301",
     "name": "Microeconomic Analysis III",
     "creditCount": 5.0,
-    "preclusions": [
-      "EC4101"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EC3101",
       "EC3102",
       "EC4301",
-      "EC4101",
       "EC4302",
-      "EC4102",
       "EC3101",
       "EC3102",
       "EC3101",
       "EC3102",
       "EC4301",
-      "EC4101",
       "EC4302",
-      "EC4102",
       "EC3101",
       "EC3102"
     ]
@@ -10052,24 +9525,18 @@
     "code": "EC4302",
     "name": "Macroeconomic Analysis III",
     "creditCount": 5.0,
-    "preclusions": [
-      "EC4102"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EC3101",
       "EC3102",
       "EC4301",
-      "EC4101",
       "EC4302",
-      "EC4102",
       "EC3101",
       "EC3102",
       "EC3101",
       "EC3102",
       "EC4301",
-      "EC4101",
       "EC4302",
-      "EC4102",
       "EC3101",
       "EC3102"
     ]
@@ -10115,7 +9582,6 @@
     "name": "Applied Microeconomic Analysis",
     "creditCount": 5.0,
     "preclusions": [
-      "EC4101",
       "EC4301"
     ],
     "prerequisites": [
@@ -10182,7 +9648,6 @@
     "name": "Financial Economics II",
     "creditCount": 5.0,
     "preclusions": [
-      "MA3245",
       "MA4269"
     ],
     "prerequisites": [
@@ -10217,11 +9682,9 @@
       "EC3101",
       "EC3102",
       "EC3303",
-      "EC3341",
       "EC3101",
       "EC3102",
       "EC3303",
-      "EC3341",
       "EC3343"
     ]
   },
@@ -10354,11 +9817,9 @@
       "EC3101",
       "EC3102",
       "EC3304",
-      "EC3383",
       "EC3101",
       "EC3102",
-      "EC3304",
-      "EC3383"
+      "EC3304"
     ]
   },
   {
@@ -10417,9 +9878,7 @@
     ],
     "prerequisites": [
       "EC4301",
-      "EC4101",
-      "EC4302",
-      "EC4102"
+      "EC4302"
     ]
   },
   {
@@ -10427,14 +9886,11 @@
     "name": "Independent Study",
     "creditCount": 5.0,
     "preclusions": [
-      "EC4401",
-      "EC4401S"
+      "EC4401"
     ],
     "prerequisites": [
       "EC4301",
-      "EC4101",
-      "EC4302",
-      "EC4102"
+      "EC4302"
     ]
   },
   {
@@ -10493,11 +9949,8 @@
     "code": "EC5103",
     "name": "Econometric Modelling And Applications I",
     "creditCount": 4.0,
-    "preclusions": [
-      "EC5154"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "EC5253",
       "EC5304",
       "ECA5103"
     ]
@@ -10506,11 +9959,8 @@
     "code": "EC5103R",
     "name": "Econometric Modelling And Applications I",
     "creditCount": 5.0,
-    "preclusions": [
-      "EC5154"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "EC5253",
       "EC5304",
       "ECA5103"
     ]
@@ -10520,7 +9970,6 @@
     "name": "Mathematical Economics",
     "creditCount": 4.0,
     "preclusions": [
-      "EC5210",
       "EC5311"
     ],
     "prerequisites": []
@@ -10530,7 +9979,6 @@
     "name": "Mathematical Economics",
     "creditCount": 5.0,
     "preclusions": [
-      "EC5210",
       "EC5311"
     ],
     "prerequisites": []
@@ -10540,7 +9988,6 @@
     "name": "Industrial Organisation",
     "creditCount": 4.0,
     "preclusions": [
-      "EC5215",
       "EC5268"
     ],
     "prerequisites": []
@@ -10550,7 +9997,6 @@
     "name": "Industrial Organisation",
     "creditCount": 5.0,
     "preclusions": [
-      "EC5215",
       "EC5268"
     ],
     "prerequisites": []
@@ -10559,18 +10005,14 @@
     "code": "EC5332",
     "name": "Money & Banking",
     "creditCount": 4.0,
-    "preclusions": [
-      "EC5208"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "EC5332R",
     "name": "Money & Banking",
     "creditCount": 5.0,
-    "preclusions": [
-      "EC5208"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -10578,9 +10020,7 @@
     "name": "Public Economics",
     "creditCount": 4.0,
     "preclusions": [
-      "EC5267",
       "EC5209",
-      "EC5351",
       "ECA5351"
     ],
     "prerequisites": []
@@ -10590,9 +10030,7 @@
     "name": "Public Economics",
     "creditCount": 5.0,
     "preclusions": [
-      "EC5267",
       "EC5209",
-      "EC5351",
       "ECA5351"
     ],
     "prerequisites": []
@@ -10637,11 +10075,8 @@
     "code": "EC6103",
     "name": "Econometric Modelling And Applications Ii",
     "creditCount": 4.0,
-    "preclusions": [
-      "EC6154"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "EC5154",
       "EC5103"
     ]
   },
@@ -10650,7 +10085,6 @@
     "name": "Advanced Mathematical Economics",
     "creditCount": 4.0,
     "preclusions": [
-      "EC6210",
       "EC6311"
     ],
     "prerequisites": []
@@ -10660,7 +10094,6 @@
     "name": "Advanced Industrial Organisation",
     "creditCount": 4.0,
     "preclusions": [
-      "EC6215",
       "EC6268"
     ],
     "prerequisites": []
@@ -10684,7 +10117,6 @@
     "name": "Microeconomics",
     "creditCount": 4.0,
     "preclusions": [
-      "EC5151",
       "EC5101A"
     ],
     "prerequisites": []
@@ -10694,7 +10126,6 @@
     "name": "Macroeconomics",
     "creditCount": 4.0,
     "preclusions": [
-      "EC5152",
       "EC5102A"
     ],
     "prerequisites": []
@@ -10704,7 +10135,6 @@
     "name": "Quantitative & Computing Methods",
     "creditCount": 4.0,
     "preclusions": [
-      "EC5253",
       "EC5304"
     ],
     "prerequisites": []
@@ -10714,7 +10144,6 @@
     "name": "Topics in Econometrics",
     "creditCount": 4.0,
     "preclusions": [
-      "ECA5253",
       "ECA5304",
       "ECA5103"
     ],
@@ -10725,13 +10154,9 @@
     "name": "Financial Markets & Portfolio Management",
     "creditCount": 4.0,
     "preclusions": [
-      "EC5274",
       "EC5333",
-      "EC4209",
       "EC4333",
-      "EC5274",
       "ECA5333",
-      "EC5274",
       "ECA5333"
     ],
     "prerequisites": []
@@ -10741,11 +10166,9 @@
     "name": "Corporate Finance",
     "creditCount": 4.0,
     "preclusions": [
-      "EC5269",
       "EC5334"
     ],
     "prerequisites": [
-      "EC5274",
       "EC5333",
       "ECA5333"
     ]
@@ -10754,9 +10177,7 @@
     "code": "ECA5335",
     "name": "Derivative Securities",
     "creditCount": 4.0,
-    "preclusions": [
-      "EC5260"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -10764,9 +10185,7 @@
     "name": "Economic Growth And Development",
     "creditCount": 4.0,
     "preclusions": [
-      "EC5262",
       "EC5263",
-      "IZ5201",
       "EC5371"
     ],
     "prerequisites": []
@@ -10776,9 +10195,7 @@
     "name": "The Singapore Economy",
     "creditCount": 4.0,
     "preclusions": [
-      "EC5205",
-      "EC5255",
-      "EC5373"
+      "EC5255"
     ],
     "prerequisites": []
   },
@@ -10787,9 +10204,7 @@
     "name": "The Singapore Economy",
     "creditCount": 5.0,
     "preclusions": [
-      "EC5205",
-      "EC5255",
-      "EC5373"
+      "EC5255"
     ],
     "prerequisites": []
   },
@@ -10798,7 +10213,6 @@
     "name": "Economic Growth in East Asia",
     "creditCount": 4.0,
     "preclusions": [
-      "EC5266",
       "IZ5212"
     ],
     "prerequisites": []
@@ -10856,7 +10270,6 @@
     ],
     "prerequisites": [
       "MA1505",
-      "MA1506",
       "MA1511",
       "MA1512"
     ]
@@ -10871,7 +10284,6 @@
       "TEE2023"
     ],
     "prerequisites": [
-      "MA1506",
       "MA1512"
     ]
   },
@@ -10880,7 +10292,6 @@
     "name": "Signals and Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "EE2009E",
       "EE2010E",
       "TEE2023"
     ],
@@ -10894,7 +10305,6 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "EE2020",
       "CS1010E"
     ]
   },
@@ -10902,9 +10312,7 @@
     "code": "EE2026",
     "name": "Digital Design",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE2020"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EG1111"
     ]
@@ -10914,7 +10322,6 @@
     "name": "Electronic Circuits",
     "creditCount": 4.0,
     "preclusions": [
-      "EE2021",
       "CG2027"
     ],
     "prerequisites": [
@@ -10939,9 +10346,7 @@
     "name": "Circuit and Systems Design Lab",
     "creditCount": 3.0,
     "preclusions": [],
-    "prerequisites": [
-      "EE2021"
-    ]
+    "prerequisites": []
   },
   {
     "code": "EE2032",
@@ -10949,7 +10354,6 @@
     "creditCount": 3.0,
     "preclusions": [],
     "prerequisites": [
-      "EE2011",
       "EE2023"
     ]
   },
@@ -10971,7 +10375,6 @@
     "name": "Innovation & Enterprise I",
     "creditCount": 4.0,
     "preclusions": [
-      "TR3001",
       "EE3001",
       "MT4003"
     ],
@@ -10982,7 +10385,6 @@
     "name": "Innovation & Enterprise I",
     "creditCount": 4.0,
     "preclusions": [
-      "TM4209",
       "EE3001E",
       "TEE3031"
     ],
@@ -10993,23 +10395,18 @@
     "name": "Introduction to RF and Microwave Systems & Circuits",
     "creditCount": 4.0,
     "preclusions": [
-      "EE3104E",
       "TEE3104"
     ],
     "prerequisites": [
       "PC2020",
-      "AY2017",
-      "EE2011",
-      "AY2016"
+      "EE2011"
     ]
   },
   {
     "code": "EE3131C",
     "name": "Communication Systems",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE3103"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EE2023"
     ]
@@ -11019,11 +10416,9 @@
     "name": "Communication Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "EE3103E",
       "TEE3131"
     ],
     "prerequisites": [
-      "EE2009E",
       "EE2010E",
       "EE2023E"
     ]
@@ -11036,7 +10431,6 @@
       "TEE3207"
     ],
     "prerequisites": [
-      "EE2007E",
       "EE2024E",
       "TEE2028"
     ]
@@ -11045,9 +10439,7 @@
     "code": "EE3331C",
     "name": "Feedback Control Systems",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE2010"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EE2023"
     ]
@@ -11057,7 +10449,6 @@
     "name": "Feedback Control Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "EE2010E",
       "TEE3331"
     ],
     "prerequisites": [
@@ -11075,9 +10466,7 @@
     "prerequisites": [
       "CG2027",
       "EE2027",
-      "AY2017",
-      "EE2021",
-      "AY2016"
+      "EE2021"
     ]
   },
   {
@@ -11088,7 +10477,6 @@
       "TEE3408"
     ],
     "prerequisites": [
-      "EE2021E",
       "TEE2027"
     ]
   },
@@ -11097,14 +10485,12 @@
     "name": "Microelectronics Materials and Devices",
     "creditCount": 4.0,
     "preclusions": [
-      "EE3406",
       "EE2004",
       "PC3235"
     ],
     "prerequisites": [
       "EE2027",
-      "CG2027",
-      "EE2021"
+      "CG2027"
     ]
   },
   {
@@ -11112,7 +10498,6 @@
     "name": "Microelectronics Materials and Devices",
     "creditCount": 4.0,
     "preclusions": [
-      "EE3406E",
       "EE2004E",
       "TEE3431"
     ],
@@ -11126,7 +10511,6 @@
       "TEE3501"
     ],
     "prerequisites": [
-      "EE2005E",
       "EE2021E",
       "TEE2027"
     ]
@@ -11135,17 +10519,12 @@
     "code": "EE3506C",
     "name": "Intro to Elect Energy Systems",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE3505C"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EG1112",
       "CG1111",
-      "AY2017",
       "EE1002",
-      "EG1108",
-      "CG1108",
-      "AY2016"
+      "CG1108"
     ]
   },
   {
@@ -11235,9 +10614,7 @@
     "name": "Computer Networks",
     "creditCount": 4.0,
     "preclusions": [
-      "EE3204",
       "EE3204E",
-      "TEE3204",
       "TEE4204"
     ],
     "prerequisites": [
@@ -11252,7 +10629,6 @@
     "preclusions": [
       "CS2105",
       "CS3103",
-      "TEE3204",
       "EE3204E",
       "TEE4204"
     ],
@@ -11306,10 +10682,8 @@
       "MA1508E",
       "EE3731C",
       "EE4704",
-      "AY2017",
       "EE3206",
-      "EE3731C",
-      "AY2016"
+      "EE3731C"
     ]
   },
   {
@@ -11322,7 +10696,6 @@
     ],
     "prerequisites": [
       "TE2101",
-      "EE2024E",
       "TEE2028"
     ]
   },
@@ -11334,9 +10707,7 @@
     "prerequisites": [
       "EE2028",
       "CG2028",
-      "AY2017",
-      "EE2024",
-      "AY2016"
+      "EE2024"
     ]
   },
   {
@@ -11353,9 +10724,7 @@
     "name": "Industrial Control Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "EE3302",
       "EE3302E",
-      "TEE3302",
       "TEE4303"
     ],
     "prerequisites": [
@@ -11367,12 +10736,10 @@
     "name": "Industrial Control Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "TEE3302",
       "EE3302E",
       "TEE4303"
     ],
     "prerequisites": [
-      "EE2010E",
       "EE3331E"
     ]
   },
@@ -11393,7 +10760,6 @@
       "TEE4305"
     ],
     "prerequisites": [
-      "EE2010E",
       "EE2023E"
     ]
   },
@@ -11410,9 +10776,7 @@
     "code": "EE4308",
     "name": "Advances in Intelligent Systems and Robotics",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE4306"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EE3331C"
     ]
@@ -11422,12 +10786,10 @@
     "name": "Analog Electronics",
     "creditCount": 4.0,
     "preclusions": [
-      "TEE3407",
       "EE3407E",
       "TEE4407"
     ],
     "prerequisites": [
-      "EE2021E",
       "TEE2027"
     ]
   },
@@ -11435,15 +10797,11 @@
     "code": "EE4409",
     "name": "Microelectronic Applications for Modern Life",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE3409"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CG2027",
       "EE2027",
-      "AY2017",
-      "EE2021",
-      "AY2016"
+      "EE2021"
     ]
   },
   {
@@ -11456,9 +10814,7 @@
     ],
     "prerequisites": [
       "EE2026",
-      "AY2017",
-      "EE2020",
-      "AY2016"
+      "EE2020"
     ]
   },
   {
@@ -11469,7 +10825,6 @@
       "TEE4415"
     ],
     "prerequisites": [
-      "EE2006E",
       "EE2020E",
       "TEE2026"
     ]
@@ -11483,9 +10838,7 @@
       "EE2026",
       "CG2027",
       "EE2027",
-      "AY2017",
       "EE2020",
-      "EE2021",
       "AY2016"
     ]
   },
@@ -11501,10 +10854,8 @@
       "CG2027",
       "EE2027",
       "EE3431C",
-      "AY2017",
       "EE2021",
-      "EE3431C",
-      "AY2016"
+      "EE3431C"
     ]
   },
   {
@@ -11512,12 +10863,10 @@
     "name": "Modern Transistors and Memory Devices",
     "creditCount": 4.0,
     "preclusions": [
-      "EE4408E",
       "EE4412E",
       "TEE4435"
     ],
     "prerequisites": [
-      "EE2021E",
       "TEE2027"
     ]
   },
@@ -11526,7 +10875,6 @@
     "name": "Fabrication Process Technology",
     "creditCount": 4.0,
     "preclusions": [
-      "EE4411",
       "EE4411E",
       "EE4436E",
       "TEE4436"
@@ -11534,9 +10882,7 @@
     "prerequisites": [
       "CG2027",
       "EE2027",
-      "AY2017",
-      "EE2021",
-      "AY2016"
+      "EE2021"
     ]
   },
   {
@@ -11544,11 +10890,9 @@
     "name": "Fabrication Process Technology",
     "creditCount": 4.0,
     "preclusions": [
-      "EE4411E",
       "TEE4436"
     ],
     "prerequisites": [
-      "EE2021E",
       "TEE2027"
     ]
   },
@@ -11556,30 +10900,22 @@
     "code": "EE4437",
     "name": "Photonics - Principles and Applications",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE4401"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CG2027",
       "EE2027",
-      "AY2017",
-      "EE2021",
-      "AY2016"
+      "EE2021"
     ]
   },
   {
     "code": "EE4438",
     "name": "Solar Cells and Modules",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE4432"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CG2027",
       "EE2027",
-      "AY2017",
-      "EE2021",
-      "AY2016"
+      "EE2021"
     ]
   },
   {
@@ -11588,10 +10924,8 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "EE3505C",
       "AY2016",
-      "EE3506C",
-      "AY2017"
+      "EE3506C"
     ]
   },
   {
@@ -11600,11 +10934,8 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "EE2025",
       "EE3505C",
-      "AY2016",
-      "EE3506C",
-      "AY2017"
+      "EE3506C"
     ]
   },
   {
@@ -11612,12 +10943,10 @@
     "name": "Advanced Power Electronics",
     "creditCount": 4.0,
     "preclusions": [
-      "EE2025",
       "EE3501E",
       "TEE3501"
     ],
     "prerequisites": [
-      "EE3505C",
       "EE3506C"
     ]
   },
@@ -11627,9 +10956,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "AY2017",
-      "EE2021",
-      "AY2016"
+      "EE2021"
     ]
   },
   {
@@ -11638,10 +10965,8 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "EE3505C",
       "AY2016",
-      "EE3506C",
-      "AY2017"
+      "EE3506C"
     ]
   },
   {
@@ -11650,8 +10975,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "EE2023",
-      "BN2401"
+      "EE2023"
     ]
   },
   {
@@ -11660,9 +10984,7 @@
     "creditCount": 4.0,
     "preclusions": [
       "CS4243",
-      "EE3206",
       "EE3206E",
-      "TEE3206",
       "TEE4704"
     ],
     "prerequisites": [
@@ -11784,9 +11106,7 @@
     "name": "Linear Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "MCH5201",
-      "ME5401",
-      "EE5101R"
+      "ME5401"
     ],
     "prerequisites": []
   },
@@ -11796,13 +11116,9 @@
     "creditCount": 4.0,
     "preclusions": [
       "ME5403",
-      "EE5103R",
-      "MCH5103",
-      "TD5241"
+      "MCH5103"
     ],
-    "prerequisites": [
-      "EE2010"
-    ]
+    "prerequisites": []
   },
   {
     "code": "EE5104",
@@ -11813,7 +11129,6 @@
     ],
     "prerequisites": [
       "EE5101",
-      "EE5101R",
       "ME5401"
     ]
   },
@@ -11822,9 +11137,7 @@
     "name": "Advanced Robotics",
     "creditCount": 4.0,
     "preclusions": [
-      "MCH5209",
-      "ME5402",
-      "EE5106R"
+      "ME5402"
     ],
     "prerequisites": []
   },
@@ -11833,7 +11146,6 @@
     "name": "Modelling and Applications of Mechatronic Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "MCH5002",
       "EE5063"
     ],
     "prerequisites": []
@@ -11862,13 +11174,11 @@
     "name": "Wireless and Sensor Networks",
     "creditCount": 4.0,
     "preclusions": [
-      "EE5406",
       "EE5913",
       "EE5023",
       "EE5024"
     ],
     "prerequisites": [
-      "EE3204",
       "EE4210"
     ]
   },
@@ -11878,9 +11188,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "EE4131",
-      "EE5306",
-      "EE5137R"
+      "EE5306"
     ]
   },
   {
@@ -11888,7 +11196,6 @@
     "name": "Optical Communications and Networks",
     "creditCount": 4.0,
     "preclusions": [
-      "EE5912",
       "EE6134"
     ],
     "prerequisites": []
@@ -11898,12 +11205,10 @@
     "name": "Digital Communications",
     "creditCount": 4.0,
     "preclusions": [
-      "EE5305",
       "EE6135"
     ],
     "prerequisites": [
       "EE5137",
-      "EE5137R",
       "EE5306"
     ]
   },
@@ -11912,7 +11217,6 @@
     "name": "Stochastic Processes",
     "creditCount": 4.0,
     "preclusions": [
-      "EE5306",
       "EE5137R"
     ],
     "prerequisites": []
@@ -11921,18 +11225,14 @@
     "code": "EE5138",
     "name": "Optimization for Communication Systems",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE5138R"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "EE5303",
     "name": "Microwave Electronics",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE5303R"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EE4101",
       "EE4104",
@@ -11943,9 +11243,7 @@
     "code": "EE5308",
     "name": "Antenna Engineering",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE5308R"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -11957,7 +11255,6 @@
     ],
     "prerequisites": [
       "EE2012",
-      "EE3204",
       "EE4210"
     ]
   },
@@ -11965,9 +11262,7 @@
     "code": "EE5431",
     "name": "Fundamentals of Nanoelectronics",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE5431R"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PC2232",
       "EE3431C"
@@ -11978,9 +11273,7 @@
     "name": "Microelectronic Processes and Integration",
     "creditCount": 4.0,
     "preclusions": [
-      "EE5515",
-      "EE5516",
-      "EE5432R"
+      "EE5516"
     ],
     "prerequisites": [
       "EE3431C"
@@ -11991,11 +11284,9 @@
     "name": "Micro/Nano Electromechanical Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "EE6439",
-      "EE5520"
+      "EE6439"
     ],
     "prerequisites": [
-      "EE4411",
       "CN4217"
     ]
   },
@@ -12003,9 +11294,7 @@
     "code": "EE5440",
     "name": "Magnetic Data Storage for Big Data",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE4433"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -12019,12 +11308,8 @@
     "code": "EE5507",
     "name": "Analog Integrated Circuits Design",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE5507R"
-    ],
-    "prerequisites": [
-      "EE3408"
-    ]
+    "preclusions": [],
+    "prerequisites": []
   },
   {
     "code": "EE5508",
@@ -12032,7 +11317,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "EE2004",
       "EE3406",
       "EE3431C"
     ]
@@ -12050,11 +11334,8 @@
     "code": "EE5518",
     "name": "Vlsi Digital Circuit Design",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE5518R"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "EE2020",
       "EE4415"
     ]
   },
@@ -12076,9 +11357,7 @@
     "code": "EE5702",
     "name": "Advanced Power System Analysis",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE5702R"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EE4501"
     ]
@@ -12088,7 +11367,6 @@
     "name": "Industrial Drives",
     "creditCount": 4.0,
     "preclusions": [
-      "EE5703R",
       "MCH5203"
     ],
     "prerequisites": [
@@ -12099,19 +11377,14 @@
     "code": "EE5711",
     "name": "Power Electronic Systems",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE5711R"
-    ],
-    "prerequisites": [
-      "EE3501C"
-    ]
+    "preclusions": [],
+    "prerequisites": []
   },
   {
     "code": "EE5731",
     "name": "Visual Computing",
     "creditCount": 4.0,
     "preclusions": [
-      "EE6904",
       "EE5731R"
     ],
     "prerequisites": []
@@ -12127,9 +11400,7 @@
     "code": "EE5831",
     "name": "Electromagnetic Wave Theory",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE5831R"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -12137,11 +11408,9 @@
     "name": "Multiprocessor Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "EE5902R",
       "TD5180A"
     ],
     "prerequisites": [
-      "EE3204",
       "EE3207"
     ]
   },
@@ -12150,9 +11419,7 @@
     "name": "Real-Time Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "EE4214",
-      "MCH5205",
-      "TD5103"
+      "MCH5205"
     ],
     "prerequisites": []
   },
@@ -12162,7 +11429,6 @@
     "creditCount": 4.0,
     "preclusions": [
       "ME5404",
-      "EE5904R",
       "MCH5202"
     ],
     "prerequisites": []
@@ -12172,7 +11438,6 @@
     "name": "Pattern Recognition",
     "creditCount": 4.0,
     "preclusions": [
-      "EE5907R",
       "EE5026",
       "EE5027"
     ],
@@ -12209,7 +11474,6 @@
     ],
     "prerequisites": [
       "EE5101",
-      "EE5101R",
       "ME5401"
     ]
   },
@@ -12229,7 +11493,6 @@
     "preclusions": [],
     "prerequisites": [
       "EE5137",
-      "EE5137R",
       "EE5306"
     ]
   },
@@ -12238,12 +11501,10 @@
     "name": "Digital Communications (Advanced)",
     "creditCount": 4.0,
     "preclusions": [
-      "EE5305",
       "EE5135"
     ],
     "prerequisites": [
       "EE5137",
-      "EE5137R",
       "EE5306"
     ]
   },
@@ -12256,7 +11517,6 @@
     ],
     "prerequisites": [
       "EE2012",
-      "EE3204",
       "EE4210"
     ]
   },
@@ -12265,36 +11525,28 @@
     "name": "Advanced Concepts in Nanoelectronics",
     "creditCount": 4.0,
     "preclusions": [
-      "EE5209",
       "EE5521"
     ],
     "prerequisites": [
-      "EE5431",
-      "EE5431R"
+      "EE5431"
     ]
   },
   {
     "code": "EE6436",
     "name": "Advanced Characterization of Materials and Devices",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE6503"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "EE5434",
-      "EE5432R"
+      "EE5434"
     ]
   },
   {
     "code": "EE6437",
     "name": "Advanced Semiconductor Devices",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE6505"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "EE5502",
-      "EE5433R"
+      "EE5502"
     ]
   },
   {
@@ -12304,7 +11556,6 @@
     "preclusions": [],
     "prerequisites": [
       "EE5431",
-      "EE5431R",
       "EE5433R"
     ]
   },
@@ -12313,11 +11564,9 @@
     "name": "Micro/Nano Electromechanical Systems (Advanced)",
     "creditCount": 4.0,
     "preclusions": [
-      "EE5439",
-      "EE5520"
+      "EE5439"
     ],
     "prerequisites": [
-      "EE4411",
       "CN4217"
     ]
   },
@@ -12328,9 +11577,7 @@
     "preclusions": [],
     "prerequisites": [
       "EE5711",
-      "EE5711R",
-      "EE5702",
-      "EE5702R"
+      "EE5702"
     ]
   },
   {
@@ -12340,9 +11587,7 @@
     "preclusions": [],
     "prerequisites": [
       "EE5907",
-      "EE5907R",
-      "EE5731",
-      "EE5731R"
+      "EE5731"
     ]
   },
   {
@@ -12351,8 +11596,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "EE5831",
-      "EE5831R"
+      "EE5831"
     ]
   },
   {
@@ -12361,8 +11605,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "EE5308",
-      "EE5308R"
+      "EE5308"
     ]
   },
   {
@@ -12372,9 +11615,7 @@
     "preclusions": [],
     "prerequisites": [
       "EE5303",
-      "EE5303R",
-      "EE5308",
-      "EE5308R"
+      "EE5308"
     ]
   },
   {
@@ -12458,9 +11699,7 @@
     "creditCount": 3.0,
     "preclusions": [],
     "prerequisites": [
-      "ES1501A",
       "ES1501B",
-      "ES1501C",
       "EG1413",
       "ES1531"
     ]
@@ -12507,19 +11746,14 @@
     "preclusions": [
       "ESP3902",
       "ESP3903",
-      "BN2203",
       "BN3101",
       "CG3002",
-      "EE3001",
       "EE3031",
-      "EE3032",
       "IE3100M",
-      "ME3101",
       "ME3102",
       "ESE4501",
       "MLE3103",
-      "MLE4102",
-      "EG3301"
+      "MLE4102"
     ],
     "prerequisites": []
   },
@@ -12528,7 +11762,6 @@
     "name": "Industrial Attachment",
     "creditCount": 12.0,
     "preclusions": [
-      "EG3601",
       "EG3602",
       "EG3612"
     ],
@@ -12539,7 +11772,6 @@
     "name": "Vacation Internship Programme",
     "creditCount": 6.0,
     "preclusions": [
-      "EG3601",
       "EG3602",
       "EG3611"
     ],
@@ -12562,15 +11794,12 @@
       "CN4118R",
       "CG4001",
       "EE4001",
-      "IE4100",
       "ME4101",
       "CE4104",
       "ESE4502",
       "MLE4101",
       "BN4101",
-      "CG4003",
       "CN4118",
-      "EE4002R",
       "ESE4502R",
       "IE4100R",
       "ME4101A",
@@ -12588,15 +11817,12 @@
       "BN4101R",
       "CE4104",
       "CG4001",
-      "CG4003",
       "CN4118",
       "CN4118R",
       "EE4001",
-      "EE4002R",
       "ESP4901",
       "ESE4502",
       "ESE4502R",
-      "IE4100",
       "IE4100R",
       "ME4101",
       "ME4101A",
@@ -12627,9 +11853,7 @@
     "code": "EL2101",
     "name": "Structure of Sentences and Meanings",
     "creditCount": 4.0,
-    "preclusions": [
-      "EL2201"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EL1101E",
       "GEK1011"
@@ -12639,9 +11863,7 @@
     "code": "EL2102",
     "name": "Sound Patterns in Language",
     "creditCount": 4.0,
-    "preclusions": [
-      "EL2202"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EL1101E",
       "GEK1011"
@@ -12651,9 +11873,7 @@
     "code": "EL2111",
     "name": "Historical Variation in English",
     "creditCount": 4.0,
-    "preclusions": [
-      "EL2211"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EL1101E",
       "GEK1011"
@@ -12663,9 +11883,7 @@
     "code": "EL2151",
     "name": "Social Variation in English",
     "creditCount": 4.0,
-    "preclusions": [
-      "EL2251"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EL1101E",
       "GEK1011"
@@ -12677,8 +11895,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "EL2101",
-      "EL2201"
+      "EL2101"
     ]
   },
   {
@@ -12737,8 +11954,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "EL2101",
-      "EL2201"
+      "EL2101"
     ]
   },
   {
@@ -12765,9 +11981,7 @@
     "code": "EL3222",
     "name": "Cinematic Discourse and Language",
     "creditCount": 4.0,
-    "preclusions": [
-      "EL3880B"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EL1101E",
       "GEK1011"
@@ -12777,11 +11991,8 @@
     "code": "EL3231",
     "name": "Phonetics",
     "creditCount": 4.0,
-    "preclusions": [
-      "EL3202"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "EL2202",
       "EL2102"
     ]
   },
@@ -12791,8 +12002,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "EL2151",
-      "EL2251"
+      "EL2151"
     ]
   },
   {
@@ -12806,9 +12016,7 @@
     "code": "EL4212",
     "name": "Field Methods in Linguistics",
     "creditCount": 5.0,
-    "preclusions": [
-      "EL3212"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -12822,9 +12030,7 @@
     "code": "EL4222",
     "name": "Stylistics and Drama",
     "creditCount": 5.0,
-    "preclusions": [
-      "TS4213"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -12833,7 +12039,6 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "EL2251",
       "EL2151"
     ]
   },
@@ -12888,7 +12093,6 @@
     "name": "Exploring Second Language Writing",
     "creditCount": 5.0,
     "preclusions": [
-      "EL5880B",
       "EL5880BR"
     ],
     "prerequisites": []
@@ -12934,18 +12138,14 @@
     "code": "EL5103",
     "name": "Language in Society",
     "creditCount": 4.0,
-    "preclusions": [
-      "EL5250"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "EL5103R",
     "name": "Language in Society",
     "creditCount": 5.0,
-    "preclusions": [
-      "EL5250"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -13022,18 +12222,14 @@
     "code": "EL5255",
     "name": "Second Language Writing",
     "creditCount": 4.0,
-    "preclusions": [
-      "EL5880B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "EL5255R",
     "name": "Second Language Writing",
     "creditCount": 5.0,
-    "preclusions": [
-      "EL5880B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -13076,44 +12272,28 @@
     "name": "English for Academic Purposes (Music) 1",
     "creditCount": 0.0,
     "preclusions": [
-      "AR1000",
       "BE1000",
-      "ID1000",
       "ET1000",
-      "NK1001",
       "EA1101",
-      "EG1471",
       "ES1301",
-      "ES1101",
       "ES1102",
-      "ES1103",
-      "EM1101"
+      "ES1103"
     ],
-    "prerequisites": [
-      "AY2009"
-    ]
+    "prerequisites": []
   },
   {
     "code": "EM1202",
     "name": "English for Academic Purposes (Music) 2",
     "creditCount": 0.0,
     "preclusions": [
-      "AR1000",
       "BE1000",
-      "ID1000",
       "ET1000",
-      "NK1001",
       "EA1101",
-      "EG1471",
       "ES1301",
-      "ES1101",
       "ES1102",
-      "ES1103",
-      "EM1101"
+      "ES1103"
     ],
-    "prerequisites": [
-      "AY2009"
-    ]
+    "prerequisites": []
   },
   {
     "code": "EN1101E",
@@ -13138,9 +12318,7 @@
     "code": "EN2202",
     "name": "Critical Reading",
     "creditCount": 4.0,
-    "preclusions": [
-      "EN3274"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EN1101E",
       "GEK1000"
@@ -13150,9 +12328,7 @@
     "code": "EN2203",
     "name": "Introduction to Film Studies",
     "creditCount": 4.0,
-    "preclusions": [
-      "EN2113"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -13202,7 +12378,6 @@
       "EN2201",
       "EN2202",
       "EN2203",
-      "EN2204",
       "EN2205",
       "EN2207"
     ]
@@ -13220,7 +12395,6 @@
       "EN2201",
       "EN2202",
       "EN2203",
-      "EN2204",
       "EN2205",
       "EN2207"
     ]
@@ -13238,7 +12412,6 @@
       "EN2201",
       "EN2202",
       "EN2203",
-      "EN2204",
       "EN2205",
       "EN2207"
     ]
@@ -13256,7 +12429,6 @@
       "EN2201",
       "EN2202",
       "EN2203",
-      "EN2204",
       "EN2205",
       "EN2207"
     ]
@@ -13274,7 +12446,6 @@
       "EN2201",
       "EN2202",
       "EN2203",
-      "EN2204",
       "EN2205",
       "EN2207"
     ]
@@ -13283,9 +12454,7 @@
     "code": "EN3231",
     "name": "American Literature I",
     "creditCount": 4.0,
-    "preclusions": [
-      "AS3231"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EN1101E",
       "GEK1000",
@@ -13294,7 +12463,6 @@
       "EN2201",
       "EN2202",
       "EN2203",
-      "EN2204",
       "EN2205",
       "EN2207"
     ]
@@ -13312,7 +12480,6 @@
       "EN2201",
       "EN2202",
       "EN2203",
-      "EN2204",
       "EN2205",
       "EN2207"
     ]
@@ -13330,7 +12497,6 @@
       "EN2201",
       "EN2202",
       "EN2203",
-      "EN2204",
       "EN2205",
       "EN2207"
     ]
@@ -13348,7 +12514,6 @@
       "EN2201",
       "EN2202",
       "EN2203",
-      "EN2204",
       "EN2205",
       "EN2207"
     ]
@@ -13357,9 +12522,7 @@
     "code": "EN3248",
     "name": "Reading the Horror Film",
     "creditCount": 4.0,
-    "preclusions": [
-      "EN2204"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EN2203"
     ]
@@ -13377,7 +12540,6 @@
       "EN2201",
       "EN2202",
       "EN2203",
-      "EN2204",
       "EN2205",
       "EN2207"
     ]
@@ -13386,9 +12548,7 @@
     "code": "EN3271",
     "name": "Advanced Playwriting",
     "creditCount": 4.0,
-    "preclusions": [
-      "TS4212"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "EN2271"
     ]
@@ -13453,9 +12613,7 @@
     "code": "EN4271",
     "name": "Research Workshop",
     "creditCount": 5.0,
-    "preclusions": [
-      "EL4200"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -13634,18 +12792,14 @@
     "code": "ENV1101",
     "name": "Environmental Studies: An Interdisciplinary Overview",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM1903"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "ENV1202",
     "name": "Communications for Environmental Studies",
     "creditCount": 4.0,
-    "preclusions": [
-      "SP1202"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "ES1000",
       "ES1103"
@@ -13732,12 +12886,9 @@
     "code": "ES1103",
     "name": "English for Academic Purposes",
     "creditCount": 4.0,
-    "preclusions": [
-      "ES1102"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "ES1000",
-      "AY2016",
       "ES1103"
     ]
   },
@@ -13746,20 +12897,16 @@
     "name": "Critical Thinking And Writing",
     "creditCount": 4.0,
     "preclusions": [
-      "IEM1201",
       "UTW1001",
-      "GEK1901",
       "GET1021",
       "ES1531",
       "GEK1549"
     ],
     "prerequisites": [
       "ES1000",
-      "ES1102",
       "ES1103",
       "ES1531",
       "GEK1549",
-      "AY2014",
       "GEK1549"
     ]
   },
@@ -13768,7 +12915,6 @@
     "name": "Exploring Science Communication through Popular Science",
     "creditCount": 4.0,
     "preclusions": [
-      "SP1203",
       "ENV1202",
       "SP2171",
       "SP1541",
@@ -13777,7 +12923,6 @@
     ],
     "prerequisites": [
       "ES1000",
-      "ES1102",
       "ES1541"
     ]
   },
@@ -13792,12 +12937,10 @@
       "ES2002",
       "ES2007D",
       "ES1541",
-      "SP1541",
-      "ES1501"
+      "SP1541"
     ],
     "prerequisites": [
       "ES1000",
-      "ES1102",
       "ES1103"
     ]
   },
@@ -13809,8 +12952,7 @@
       "MNO2706",
       "IS2101",
       "ES2007D",
-      "ES1601",
-      "UWC2101"
+      "ES1601"
     ],
     "prerequisites": [
       "ES1000",
@@ -13822,16 +12964,13 @@
     "name": "Professional Communication",
     "creditCount": 4.0,
     "preclusions": [
-      "CS2301",
       "ES2002",
       "IS2101",
       "CS2101",
-      "CG1413",
       "ES1601"
     ],
     "prerequisites": [
       "ES1000",
-      "ES1102",
       "ES1103",
       "ES2007D"
     ]
@@ -13841,9 +12980,7 @@
     "name": "Communicating Engineering",
     "creditCount": 4.0,
     "preclusions": [
-      "ES1501",
-      "ES1601",
-      "AY2014"
+      "ES1601"
     ],
     "prerequisites": [
       "ES1000",
@@ -13856,13 +12993,11 @@
     "name": "Communicating in the Information Age",
     "creditCount": 4.0,
     "preclusions": [
-      "GET1006",
       "GEK1901"
     ],
     "prerequisites": [
       "ES1000",
       "ES1103",
-      "AY2016",
       "ES2660"
     ]
   },
@@ -13899,7 +13034,6 @@
     "name": "Environmental Engineering Fundamentals",
     "creditCount": 4.0,
     "preclusions": [
-      "ESE1001FC",
       "ESE1001X"
     ],
     "prerequisites": [
@@ -13924,9 +13058,7 @@
     "code": "ESE2401",
     "name": "Water Science & Technology",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE3001"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "ESE2001"
     ]
@@ -13937,8 +13069,7 @@
     "creditCount": 4.0,
     "preclusions": [
       "ESE2401",
-      "ESE3401",
-      "TCE3001"
+      "ESE3401"
     ],
     "prerequisites": []
   },
@@ -13967,9 +13098,7 @@
     "code": "ESE3401",
     "name": "Water & Wastewater Engineering 1",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE3001"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "ESE2401"
     ]
@@ -13978,9 +13107,7 @@
     "code": "ESE4401",
     "name": "Water & Wastewater Engineering 2",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE4401"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "ESE2401",
       "ESE3401"
@@ -13997,9 +13124,7 @@
     "code": "ESE4408",
     "name": "Environmental Impact Assessment",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE4408"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "ESE3101",
       "ESE3201",
@@ -14186,7 +13311,6 @@
     "preclusions": [],
     "prerequisites": [
       "MA1507",
-      "MA1508",
       "MA1508E"
     ]
   },
@@ -14196,7 +13320,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "ESP1104",
       "ESP1107"
     ]
   },
@@ -14214,18 +13337,14 @@
     "code": "ESP3902",
     "name": "Major Design Project I",
     "creditCount": 4.0,
-    "preclusions": [
-      "ESP3901"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "ESP3903",
     "name": "Major Design Project 2",
     "creditCount": 4.0,
-    "preclusions": [
-      "ESP3901"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -14267,9 +13386,7 @@
     "creditCount": 4.0,
     "preclusions": [
       "PS2203",
-      "PS2231",
       "EU2218",
-      "PS2201B",
       "PS2218"
     ],
     "prerequisites": []
@@ -14280,9 +13397,7 @@
     "creditCount": 4.0,
     "preclusions": [
       "PS2204",
-      "PS2231",
       "EU2218",
-      "PS2201B",
       "PS2218"
     ],
     "prerequisites": []
@@ -14375,8 +13490,7 @@
     "preclusions": [
       "ES1531",
       "GEK1549",
-      "GET1021",
-      "ES1501"
+      "GET1021"
     ],
     "prerequisites": [
       "ES1000",
@@ -14391,7 +13505,6 @@
       "ES2002",
       "CS2101",
       "IS2101",
-      "GEK1901",
       "GET1006",
       "ES2660",
       "ES2007D",
@@ -14432,18 +13545,14 @@
     "code": "FDP2011",
     "name": "Special Mathematics Class 1, 2",
     "creditCount": 8.0,
-    "preclusions": [
-      "FDP2001"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "FDP2021",
     "name": "Special Physics Class 1, 2",
     "creditCount": 8.0,
-    "preclusions": [
-      "FDP2002"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -14502,9 +13611,7 @@
     "preclusions": [],
     "prerequisites": [
       "FE5101",
-      "FE5101D",
-      "FE5112",
-      "FE5112D"
+      "FE5112"
     ]
   },
   {
@@ -14514,9 +13621,7 @@
     "preclusions": [],
     "prerequisites": [
       "FE5101",
-      "FE5101D",
-      "FE5112",
-      "FE5112D"
+      "FE5112"
     ]
   },
   {
@@ -14575,27 +13680,19 @@
     "name": "Finance",
     "creditCount": 4.0,
     "preclusions": [
-      "CS2251",
       "EC3209",
       "EC3333",
-      "BK2004",
       "BZ2004",
-      "BH2004",
       "FNA2004",
       "FIN2004",
       "FIN2004"
     ],
     "prerequisites": [
-      "BK1003",
       "BZ1002",
-      "BH1002",
       "FNA1002",
       "ACC1002",
-      "FNA1002X",
       "ACC1002X",
-      "FNA1002E",
       "BH1002E",
-      "EC3212",
       "EG1422",
       "FIN2004"
     ]
@@ -14605,27 +13702,19 @@
     "name": "Finance",
     "creditCount": 4.0,
     "preclusions": [
-      "CS2251",
       "EC3209",
       "EC3333",
-      "BK2004",
       "BZ2004",
-      "BH2004",
       "FNA2004",
       "FIN2004",
       "FIN2004"
     ],
     "prerequisites": [
-      "BK1003",
       "BZ1002",
-      "BH1002",
       "FNA1002",
       "ACC1002",
-      "FNA1002X",
       "ACC1002X",
-      "FNA1002E",
       "BH1002E",
-      "EC3212",
       "EG1422",
       "FIN2004"
     ]
@@ -14661,21 +13750,15 @@
     "name": "Corporate Finance",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3101",
       "BZ3301",
-      "BK3100",
       "FNA3101",
       "FE5105",
       "FIN3101A",
-      "FIN3101B",
-      "FIN3101C"
+      "FIN3101B"
     ],
     "prerequisites": [
-      "FNA2004",
       "FIN2004",
-      "BH2004",
-      "BZ2004",
-      "BK2004"
+      "BZ2004"
     ]
   },
   {
@@ -14683,21 +13766,15 @@
     "name": "Corporate Finance",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3101",
       "BZ3301",
-      "BK3100",
       "FNA3101",
       "FE5105",
       "FIN3101",
-      "FIN3101B",
-      "FIN3101C"
+      "FIN3101B"
     ],
     "prerequisites": [
-      "FNA2004",
       "FIN2004",
-      "BH2004",
-      "BZ2004",
-      "BK2004"
+      "BZ2004"
     ]
   },
   {
@@ -14705,21 +13782,15 @@
     "name": "Corporate Finance",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3101",
       "BZ3301",
-      "BK3100",
       "FNA3101",
       "FE5105",
       "FIN3101",
-      "FIN3101A",
-      "FIN3101C"
+      "FIN3101A"
     ],
     "prerequisites": [
-      "FNA2004",
       "FIN2004",
-      "BH2004",
-      "BZ2004",
-      "BK2004"
+      "BZ2004"
     ]
   },
   {
@@ -14727,24 +13798,17 @@
     "name": "Investment Analysis and Portfolio Management",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3102",
       "BZ3302",
-      "BK3101",
       "FNA3102",
-      "FNA3102B",
       "FIN3102",
       "FIN3102B",
       "FE5108",
       "EC3333",
-      "CF3101",
       "QF3101"
     ],
     "prerequisites": [
-      "FNA2004",
       "FIN2004",
-      "BH2004",
-      "BZ2004",
-      "BK2004"
+      "BZ2004"
     ]
   },
   {
@@ -14752,24 +13816,17 @@
     "name": "Investment Analysis and Portfolio Management",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3102",
       "BZ3302",
-      "BK3101",
       "FNA3102",
-      "FNA3102A",
       "FIN3102",
       "FIN3102A",
       "FE5108",
       "EC3333",
-      "CF3101",
       "QF3101"
     ],
     "prerequisites": [
-      "FNA2004",
       "FIN2004",
-      "BH2004",
-      "BZ2004",
-      "BK2004"
+      "BZ2004"
     ]
   },
   {
@@ -14777,24 +13834,17 @@
     "name": "Investment Analysis and Portfolio Management",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3102",
       "BZ3302",
-      "BK3101",
       "FNA3102",
-      "FNA3102A",
       "FIN3102",
       "FIN3102A",
       "FE5108",
       "EC3333",
-      "CF3101",
       "QF3101"
     ],
     "prerequisites": [
-      "FNA2004",
       "FIN2004",
-      "BH2004",
-      "BZ2004",
-      "BK2004"
+      "BZ2004"
     ]
   },
   {
@@ -14802,19 +13852,13 @@
     "name": "Financial Markets",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3103",
       "BZ3303",
-      "BK3102",
       "FNA3103",
-      "FIN3103",
       "FIN3103B"
     ],
     "prerequisites": [
-      "FNA2004",
       "FIN2004",
-      "BH2004",
-      "BZ2004",
-      "BK2004"
+      "BZ2004"
     ]
   },
   {
@@ -14822,19 +13866,13 @@
     "name": "Financial Markets",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3103",
       "BZ3303",
-      "BK3102",
       "FNA3103",
-      "FIN3103",
       "FIN3103A"
     ],
     "prerequisites": [
-      "FNA2004",
       "FIN2004",
-      "BH2004",
-      "BZ2004",
-      "BK2004"
+      "BZ2004"
     ]
   },
   {
@@ -14842,21 +13880,15 @@
     "name": "Financial Statement Analysis",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3113",
       "BZ3105",
-      "BK3105",
       "FNA3113"
     ],
     "prerequisites": [
-      "FNA1002",
       "FNA1002X",
       "ACC1002",
       "ACC1002X",
-      "BH1002",
       "BZ1002",
-      "BK1003",
-      "FNA1002E",
-      "BH1002E"
+      "FNA1002E"
     ]
   },
   {
@@ -14864,19 +13896,13 @@
     "name": "Options and Futures",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3116",
       "BZ3312",
-      "BK3109A",
       "FNA3116",
-      "FIN3116A",
       "FIN3116B"
     ],
     "prerequisites": [
-      "FNA3102",
       "FNA3102A",
-      "FNA3102B",
       "FNA3102C",
-      "FIN3102",
       "FIN3102A",
       "FIN3102B",
       "FIN3102C"
@@ -14887,14 +13913,11 @@
     "name": "Bank Management",
     "creditCount": 4.0,
     "preclusions": [
-      "FNA3117",
       "FIN3117",
       "FE5105"
     ],
     "prerequisites": [
-      "FNA2004",
       "FIN2004",
-      "FNA3102",
       "FIN3102"
     ]
   },
@@ -14903,29 +13926,20 @@
     "name": "Financial Risk Management",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3118",
-      "BZ3305",
-      "FNA3118"
+      "BZ3305"
     ],
-    "prerequisites": [
-      "FIN3102"
-    ]
+    "prerequisites": []
   },
   {
     "code": "FIN3119",
     "name": "Risk and Insurance",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3119",
-      "BZ3311",
-      "FNA3119"
+      "BZ3311"
     ],
     "prerequisites": [
-      "FNA2004",
       "FIN2004",
-      "BH2004",
-      "BZ2004",
-      "BK2004"
+      "BZ2004"
     ]
   },
   {
@@ -14951,8 +13965,7 @@
     "preclusions": [],
     "prerequisites": [
       "ACC1002",
-      "FIN2004",
-      "FIN3102"
+      "FIN2004"
     ]
   },
   {
@@ -14960,12 +13973,9 @@
     "name": "Fixed Income Securities",
     "creditCount": 4.0,
     "preclusions": [
-      "FNA3120A",
-      "CF3201",
-      "QF3201"
+      "CF3201"
     ],
     "prerequisites": [
-      "FNA3102",
       "FIN3102",
       "FIN3102A",
       "FIN3102B",
@@ -14986,12 +13996,9 @@
     "code": "FIN4112G",
     "name": "SIF: Private Equity",
     "creditCount": 4.0,
-    "preclusions": [
-      "FIN4112F"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "FIN3101",
-      "FIN3102",
       "FIN3103"
     ]
   },
@@ -14999,12 +14006,9 @@
     "code": "FIN4112H",
     "name": "SIF: Investment Banking",
     "creditCount": 4.0,
-    "preclusions": [
-      "FIN4112F"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "FIN3101",
-      "FIN3102",
       "FIN3103"
     ]
   },
@@ -15013,9 +14017,7 @@
     "name": "SIF: Applied Portfolio Management Techniques",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "FIN3102"
-    ]
+    "prerequisites": []
   },
   {
     "code": "FIN4112L",
@@ -15030,24 +14032,18 @@
     "code": "FIN4113",
     "name": "Personal Finance and Wealth Management",
     "creditCount": 4.0,
-    "preclusions": [
-      "FNA4112E"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "FIN3101",
-      "ST1131A"
+      "FIN3101"
     ]
   },
   {
     "code": "FIN4113Y",
     "name": "Personal Finance and Wealth Management",
     "creditCount": 4.0,
-    "preclusions": [
-      "FNA4112E"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "FIN3101",
-      "ST1131A"
+      "FIN3101"
     ]
   },
   {
@@ -15057,8 +14053,7 @@
     "preclusions": [],
     "prerequisites": [
       "ACC1002",
-      "FIN3101",
-      "FIN3102"
+      "FIN3101"
     ]
   },
   {
@@ -15240,7 +14235,6 @@
     "name": "Fundamentals of Food Engineering",
     "creditCount": 4.0,
     "preclusions": [
-      "CM1161",
       "CM2161"
     ],
     "prerequisites": [
@@ -15251,9 +14245,7 @@
     "code": "FST2102B",
     "name": "Chemistry of Food Components",
     "creditCount": 4.0,
-    "preclusions": [
-      "FST2102A"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "FST1101",
       "CM1121",
@@ -15267,7 +14259,6 @@
     "preclusions": [],
     "prerequisites": [
       "FST1101",
-      "LSM1101",
       "LSM1106"
     ]
   },
@@ -15277,7 +14268,6 @@
     "creditCount": 4.0,
     "preclusions": [
       "CM2192",
-      "CM2192A",
       "FST2102A"
     ],
     "prerequisites": [
@@ -15289,12 +14279,9 @@
     "code": "FST2108",
     "name": "Food Safety Assurance",
     "creditCount": 4.0,
-    "preclusions": [
-      "FST3102"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "FST2102B",
-      "LSM1103",
       "LSM2103",
       "LSM1106"
     ]
@@ -15305,7 +14292,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "LSM1101",
       "LSM1106"
     ]
   },
@@ -15358,9 +14344,7 @@
     "code": "FST3105",
     "name": "Food Product Development and Packaging",
     "creditCount": 4.0,
-    "preclusions": [
-      "FST3104"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "FST2102B",
       "FST2107",
@@ -15372,7 +14356,6 @@
     "name": "Sensory and Flavour Science",
     "creditCount": 4.0,
     "preclusions": [
-      "FST3104",
       "FST4101"
     ],
     "prerequisites": [
@@ -15422,18 +14405,14 @@
     "code": "FST3310",
     "name": "Undergraduate Professional Internship Programme",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3310"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "FST3311",
     "name": "Undergraduate Professional Internship Programme",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3311"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -15469,7 +14448,6 @@
     "preclusions": [],
     "prerequisites": [
       "FST3202",
-      "LSM2101",
       "LSM2211"
     ]
   },
@@ -15541,11 +14519,8 @@
     "code": "FST5301",
     "name": "Evidence Based Functional Foods",
     "creditCount": 4.0,
-    "preclusions": [
-      "FST5204"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "FST2102",
       "CM2121"
     ]
   },
@@ -15569,18 +14544,14 @@
     "code": "GE1101E",
     "name": "Geographical Journeys: Exploring World Environments",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEK1001"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "GE2101",
     "name": "Methods and Practices in Geography",
     "creditCount": 4.0,
-    "preclusions": [
-      "GE2225"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -15608,9 +14579,7 @@
     "code": "GE2215",
     "name": "Introduction to GIS & Remote Sensing",
     "creditCount": 4.0,
-    "preclusions": [
-      "IF2203"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -15659,18 +14628,14 @@
     "code": "GE2228",
     "name": "Weather and Climate",
     "creditCount": 4.0,
-    "preclusions": [
-      "GE2219"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "GE2229",
     "name": "Water and the Environment",
     "creditCount": 4.0,
-    "preclusions": [
-      "GE2219"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -15735,9 +14700,7 @@
     "code": "GE3230A",
     "name": "Field Studies in Geography: SE Asia",
     "creditCount": 8.0,
-    "preclusions": [
-      "GE3230"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -15781,9 +14744,7 @@
     "code": "GE3241",
     "name": "Geographies of Social Life",
     "creditCount": 4.0,
-    "preclusions": [
-      "GE2224"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -15798,8 +14759,7 @@
     "name": "GIS Internship Module",
     "creditCount": 4.0,
     "preclusions": [
-      "GE3550B",
-      "XX3550"
+      "GE3550B"
     ],
     "prerequisites": [
       "GE2215",
@@ -15812,8 +14772,7 @@
     "name": "Geography Internship",
     "creditCount": 4.0,
     "preclusions": [
-      "GE3550A",
-      "XX3550"
+      "GE3550A"
     ],
     "prerequisites": []
   },
@@ -15843,24 +14802,19 @@
     "preclusions": [],
     "prerequisites": [
       "GE1101E",
-      "GE2219",
       "GE2220",
       "GE2228",
       "GE2229",
-      "GE3221",
-      "GE3227",
-      "GE1101E",
-      "GE2219",
-      "GE2220",
-      "GE2228",
-      "GE2229",
-      "GE3221",
       "GE3227",
       "GE1101E",
       "GE2220",
       "GE2228",
       "GE2229",
-      "GE3221",
+      "GE3227",
+      "GE1101E",
+      "GE2220",
+      "GE2228",
+      "GE2229",
       "GE3223",
       "GE3231"
     ]
@@ -15872,30 +14826,23 @@
     "preclusions": [],
     "prerequisites": [
       "GE1101E",
-      "GE2219",
       "GE2220",
       "GE2228",
       "GE2229",
-      "GE3221",
-      "GE3227",
-      "GE1101E",
-      "GE2219",
-      "GE2220",
-      "GE2228",
-      "GE2229",
-      "GE3221",
       "GE3227",
       "GE1101E",
       "GE2220",
       "GE2228",
       "GE2229",
-      "GE3221",
+      "GE3227",
       "GE1101E",
-      "GE2219",
       "GE2220",
       "GE2228",
       "GE2229",
-      "GE3221",
+      "GE1101E",
+      "GE2220",
+      "GE2228",
+      "GE2229",
       "GE3227"
     ]
   },
@@ -15906,31 +14853,24 @@
     "preclusions": [],
     "prerequisites": [
       "GE1101E",
-      "GE2219",
       "GE2220",
       "GE2228",
       "GE2229",
-      "GE3221",
-      "GE3227",
-      "GE1101E",
-      "GE2219",
-      "GE2220",
-      "GE2228",
-      "GE2229",
-      "GE3221",
-      "GE3227",
-      "GE1101E",
-      "GE2219",
-      "GE2220",
-      "GE2228",
-      "GE2229",
-      "GE3221",
       "GE3227",
       "GE1101E",
       "GE2220",
       "GE2228",
       "GE2229",
-      "GE3221",
+      "GE3227",
+      "GE1101E",
+      "GE2220",
+      "GE2228",
+      "GE2229",
+      "GE3227",
+      "GE1101E",
+      "GE2220",
+      "GE2228",
+      "GE2229",
       "GE3223",
       "GE3227"
     ]
@@ -15982,8 +14922,7 @@
     "preclusions": [],
     "prerequisites": [
       "GE1101E",
-      "GE2221",
-      "GE3210"
+      "GE2221"
     ]
   },
   {
@@ -15997,9 +14936,7 @@
     "code": "GE4223",
     "name": "Development of Geographic Thought",
     "creditCount": 5.0,
-    "preclusions": [
-      "GE4101A"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -16065,9 +15002,7 @@
     "code": "GE4233",
     "name": "Geography in the Contemporary World",
     "creditCount": 5.0,
-    "preclusions": [
-      "GE4102"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "GE1101E",
       "GE2202",
@@ -16077,7 +15012,6 @@
       "GE2229",
       "GE3201",
       "GE3206",
-      "GE3221",
       "GE3223",
       "GE3227",
       "GE3231",
@@ -16261,7 +15195,6 @@
     "name": "Economic Issues in Dev World",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM1018K",
       "GEK1018"
     ],
     "prerequisites": []
@@ -16361,8 +15294,7 @@
     "name": "Food & Health",
     "creditCount": 4.0,
     "preclusions": [
-      "GEK1529",
-      "GEM1908"
+      "GEK1529"
     ],
     "prerequisites": []
   },
@@ -16380,8 +15312,7 @@
     "name": "Exploring Chinese Cinema: Shanghai-Hong Kong-Singapore",
     "creditCount": 4.0,
     "preclusions": [
-      "GEK2047",
-      "CH2297"
+      "GEK2047"
     ],
     "prerequisites": []
   },
@@ -16409,9 +15340,7 @@
     "code": "GEH1026",
     "name": "Drugs and Society",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEK2506"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -16436,9 +15365,7 @@
     "code": "GEH1030",
     "name": "Science of Music",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEK1519"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -16455,8 +15382,7 @@
     "name": "How the Ocean Works",
     "creditCount": 4.0,
     "preclusions": [
-      "GEK1548",
-      "GEK1548FC"
+      "GEK1548"
     ],
     "prerequisites": []
   },
@@ -16473,9 +15399,7 @@
     "code": "GEH1035",
     "name": "Phy'cal Qns from Everyday Life",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM2507"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -16491,18 +15415,14 @@
     "code": "GEH1040",
     "name": "Exploration in Musical Production",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEK1065"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "GEH1041",
     "name": "Engaging the natural environment in ASEAN",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEK1066"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -16545,9 +15465,7 @@
     "code": "GEH1050",
     "name": "Plants and Society",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEK1538"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -16733,7 +15651,6 @@
     "name": "Introduction to Politics",
     "creditCount": 4.0,
     "preclusions": [
-      "PS1101",
       "GEM1003K",
       "PS1101E"
     ],
@@ -16764,7 +15681,6 @@
     "preclusions": [
       "SE1101E",
       "SSA1202",
-      "SS1203SE",
       "GEM1008K"
     ],
     "prerequisites": []
@@ -16908,7 +15824,6 @@
     "name": "Life, the Universe, and Everything",
     "creditCount": 4.0,
     "preclusions": [
-      "PH1102E",
       "GET1029"
     ],
     "prerequisites": []
@@ -16927,7 +15842,6 @@
     "name": "Einstein's Universe & Quantum Weirdness",
     "creditCount": 4.0,
     "preclusions": [
-      "PC1325",
       "GEH1027"
     ],
     "prerequisites": []
@@ -16945,9 +15859,7 @@
     "code": "GEK1520",
     "name": "Understanding the Universe",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEH1031"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -16975,8 +15887,7 @@
     "name": "Food & Health",
     "creditCount": 4.0,
     "preclusions": [
-      "GEH1019",
-      "GEM1908"
+      "GEH1019"
     ],
     "prerequisites": []
   },
@@ -17048,20 +15959,16 @@
     "name": "Critical Thinking And Writing",
     "creditCount": 4.0,
     "preclusions": [
-      "IEM1201",
       "UTW1001",
-      "GEK1901",
       "GET1021",
       "ES1531",
       "GEK1549"
     ],
     "prerequisites": [
       "ES1000",
-      "ES1102",
       "ES1103",
       "ES1531",
       "GEK1549",
-      "AY2014",
       "GEK1549"
     ]
   },
@@ -17096,12 +16003,9 @@
     "name": "Government and Politics of Singapore",
     "creditCount": 4.0,
     "preclusions": [
-      "PS1102",
       "GEM2003K",
-      "SS2209PS",
       "PS2101B",
       "SSA2209",
-      "PS2101",
       "PS2249"
     ],
     "prerequisites": []
@@ -17172,8 +16076,7 @@
     "name": "Greek Philosophy (Socrates and Plato)",
     "creditCount": 4.0,
     "preclusions": [
-      "PH2222",
-      "PH3209"
+      "PH2222"
     ],
     "prerequisites": []
   },
@@ -17182,7 +16085,6 @@
     "name": "Science Fiction and Philosophy",
     "creditCount": 4.0,
     "preclusions": [
-      "PH2225",
       "GET1025"
     ],
     "prerequisites": []
@@ -17210,7 +16112,6 @@
     "name": "Exploring Chinese Cinema: Shanghai-Hong Kong-Singapore",
     "creditCount": 4.0,
     "preclusions": [
-      "CH2297",
       "GEH1023"
     ],
     "prerequisites": []
@@ -17220,7 +16121,6 @@
     "name": "Effective Reasoning",
     "creditCount": 4.0,
     "preclusions": [
-      "PH2111",
       "GET1026"
     ],
     "prerequisites": []
@@ -17275,7 +16175,6 @@
     "name": "Patrons of the Arts",
     "creditCount": 4.0,
     "preclusions": [
-      "MUL2102",
       "GET1019"
     ],
     "prerequisites": []
@@ -17368,7 +16267,6 @@
     "name": "Darwin and Evolution",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM1902B",
       "GET1020"
     ],
     "prerequisites": []
@@ -17396,7 +16294,6 @@
     "name": "Logic",
     "creditCount": 4.0,
     "preclusions": [
-      "PH2110",
       "CS3234",
       "MA4207",
       "GET1028"
@@ -17432,9 +16329,7 @@
     "code": "GEQ1917",
     "name": "Understanding and Critiquing Sustainability",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM1917"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -17448,8 +16343,7 @@
       "GER1000R",
       "GER1000S",
       "GER1000T",
-      "GER1000P",
-      "GER1000B"
+      "GER1000P"
     ],
     "prerequisites": []
   },
@@ -17464,8 +16358,7 @@
       "GER1000R",
       "GER1000S",
       "GER1000T",
-      "GER1000P",
-      "GER1000B"
+      "GER1000P"
     ],
     "prerequisites": []
   },
@@ -17480,8 +16373,7 @@
       "GER1000R",
       "GER1000S",
       "GER1000T",
-      "GER1000P",
-      "GER1000B"
+      "GER1000P"
     ],
     "prerequisites": []
   },
@@ -17496,8 +16388,7 @@
       "GER1000W",
       "GER1000R",
       "GER1000S",
-      "GER1000T",
-      "GER1000B"
+      "GER1000T"
     ],
     "prerequisites": []
   },
@@ -17512,8 +16403,7 @@
       "GER1000W",
       "GER1000S",
       "GER1000T",
-      "GER1000P",
-      "GER1000B"
+      "GER1000P"
     ],
     "prerequisites": []
   },
@@ -17528,8 +16418,7 @@
       "GER1000W",
       "GER1000R",
       "GER1000T",
-      "GER1000P",
-      "GER1000B"
+      "GER1000P"
     ],
     "prerequisites": []
   },
@@ -17544,8 +16433,7 @@
       "GER1000W",
       "GER1000R",
       "GER1000S",
-      "GER1000P",
-      "GER1000B"
+      "GER1000P"
     ],
     "prerequisites": []
   },
@@ -17560,8 +16448,7 @@
       "GER1000R",
       "GER1000S",
       "GER1000T",
-      "GER1000P",
-      "GER1000B"
+      "GER1000P"
     ],
     "prerequisites": []
   },
@@ -17570,9 +16457,7 @@
     "name": "Labour Law In Singapore",
     "creditCount": 4.0,
     "preclusions": [
-      "SSB1204",
-      "SSB1204T",
-      "GES1000"
+      "SSB1204T"
     ],
     "prerequisites": []
   },
@@ -17592,7 +16477,6 @@
     "name": "Global Economic Dimensions Of Singapore",
     "creditCount": 4.0,
     "preclusions": [
-      "EC2202",
       "EC2373",
       "GES1002",
       "SSA2220",
@@ -17660,7 +16544,6 @@
     "name": "Singapore\u2019s Business History",
     "creditCount": 4.0,
     "preclusions": [
-      "HY2239",
       "SSA2203"
     ],
     "prerequisites": []
@@ -17670,7 +16553,6 @@
     "name": "Nation-Building in Singapore",
     "creditCount": 4.0,
     "preclusions": [
-      "HY2229",
       "USE2304",
       "SSA2204"
     ],
@@ -17690,7 +16572,6 @@
     "name": "Popular Culture in Singapore",
     "creditCount": 4.0,
     "preclusions": [
-      "HY2254",
       "SSA2221"
     ],
     "prerequisites": []
@@ -17700,8 +16581,7 @@
     "name": "Islam and Contemporary Malay Society",
     "creditCount": 4.0,
     "preclusions": [
-      "SSA2206",
-      "MS2205"
+      "SSA2206"
     ],
     "prerequisites": []
   },
@@ -17710,8 +16590,7 @@
     "name": "Singapore and Japan: Historical and Contemporary Relationships",
     "creditCount": 4.0,
     "preclusions": [
-      "SSA2205",
-      "JS2224"
+      "SSA2205"
     ],
     "prerequisites": []
   },
@@ -17783,8 +16662,7 @@
     "name": "Singapore Literature in English: Selected Texts",
     "creditCount": 4.0,
     "preclusions": [
-      "SSA1207",
-      "SSA1207FC"
+      "SSA1207"
     ],
     "prerequisites": []
   },
@@ -17811,8 +16689,7 @@
     "name": "Singapore Film: Performance of Identity",
     "creditCount": 4.0,
     "preclusions": [
-      "SSA2218",
-      "TS2238"
+      "SSA2218"
     ],
     "prerequisites": []
   },
@@ -17862,9 +16739,7 @@
     "code": "GET1001",
     "name": "Seeing the World Through Maps",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEK1037"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -17917,9 +16792,7 @@
     "name": "Towards an Understanding of the Complex World",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM1912",
-      "GEM1912",
-      "GEM1915"
+      "GEM1912"
     ],
     "prerequisites": []
   },
@@ -17927,9 +16800,7 @@
     "code": "GET1013",
     "name": "Physics in the Life Sciences",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEK1521"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -17974,8 +16845,7 @@
     "name": "Patrons of the Arts",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM1029",
-      "MUL2102"
+      "GEM1029"
     ],
     "prerequisites": []
   },
@@ -17984,7 +16854,6 @@
     "name": "Darwin and Evolution",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM1902B",
       "GEM1536"
     ],
     "prerequisites": []
@@ -17994,18 +16863,14 @@
     "name": "Critical Thinking And Writing",
     "creditCount": 4.0,
     "preclusions": [
-      "IEM1201",
       "UTW1001",
-      "GET1006",
       "ES1531",
       "GEK1549",
       "GET1021"
     ],
     "prerequisites": [
       "ES1000",
-      "ES1102",
       "GET1021",
-      "AY2015",
       "GET1021"
     ]
   },
@@ -18062,7 +16927,6 @@
     "name": "Logic",
     "creditCount": 4.0,
     "preclusions": [
-      "PH2110",
       "CS3234",
       "MA4207",
       "GEM2006"
@@ -18074,7 +16938,6 @@
     "name": "Life, the Universe, and Everything",
     "creditCount": 4.0,
     "preclusions": [
-      "PH1102E",
       "GEK1067"
     ],
     "prerequisites": []
@@ -18222,9 +17085,7 @@
     "code": "GL3550",
     "name": "Global Studies Internship",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3550"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "GL1101E",
       "GL2101",
@@ -18648,9 +17509,7 @@
     "name": "Human Capital in Organizations",
     "creditCount": 3.0,
     "preclusions": [
-      "HR2001",
       "HR2101",
-      "HR3111",
       "HR2002"
     ],
     "prerequisites": []
@@ -18908,9 +17767,7 @@
     "code": "HY4230",
     "name": "Historiography and Historical Method",
     "creditCount": 5.0,
-    "preclusions": [
-      "HY4101"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -18947,7 +17804,6 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "HY3250",
       "HY3250"
     ]
   },
@@ -19194,7 +18050,6 @@
     "creditCount": 12.0,
     "preclusions": [],
     "prerequisites": [
-      "ID3103",
       "ID3104",
       "ID3105"
     ]
@@ -19313,8 +18168,7 @@
     "name": "Introduction to Systems Thinking and Dynamics",
     "creditCount": 4.0,
     "preclusions": [
-      "IE1112",
-      "IE2101"
+      "IE1112"
     ],
     "prerequisites": [
       "IE1113"
@@ -19325,7 +18179,6 @@
     "name": "Introduction to Industrial System",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3161",
       "TIE2010"
     ],
     "prerequisites": []
@@ -19359,7 +18212,6 @@
     "name": "Operations Research I",
     "creditCount": 4.0,
     "preclusions": [
-      "DBA3701",
       "MA2215",
       "MA3236"
     ],
@@ -19371,7 +18223,6 @@
     "creditCount": 4.0,
     "preclusions": [
       "DSC3214",
-      "MA2215",
       "MA3236",
       "TIE2110"
     ],
@@ -19404,7 +18255,6 @@
     "name": "Quality Engineering I",
     "creditCount": 4.0,
     "preclusions": [
-      "TM4271",
       "TIE2130"
     ],
     "prerequisites": []
@@ -19495,9 +18345,7 @@
     "code": "IE3105",
     "name": "Fundamentals of Systems Engineering and Architecture",
     "creditCount": 4.0,
-    "preclusions": [
-      "IE2101"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "IE1112"
     ]
@@ -19506,9 +18354,7 @@
     "code": "IE3110",
     "name": "Simulation",
     "creditCount": 5.0,
-    "preclusions": [
-      "DSC3221"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "IE2100",
       "DSC3215"
@@ -19519,7 +18365,6 @@
     "name": "Simulation",
     "creditCount": 5.0,
     "preclusions": [
-      "DSC3221",
       "TIE3110"
     ],
     "prerequisites": []
@@ -19539,8 +18384,7 @@
     "name": "BTech Dissertation",
     "creditCount": 12.0,
     "preclusions": [
-      "IE4101E",
-      "TIE4101"
+      "IE4101E"
     ],
     "prerequisites": []
   },
@@ -19558,7 +18402,6 @@
     "name": "B.Tech. Dissertation",
     "creditCount": 8.0,
     "preclusions": [
-      "TIE4101",
       "IE4100E"
     ],
     "prerequisites": []
@@ -19773,7 +18616,6 @@
     "name": "Modelling for Supply Chain Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "IE5401",
       "IE5405"
     ],
     "prerequisites": []
@@ -19976,26 +18818,21 @@
       "BDC6306"
     ],
     "prerequisites": [
-      "BDC6112",
-      "IE6004"
+      "BDC6112"
     ]
   },
   {
     "code": "IE6509",
     "name": "Theory and Algorithms for Dynamic Programming",
     "creditCount": 4.0,
-    "preclusions": [
-      "BDC6305"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "IE6511",
     "name": "Surrogate and Metaheuristic Global Optimization",
     "creditCount": 4.0,
-    "preclusions": [
-      "IE6499A"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -20037,7 +18874,6 @@
     "name": "Information Security Capstone Project.",
     "creditCount": 8.0,
     "preclusions": [
-      "CS3205",
       "IFS4205"
     ],
     "prerequisites": [
@@ -20048,9 +18884,7 @@
     "code": "IGL3550",
     "name": "Extended Global Studies Internship",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3550"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "GL1101E",
       "GL2101",
@@ -20114,9 +18948,7 @@
     "code": "IPS3550",
     "name": "Extended Political Science Internship",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3550"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -20139,7 +18971,6 @@
     ],
     "prerequisites": [
       "ES1000",
-      "ES1102",
       "ES1103",
       "IS2101"
     ]
@@ -20168,9 +18999,7 @@
     "code": "IS3103",
     "name": "Information Systems Leadership and Communication",
     "creditCount": 4.0,
-    "preclusions": [
-      "IS3101"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "IS1103",
       "CS2101",
@@ -20181,9 +19010,7 @@
     "code": "IS3106",
     "name": "Enterprise Systems Interface Design and Development",
     "creditCount": 4.0,
-    "preclusions": [
-      "CS3226"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "IS2103"
     ]
@@ -20204,7 +19031,6 @@
     "preclusions": [],
     "prerequisites": [
       "IS1103",
-      "IS1103FC",
       "IS1103X"
     ]
   },
@@ -20235,7 +19061,6 @@
     "preclusions": [],
     "prerequisites": [
       "CS1020",
-      "CS2020",
       "CS2030",
       "CS2040"
     ]
@@ -20248,7 +19073,6 @@
     "prerequisites": [
       "IS2101",
       "CS2101",
-      "IS1105",
       "IS3101",
       "IS3103",
       "IS2103",
@@ -20263,7 +19087,6 @@
     "creditCount": 4.0,
     "preclusions": [
       "IS5110",
-      "CS5212",
       "IS5110"
     ],
     "prerequisites": [
@@ -20277,9 +19100,7 @@
     "code": "IS4103",
     "name": "Information Systems Capstone Project",
     "creditCount": 8.0,
-    "preclusions": [
-      "IS3102"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "IS2101",
       "IS2102",
@@ -20292,9 +19113,7 @@
     "name": "Pervasive Technology Solutions and Development",
     "creditCount": 4.0,
     "preclusions": [
-      "IS4150",
       "IS5451",
-      "SMA5508",
       "SG5233"
     ],
     "prerequisites": [
@@ -20308,7 +19127,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "IS3101",
       "IS3103"
     ]
   },
@@ -20318,7 +19136,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "IS3101",
       "IS3103"
     ]
   },
@@ -20326,9 +19143,7 @@
     "code": "IS4231",
     "name": "Information Security Management",
     "creditCount": 4.0,
-    "preclusions": [
-      "CS3254"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CS2107"
     ]
@@ -20337,11 +19152,8 @@
     "code": "IS4233",
     "name": "Legal Aspects of Information Technology",
     "creditCount": 4.0,
-    "preclusions": [
-      "CS4259"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "IS3101",
       "IS3103"
     ]
   },
@@ -20349,9 +19161,7 @@
     "code": "IS4234",
     "name": "Quality Control and Audit of IS",
     "creditCount": 4.0,
-    "preclusions": [
-      "CS4252"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "IS2102",
       "IS2103",
@@ -20395,7 +19205,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "IS3101",
       "IS3103"
     ]
   },
@@ -20416,8 +19225,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "IS3103",
-      "IS3101"
+      "IS3103"
     ]
   },
   {
@@ -20606,9 +19414,7 @@
     "creditCount": 4.0,
     "preclusions": [
       "IS4151",
-      "IS4150",
-      "SMA5508",
-      "SG5233"
+      "SMA5508"
     ],
     "prerequisites": []
   },
@@ -20707,9 +19513,7 @@
     "code": "ISE3550",
     "name": "Extended Internship",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3550"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -20719,12 +19523,9 @@
     "preclusions": [
       "CS1010",
       "CS1010E",
-      "CS1010FC",
       "CS1010S",
-      "CS1101",
       "CS1101C",
       "CS1101S",
-      "GEK1511",
       "AY2001"
     ],
     "prerequisites": []
@@ -20734,8 +19535,7 @@
     "name": "Introduction to Programming with Python and C",
     "creditCount": 4.0,
     "preclusions": [
-      "CS1010",
-      "IT1005"
+      "CS1010"
     ],
     "prerequisites": []
   },
@@ -20863,9 +19663,7 @@
     "code": "JS4101",
     "name": "Research and Writing in Japanese Studies",
     "creditCount": 5.0,
-    "preclusions": [
-      "JS4221"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -20875,9 +19673,7 @@
     "preclusions": [],
     "prerequisites": [
       "LAJ3201",
-      "LAJ3203",
-      "LAJ3201",
-      "LAJ3203"
+      "LAJ3201"
     ]
   },
   {
@@ -21032,7 +19828,6 @@
     "creditCount": 8.0,
     "preclusions": [],
     "prerequisites": [
-      "KE4102",
       "KE5107"
     ]
   },
@@ -21068,9 +19863,7 @@
     "code": "LA4203",
     "name": "History and Theory of Landscape Architecture",
     "creditCount": 4.0,
-    "preclusions": [
-      "LA3201"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -21319,9 +20112,7 @@
     "code": "LAF3202",
     "name": "French 4",
     "creditCount": 4.0,
-    "preclusions": [
-      "LAF3203"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LAF3201"
     ]
@@ -21332,8 +20123,7 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "LAF3202",
-      "LAF3203"
+      "LAF3202"
     ]
   },
   {
@@ -21374,9 +20164,7 @@
     "code": "LAG3202",
     "name": "German 4",
     "creditCount": 4.0,
-    "preclusions": [
-      "LAG3203"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LAG3201"
     ]
@@ -21387,8 +20175,7 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "LAG3202",
-      "LAG3203"
+      "LAG3202"
     ]
   },
   {
@@ -21490,9 +20277,7 @@
     "code": "LAJ3201",
     "name": "Japanese 5",
     "creditCount": 4.0,
-    "preclusions": [
-      "LAJ3203"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LAJ2203"
     ]
@@ -21503,8 +20288,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "LAJ3201",
-      "LAJ3203"
+      "LAJ3201"
     ]
   },
   {
@@ -21513,7 +20297,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "LAJ3203",
       "LAJ3201"
     ]
   },
@@ -21523,8 +20306,7 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "LAJ3201",
-      "LAJ3203"
+      "LAJ3201"
     ]
   },
   {
@@ -21566,9 +20348,7 @@
     "code": "LAK3202",
     "name": "Korean 4",
     "creditCount": 4.0,
-    "preclusions": [
-      "LAK3203"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LAK3201"
     ]
@@ -21579,8 +20359,7 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "LAK3202",
-      "LAK3203"
+      "LAK3202"
     ]
   },
   {
@@ -21751,9 +20530,7 @@
     "code": "LAS3202",
     "name": "Spanish 4",
     "creditCount": 4.0,
-    "preclusions": [
-      "YS2202"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LAS3201",
       "YLS2201"
@@ -21775,9 +20552,7 @@
     "code": "LAS4202",
     "name": "Spanish 6",
     "creditCount": 5.0,
-    "preclusions": [
-      "YLS3202"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LAS4201",
       "YLS3201"
@@ -22144,9 +20919,7 @@
     "name": "Trial Advocacy",
     "creditCount": 4.0,
     "preclusions": [
-      "LC2002",
-      "LC2013",
-      "LC2003"
+      "LC2013"
     ],
     "prerequisites": []
   },
@@ -22155,9 +20928,7 @@
     "name": "Corporate Deals",
     "creditCount": 4.0,
     "preclusions": [
-      "LC2002",
-      "LC2012",
-      "LC2003"
+      "LC2012"
     ],
     "prerequisites": []
   },
@@ -22194,15 +20965,10 @@
     "name": "Taxation Issues in Cross-Border Transactions",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4035",
       "LL5035",
-      "LL6035",
       "LL4035V",
-      "LL5035V",
       "LL6035V",
-      "LL4342",
       "LL5342",
-      "LL6342",
       "LL4342V",
       "LL5342V",
       "LL6342V"
@@ -22213,9 +20979,7 @@
     "code": "LC5050V",
     "name": "Public International Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LC5050"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22271,9 +21035,7 @@
     "code": "LC5204BV",
     "name": "Charterparties",
     "creditCount": 5.0,
-    "preclusions": [
-      "LC5204B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22294,9 +21056,7 @@
     "code": "LC5262V",
     "name": "International Commercial Arbitration",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4029"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22315,9 +21075,7 @@
     "name": "Chinese Business Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4089",
       "LL5089",
-      "LL6089",
       "LL4089V",
       "LL5089V",
       "LL6089V",
@@ -22330,9 +21088,7 @@
     "name": "International Dispute Settlement",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4285",
       "LL5285",
-      "LL6285",
       "LC5285"
     ],
     "prerequisites": []
@@ -22369,13 +21125,9 @@
     "name": "Law Of Intellectual Property (A)",
     "creditCount": 8.0,
     "preclusions": [
-      "LL4405B",
       "LL5405B",
-      "LL6405B",
       "LL4070",
-      "LL5070",
-      "LC5070",
-      "LL6070"
+      "LC5070"
     ],
     "prerequisites": []
   },
@@ -22397,9 +21149,7 @@
     "code": "LCD5204BV",
     "name": "Charterparties",
     "creditCount": 5.0,
-    "preclusions": [
-      "LCD5204B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22443,36 +21193,28 @@
     "code": "LL4002V",
     "name": "Admiralty Law & Practice",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4002"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4003V",
     "name": "China, India and International Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4003"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4004V",
     "name": "Aviation Law & Policy",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4004"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4006V",
     "name": "Banking Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4006"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22486,9 +21228,7 @@
     "code": "LL4008BV",
     "name": "Charterparties",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4008B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22502,27 +21242,21 @@
     "code": "LL4013V",
     "name": "Comparative Environmental Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4013"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4014V",
     "name": "Construction Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4014"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4019V",
     "name": "Credit & Security",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4019"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22536,63 +21270,49 @@
     "code": "LL4022V",
     "name": "Globalization And International Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4022"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4029V",
     "name": "International Commercial Arbitration",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4029"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4030V",
     "name": "International Commercial Litigation",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4030"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4031V",
     "name": "International Environmental Law & Policy",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4031"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4032V",
     "name": "International Investment Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4032"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4033V",
     "name": "International Legal Process",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4033"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4034V",
     "name": "International Regulation of Shipping",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4034"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22620,18 +21340,14 @@
     "code": "LL4049V",
     "name": "Principles Of Conflict Of Laws",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4049"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4050V",
     "name": "Public International Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4050"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22645,29 +21361,21 @@
     "code": "LL4056BV",
     "name": "Tax Planning And Policy",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4056B"
-    ],
-    "prerequisites": [
-      "LC2008"
-    ]
+    "preclusions": [],
+    "prerequisites": []
   },
   {
     "code": "LL4057V",
     "name": "Theoretical Foundations Of Criminal Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4057"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4059V",
     "name": "United Nations Law & Practice",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4059"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22675,7 +21383,6 @@
     "name": "World Trade Law",
     "creditCount": 8.0,
     "preclusions": [
-      "LL4199A",
       "LL4199B"
     ],
     "prerequisites": []
@@ -22684,9 +21391,7 @@
     "code": "LL4063V",
     "name": "Business & Finance For Lawyers",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4063"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22707,36 +21412,28 @@
     "code": "LL4070V",
     "name": "Foundations Of Intellectual Property Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4070"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4076V",
     "name": "IT Law I",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4076"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4077V",
     "name": "IT Law II",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4077"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4089V",
     "name": "Chinese Corporate & Securities Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4089"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22771,9 +21468,7 @@
     "code": "LL4099V",
     "name": "Maritime Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4099"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22781,9 +21476,7 @@
     "name": "Arbitration and Dispute Resolution in China",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4100V",
-      "LL5100V",
-      "LL6100V"
+      "LL5100V"
     ],
     "prerequisites": []
   },
@@ -22798,54 +21491,42 @@
     "code": "LL4104V",
     "name": "Jurisprudence",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4104"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4109V",
     "name": "International Law & Asia",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4109"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4133V",
     "name": "Human Rights in Asia",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4133"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4134V",
     "name": "Crossing Borders: Law, Migration & Citizenship",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4134"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4140V",
     "name": "Ocean Law & Policy in Asia",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4140"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4146V",
     "name": "Law & Society",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4146"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22853,9 +21534,7 @@
     "name": "Secured Transactions Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4019",
       "LL5019",
-      "LL6019",
       "LL4019V",
       "LL5019V",
       "LL6019V"
@@ -22867,9 +21546,7 @@
     "name": "International Investment Law and Arbitration",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4150",
-      "LL5150",
-      "LL6150"
+      "LL5150"
     ],
     "prerequisites": []
   },
@@ -22885,15 +21562,10 @@
     "name": "Climate Change Law and Policy in Asia",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4158",
       "LL5158",
-      "LL6158",
       "LL4221",
-      "LL5221",
       "LL6221",
-      "LL4221V",
-      "LL5221V",
-      "LL6221V"
+      "LL5221V"
     ],
     "prerequisites": []
   },
@@ -22901,18 +21573,14 @@
     "code": "LL4164V",
     "name": "International Projects Law & Practice",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4164"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4173V",
     "name": "Comparative Corporate Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4173"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22940,18 +21608,14 @@
     "code": "LL4195V",
     "name": "International Economic Law & Relations",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4195"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4197V",
     "name": "Comparative State and Religion in Southeast Asia",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4197"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PS1101E"
     ]
@@ -22960,9 +21624,7 @@
     "code": "LL4202V",
     "name": "ASEAN Economic Community Law and Policy",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4202"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -22997,27 +21659,21 @@
     "code": "LL4205V",
     "name": "Maritime Conflict of Laws",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4205"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4208V",
     "name": "Advanced Criminal Legal Process",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4208"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL4209V",
     "name": "Legal Argument & Narrative",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4209"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -23045,9 +21701,7 @@
     "code": "LL4233V",
     "name": "European Company Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4233"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -23055,9 +21709,7 @@
     "name": "International Contract Law: Principles and Practice",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4235",
-      "LL5235",
-      "LL6235"
+      "LL5235"
     ],
     "prerequisites": []
   },
@@ -23073,11 +21725,8 @@
     "name": "Financial Regulation and Central Banking",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4241",
       "LL5241",
-      "LL6241",
       "LL4241V",
-      "LL5241V",
       "LL6241V"
     ],
     "prerequisites": []
@@ -23087,9 +21736,7 @@
     "name": "Regulation and Geography",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4243",
-      "LL5243",
-      "LL6243"
+      "LL5243"
     ],
     "prerequisites": []
   },
@@ -23098,9 +21745,7 @@
     "name": "Criminal Practice",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4208",
       "LL5208",
-      "LL6208",
       "LL4208V",
       "LL5208V",
       "LL6208V"
@@ -23119,21 +21764,13 @@
     "name": "Personal Property Law",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4047",
       "LL5047",
-      "LL6047",
       "LL4047V",
-      "LL5047V",
       "LL6047V",
-      "LL4168",
       "LL5168",
-      "LL6168",
       "LL4168V",
-      "LL5168V",
       "LL6168V",
-      "LL4411",
-      "LL5411",
-      "LL6411"
+      "LL5411"
     ],
     "prerequisites": []
   },
@@ -23142,11 +21779,8 @@
     "name": "Alternative Investments",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4314",
       "LL5314",
-      "LL6314",
       "LL4314V",
-      "LL5314V",
       "LL6314"
     ],
     "prerequisites": []
@@ -23156,11 +21790,8 @@
     "name": "Alternative Investments",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4314",
       "LL5314",
-      "LL6314",
       "LL4314V",
-      "LL5314V",
       "LL6314"
     ],
     "prerequisites": []
@@ -23170,11 +21801,8 @@
     "name": "Intellectual Property Rights and Competition Policy",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4075V",
       "LL5075V",
-      "LL6075V",
       "LL4075",
-      "LL5075",
       "LL6075"
     ],
     "prerequisites": []
@@ -23184,11 +21812,8 @@
     "name": "Advanced Contract Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4187",
       "LL5187",
-      "LL6187",
       "LL4187V",
-      "LL5187V",
       "LL6187V"
     ],
     "prerequisites": []
@@ -23198,9 +21823,7 @@
     "name": "Medical Law and Ethics",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4400",
-      "LL5400",
-      "LL6400"
+      "LL5400"
     ],
     "prerequisites": []
   },
@@ -23210,15 +21833,11 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "LL4076",
       "LL5076",
-      "LL6076",
       "LL4076V",
       "LL5076V",
       "LL6076V",
-      "LL4077",
       "LL5077",
-      "LL6077",
       "LL4077V",
       "LL5077V",
       "LL6077V"
@@ -23229,9 +21848,7 @@
     "name": "International Dispute Settlement",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4285",
       "LL5285",
-      "LL6285",
       "LC5285"
     ],
     "prerequisites": []
@@ -23255,9 +21872,7 @@
     "name": "The Evolution of International Arbitration",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4289",
-      "LL5289",
-      "LL6289"
+      "LL5289"
     ],
     "prerequisites": []
   },
@@ -23266,9 +21881,7 @@
     "name": "Legal Research: Method & Design",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4290",
-      "LL5290",
-      "LL6290"
+      "LL5290"
     ],
     "prerequisites": []
   },
@@ -23277,9 +21890,7 @@
     "name": "State Responsibility: Theory and Practice",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4292",
-      "LL5292",
-      "LL6292"
+      "LL5292"
     ],
     "prerequisites": []
   },
@@ -23288,9 +21899,7 @@
     "name": "Conflict of Laws in Int\u2019l Commercial Arbitration",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4295V",
-      "LL5295V",
-      "LL6295V"
+      "LL5295V"
     ],
     "prerequisites": []
   },
@@ -23299,9 +21908,7 @@
     "name": "Advanced Issues in the Law & Practice of Int\u2019l Arbitration",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4299V",
-      "LL5299V",
-      "LL6299V"
+      "LL5299V"
     ],
     "prerequisites": []
   },
@@ -23310,9 +21917,7 @@
     "name": "Behavioural Economics, Law & Regulation",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4308",
-      "LL5308",
-      "LL6308"
+      "LL5308"
     ],
     "prerequisites": []
   },
@@ -23324,9 +21929,7 @@
       "LL4309",
       "LL5309",
       "LL6309",
-      "LL4309V",
-      "LL5309V",
-      "LL6309V"
+      "LL5309V"
     ],
     "prerequisites": []
   },
@@ -23335,9 +21938,7 @@
     "name": "Mediation/Conciliation of Inter- & Investor-State Disputes",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4313",
-      "LL5313",
-      "LL6313"
+      "LL5313"
     ],
     "prerequisites": []
   },
@@ -23346,15 +21947,10 @@
     "name": "Restitution of Unjust Enrichment",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4316",
       "LL5316",
-      "LL6316",
       "LL4051",
-      "LL5051",
       "LL6051",
-      "LL4051V",
-      "LL5051V",
-      "LL6051V"
+      "LL5051V"
     ],
     "prerequisites": []
   },
@@ -23363,9 +21959,7 @@
     "name": "International Arbitration in Asian Centres",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4317",
-      "LL5317",
-      "LL6317"
+      "LL5317"
     ],
     "prerequisites": []
   },
@@ -23374,9 +21968,7 @@
     "name": "Public Health Law and Regulation",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4318",
-      "LL5318",
-      "LL6318"
+      "LL5318"
     ],
     "prerequisites": []
   },
@@ -23385,9 +21977,7 @@
     "name": "Current Problems in International Law",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4319",
-      "LL5319",
-      "LL6319"
+      "LL5319"
     ],
     "prerequisites": []
   },
@@ -23396,9 +21986,7 @@
     "name": "International Space Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4320V",
-      "LL5320V",
-      "LL6320V"
+      "LL5320V"
     ],
     "prerequisites": []
   },
@@ -23407,9 +21995,7 @@
     "name": "Trade Finance Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4322V",
-      "LL5322V",
-      "LL6322V"
+      "LL5322V"
     ],
     "prerequisites": []
   },
@@ -23418,9 +22004,7 @@
     "name": "Law of Agency",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4323",
-      "LL5323",
-      "LL6323"
+      "LL5323"
     ],
     "prerequisites": []
   },
@@ -23429,16 +22013,12 @@
     "name": "The Int'l Litigation & Procedure of State Disputes",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4325V",
       "LL5325V",
-      "LL6325V",
       "LL4285V",
       "LL5285V",
       "LC5285V",
       "LL6285V",
-      "LL4285",
       "LL5285",
-      "LC5285",
       "LL6285"
     ],
     "prerequisites": []
@@ -23448,20 +22028,13 @@
     "name": "Mergers and Acquisitions: A Practitioner\u2019s Perspective",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4327",
       "LL5327",
-      "LL6327",
       "LL4074",
-      "LL5074",
       "LL6074",
-      "LL4074V",
       "LL5074V",
-      "LL6074V",
       "LL4223",
-      "LL5223",
       "LL6223",
       "LL4233V",
-      "LL5223V",
       "LL6223V"
     ],
     "prerequisites": []
@@ -23471,22 +22044,16 @@
     "name": "Advanced Practicum in International Arbitration",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4338",
-      "LL5338",
-      "LL6338"
+      "LL5338"
     ],
     "prerequisites": [
-      "LL4029",
       "LL5029",
-      "LC5262",
       "LL6029",
       "LL4029V",
       "LL5029V",
       "LC5262V",
       "LL6029V",
-      "LL4285",
       "LL5285",
-      "LC5285",
       "LL6285",
       "LL4285V",
       "LL5285V",
@@ -23499,9 +22066,7 @@
     "name": "Comparative Evidence in International Arbitration",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4339V",
-      "LL5339V",
-      "LL6339V"
+      "LL5339V"
     ],
     "prerequisites": []
   },
@@ -23510,14 +22075,10 @@
     "name": "International Refugee Law",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4340",
-      "LL5340",
-      "LL6340"
+      "LL5340"
     ],
     "prerequisites": [
-      "LL4050",
       "LL5050",
-      "LL6050",
       "LC5050",
       "LL5050V",
       "LL6050V",
@@ -23529,14 +22090,10 @@
     "name": "The Law and Politics of Forced Migration",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4341",
-      "LL5341",
-      "LL6341"
+      "LL5341"
     ],
     "prerequisites": [
-      "LL4050",
       "LL5050",
-      "LL6050",
       "LC5050",
       "LL5050V",
       "LL6050V",
@@ -23548,17 +22105,11 @@
     "name": "Taxation of Cross-Border Commercial Transactions",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4035",
       "LL5035",
-      "LL6035",
       "LC5035",
-      "LC5035A",
       "LC5035B",
-      "LL4035V",
       "LL5035V",
-      "LL6035V",
       "LL4342",
-      "LL5342",
       "LL6342"
     ],
     "prerequisites": []
@@ -23568,9 +22119,7 @@
     "name": "International Regulation of the Global Commons",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4343",
-      "LL5343",
-      "LL6343"
+      "LL5343"
     ],
     "prerequisites": []
   },
@@ -23579,9 +22128,7 @@
     "name": "Public and Private International Copyright Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4344V",
-      "LL5344V",
-      "LL6344V"
+      "LL5344V"
     ],
     "prerequisites": []
   },
@@ -23590,9 +22137,7 @@
     "name": "The Fulfilled Life and the Life of the Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4345V",
-      "LL5345V",
-      "LL6345V"
+      "LL5345V"
     ],
     "prerequisites": []
   },
@@ -23608,9 +22153,7 @@
     "name": "Art & Cultural Heritage Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4347V",
-      "LL5347V",
-      "LL6347V"
+      "LL5347V"
     ],
     "prerequisites": []
   },
@@ -23619,9 +22162,7 @@
     "name": "Monetary Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4348V",
-      "LL5348V",
-      "LL6348V"
+      "LL5348V"
     ],
     "prerequisites": []
   },
@@ -23630,9 +22171,7 @@
     "name": "Energy Arbitration",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4349",
-      "LL5349",
-      "LL6349"
+      "LL5349"
     ],
     "prerequisites": []
   },
@@ -23641,9 +22180,7 @@
     "name": "Privacy & Data Protection Law",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4350",
-      "LL5350",
-      "LL6350"
+      "LL5350"
     ],
     "prerequisites": []
   },
@@ -23652,22 +22189,16 @@
     "name": "Comparative Corporate Law in East Asia",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4351V",
-      "LL5351V",
-      "LL6351V"
+      "LL5351V"
     ],
-    "prerequisites": [
-      "LC2008"
-    ]
+    "prerequisites": []
   },
   {
     "code": "LL4352",
     "name": "China and International Economic Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4352V",
-      "LL5352V",
-      "LL6352V"
+      "LL5352V"
     ],
     "prerequisites": []
   },
@@ -23676,13 +22207,10 @@
     "name": "Character Evidence in the Common Law World",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4353V",
-      "LL5353V",
-      "LL6353V"
+      "LL5353V"
     ],
     "prerequisites": [
-      "LC3001A",
-      "LC3001B"
+      "LC3001A"
     ]
   },
   {
@@ -23690,9 +22218,7 @@
     "name": "Comparative Human Rights Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4354V",
-      "LL5354V",
-      "LL6353V"
+      "LL5354V"
     ],
     "prerequisites": []
   },
@@ -23701,9 +22227,7 @@
     "name": "International Law and Development",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4355V",
-      "LL5355V",
-      "LL6355V"
+      "LL5355V"
     ],
     "prerequisites": []
   },
@@ -23712,17 +22236,13 @@
     "name": "International Investment Law Clinic",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4356",
-      "LL5356",
-      "LL6356"
+      "LL5356"
     ],
     "prerequisites": [
       "LL4032V",
       "LL5032V",
       "LL6032V",
-      "LL4032",
-      "LL5032",
-      "LL6032"
+      "LL5032"
     ]
   },
   {
@@ -23730,9 +22250,7 @@
     "name": "Regulation & Political Economy",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4357",
-      "LL5357",
-      "LL6357"
+      "LL5357"
     ],
     "prerequisites": []
   },
@@ -23790,12 +22308,9 @@
     "name": "Corporate Insolvency Law",
     "creditCount": 8.0,
     "preclusions": [
-      "LLA4038",
       "LLA4039"
     ],
-    "prerequisites": [
-      "LLB2008"
-    ]
+    "prerequisites": []
   },
   {
     "code": "LL4403",
@@ -23809,13 +22324,9 @@
     "name": "Law Of Intellectual Property (A)",
     "creditCount": 8.0,
     "preclusions": [
-      "LL4405B",
       "LL5405B",
-      "LL6405B",
       "LL4070",
-      "LL5070",
-      "LC5070",
-      "LL6070"
+      "LC5070"
     ],
     "prerequisites": []
   },
@@ -23831,30 +22342,18 @@
     "name": "Securities and Capital Markets Regulation",
     "creditCount": 8.0,
     "preclusions": [
-      "LL4409",
       "LL5409",
-      "LLD5409",
       "LL6409",
-      "LL4238",
       "LL5238",
-      "LL6238",
       "LL4238V",
-      "LL5238V",
       "LL6238V",
-      "LL4182",
       "LL5182",
-      "LL6182",
       "LL4182V",
-      "LL5182V",
       "LL6182V",
-      "LL5055",
       "LL6055",
-      "LL4055V",
-      "LL5055V",
-      "LL6055V"
+      "LL5055V"
     ],
     "prerequisites": [
-      "LC2008",
       "LLB2008"
     ]
   },
@@ -23863,17 +22362,11 @@
     "name": "Civil Justice and Procedure",
     "creditCount": 8.0,
     "preclusions": [
-      "LL4011",
       "LL5011",
-      "LL6011",
       "LL4011V",
-      "LL5011V",
       "LL6011V",
-      "LL4281",
       "LL5281",
-      "LL6281",
       "LL4281V",
-      "LL5281V",
       "LL6281V"
     ],
     "prerequisites": []
@@ -23882,36 +22375,28 @@
     "code": "LL5002V",
     "name": "Admiralty Law & Practice",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5002"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5003V",
     "name": "China, India and International Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5003"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5004V",
     "name": "Aviation Law & Policy",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5004"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5006V",
     "name": "Banking Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5006"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -23925,9 +22410,7 @@
     "code": "LL5008BV",
     "name": "Charterparties",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5008B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -23941,27 +22424,21 @@
     "code": "LL5013V",
     "name": "Comparative Environmental Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5013"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5014V",
     "name": "Construction Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5014"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5019V",
     "name": "Credit & Security",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5019"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -23975,63 +22452,49 @@
     "code": "LL5022V",
     "name": "Globalization And International Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5022"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5029V",
     "name": "International Commercial Arbitration",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5029"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5030V",
     "name": "International Commercial Litigation",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5030"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5031V",
     "name": "International Environmental Law & Policy",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5031"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5032V",
     "name": "International Investment Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5032"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5033V",
     "name": "International Legal Process",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5033"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5034V",
     "name": "International Regulation of Shipping",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5034"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -24059,18 +22522,14 @@
     "code": "LL5049V",
     "name": "Principles Of Conflict Of Laws",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5049"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5050V",
     "name": "Public International Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5050"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -24085,26 +22544,20 @@
     "name": "Tax Planning And Policy",
     "creditCount": 5.0,
     "preclusions": [],
-    "prerequisites": [
-      "LC2008"
-    ]
+    "prerequisites": []
   },
   {
     "code": "LL5057V",
     "name": "Theoretical Foundations Of Criminal Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5057"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5059V",
     "name": "United Nations Law & Practice",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5059"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -24112,7 +22565,6 @@
     "name": "World Trade Law",
     "creditCount": 8.0,
     "preclusions": [
-      "LL4199A",
       "LL4199B"
     ],
     "prerequisites": []
@@ -24121,9 +22573,7 @@
     "code": "LL5063V",
     "name": "Business & Finance For Lawyers",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5063"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -24144,36 +22594,28 @@
     "code": "LL5070V",
     "name": "Foundations Of Intellectual Property Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5070"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5076V",
     "name": "IT Law I",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5076"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5077V",
     "name": "IT Law II",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5077"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5089V",
     "name": "Chinese Corporate & Securities Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4089"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -24208,9 +22650,7 @@
     "code": "LL5099V",
     "name": "Maritime Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5099"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -24218,9 +22658,7 @@
     "name": "Arbitration and Dispute Resolution in China",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4100V",
-      "LL5100V",
-      "LL6100V"
+      "LL5100V"
     ],
     "prerequisites": []
   },
@@ -24235,45 +22673,35 @@
     "code": "LL5104V",
     "name": "Jurisprudence",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5104"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5109V",
     "name": "International Law & Asia",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5109"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5133V",
     "name": "Human Rights in Asia",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5133"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5134V",
     "name": "Crossing Borders: Law, Migration & Citizenship",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5134"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5140V",
     "name": "Ocean Law & Policy in Asia",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5140"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -24281,9 +22709,7 @@
     "name": "Secured Transactions Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4019",
       "LL5019",
-      "LL6019",
       "LL4019V",
       "LL5019V",
       "LL6019V"
@@ -24295,9 +22721,7 @@
     "name": "International Investment Law and Arbitration",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4150",
-      "LL5150",
-      "LL6150"
+      "LL5150"
     ],
     "prerequisites": []
   },
@@ -24313,15 +22737,10 @@
     "name": "Climate Change Law and Policy in Asia",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4158",
       "LL5158",
-      "LL6158",
       "LL4221",
-      "LL5221",
       "LL6221",
-      "LL4221V",
-      "LL5221V",
-      "LL6221V"
+      "LL5221V"
     ],
     "prerequisites": []
   },
@@ -24329,18 +22748,14 @@
     "code": "LL5164V",
     "name": "International Projects Law & Practice",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5164"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5173V",
     "name": "Comparative Corporate Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5173"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -24363,7 +22778,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "LC1005",
       "LC2007"
     ]
   },
@@ -24371,27 +22785,21 @@
     "code": "LL5195V",
     "name": "International Economic Law & Relations",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5195"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5197V",
     "name": "Comparative State and Religion in Southeast Asia",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5197"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5202V",
     "name": "ASEAN Economic Community Law and Policy",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5202"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -24405,27 +22813,21 @@
     "code": "LL5205V",
     "name": "Maritime Conflict of Laws",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5205"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5208V",
     "name": "Advanced Criminal Legal Process",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5208"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL5209V",
     "name": "Legal Argument & Narrative",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5209"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -24453,9 +22855,7 @@
     "code": "LL5233V",
     "name": "European Company Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL5233"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -24463,9 +22863,7 @@
     "name": "International Contract Law: Principles and Practice",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4235",
-      "LL5235",
-      "LL6235"
+      "LL5235"
     ],
     "prerequisites": []
   },
@@ -24481,9 +22879,7 @@
     "name": "Financial Regulation and Central Banking",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4006",
       "LL5006",
-      "LL6006",
       "LL4006V",
       "LL5006V",
       "LL6006V",
@@ -24498,11 +22894,8 @@
     "name": "Financial Regulation and Central Banking",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4241",
       "LL5241",
-      "LL6241",
       "LL4241V",
-      "LL5241V",
       "LL6241V"
     ],
     "prerequisites": []
@@ -24512,9 +22905,7 @@
     "name": "Regulation and Geography",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4243",
-      "LL5243",
-      "LL6243"
+      "LL5243"
     ],
     "prerequisites": []
   },
@@ -24523,9 +22914,7 @@
     "name": "Criminal Practice",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4208",
       "LL5208",
-      "LL6208",
       "LL4208V",
       "LL5208V",
       "LL6208V"
@@ -24544,21 +22933,13 @@
     "name": "Personal Property Law",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4047",
       "LL5047",
-      "LL6047",
       "LL4047V",
-      "LL5047V",
       "LL6047V",
-      "LL4168",
       "LL5168",
-      "LL6168",
       "LL4168V",
-      "LL5168V",
       "LL6168V",
-      "LL4411",
-      "LL5411",
-      "LL6411"
+      "LL5411"
     ],
     "prerequisites": []
   },
@@ -24567,11 +22948,8 @@
     "name": "Alternative Investments",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4314",
       "LL5314",
-      "LL6314",
       "LL4314V",
-      "LL5314V",
       "LL6314"
     ],
     "prerequisites": []
@@ -24581,11 +22959,8 @@
     "name": "Alternative Investments",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4314",
       "LL5314",
-      "LL6314",
       "LL4314V",
-      "LL5314V",
       "LL6314"
     ],
     "prerequisites": []
@@ -24595,11 +22970,8 @@
     "name": "Intellectual Property Rights and Competition Policy",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4075V",
       "LL5075V",
-      "LL6075V",
       "LL4075",
-      "LL5075",
       "LL6075"
     ],
     "prerequisites": []
@@ -24609,11 +22981,8 @@
     "name": "Advanced Contract Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4187",
       "LL5187",
-      "LL6187",
       "LL4187V",
-      "LL5187V",
       "LL6187V"
     ],
     "prerequisites": []
@@ -24623,9 +22992,7 @@
     "name": "Medical Law and Ethics",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4400",
-      "LL5400",
-      "LL6400"
+      "LL5400"
     ],
     "prerequisites": []
   },
@@ -24635,15 +23002,11 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "LL4076",
       "LL5076",
-      "LL6076",
       "LL4076V",
       "LL5076V",
       "LL6076V",
-      "LL4077",
       "LL5077",
-      "LL6077",
       "LL4077V",
       "LL5077V",
       "LL6077V"
@@ -24654,9 +23017,7 @@
     "name": "International Dispute Settlement",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4285",
       "LL5285",
-      "LL6285",
       "LC5285"
     ],
     "prerequisites": []
@@ -24680,9 +23041,7 @@
     "name": "The Evolution of International Arbitration",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4289",
-      "LL5289",
-      "LL6289"
+      "LL5289"
     ],
     "prerequisites": []
   },
@@ -24691,9 +23050,7 @@
     "name": "State Responsibility: Theory and Practice",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4292",
-      "LL5292",
-      "LL6292"
+      "LL5292"
     ],
     "prerequisites": []
   },
@@ -24722,9 +23079,7 @@
     "name": "Conflict of Laws in Int\u2019l Commercial Arbitration",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4295V",
-      "LL5295V",
-      "LL6295V"
+      "LL5295V"
     ],
     "prerequisites": []
   },
@@ -24733,9 +23088,7 @@
     "name": "Advanced Issues in the Law & Practice of Int\u2019l Arbitration",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4299V",
-      "LL5299V",
-      "LL6299V"
+      "LL5299V"
     ],
     "prerequisites": []
   },
@@ -24744,9 +23097,7 @@
     "name": "Behavioural Economics, Law & Regulation",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4308",
-      "LL5308",
-      "LL6308"
+      "LL5308"
     ],
     "prerequisites": []
   },
@@ -24758,9 +23109,7 @@
       "LL4309",
       "LL5309",
       "LL6309",
-      "LL4309V",
-      "LL5309V",
-      "LL6309V"
+      "LL5309V"
     ],
     "prerequisites": []
   },
@@ -24769,9 +23118,7 @@
     "name": "Mediation/Conciliation of Inter- & Investor-State Disputes",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4313",
-      "LL5313",
-      "LL6313"
+      "LL5313"
     ],
     "prerequisites": []
   },
@@ -24798,15 +23145,10 @@
     "name": "Restitution of Unjust Enrichment",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4316",
       "LL5316",
-      "LL6316",
       "LL4051",
-      "LL5051",
       "LL6051",
-      "LL4051V",
-      "LL5051V",
-      "LL6051V"
+      "LL5051V"
     ],
     "prerequisites": []
   },
@@ -24815,9 +23157,7 @@
     "name": "International Arbitration in Asian Centres",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4317",
-      "LL5317",
-      "LL6317"
+      "LL5317"
     ],
     "prerequisites": []
   },
@@ -24826,9 +23166,7 @@
     "name": "Public Health Law and Regulation",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4318",
-      "LL5318",
-      "LL6318"
+      "LL5318"
     ],
     "prerequisites": []
   },
@@ -24837,9 +23175,7 @@
     "name": "Current Problems in International Law",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4319",
-      "LL5319",
-      "LL6319"
+      "LL5319"
     ],
     "prerequisites": []
   },
@@ -24848,9 +23184,7 @@
     "name": "International Space Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4320V",
-      "LL5320V",
-      "LL6320V"
+      "LL5320V"
     ],
     "prerequisites": []
   },
@@ -24859,9 +23193,7 @@
     "name": "Trade Finance Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4322V",
-      "LL5322V",
-      "LL6322V"
+      "LL5322V"
     ],
     "prerequisites": []
   },
@@ -24870,9 +23202,7 @@
     "name": "Law of Agency",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4323",
-      "LL5323",
-      "LL6323"
+      "LL5323"
     ],
     "prerequisites": []
   },
@@ -24881,16 +23211,12 @@
     "name": "The Int'l Litigation & Procedure of State Disputes",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4325V",
       "LL5325V",
-      "LL6325V",
       "LL4285V",
       "LL5285V",
       "LC5285V",
       "LL6285V",
-      "LL4285",
       "LL5285",
-      "LC5285",
       "LL6285"
     ],
     "prerequisites": []
@@ -24900,20 +23226,13 @@
     "name": "Mergers and Acquisitions: A Practitioner\u2019s Perspective",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4327",
       "LL5327",
-      "LL6327",
       "LL4074",
-      "LL5074",
       "LL6074",
-      "LL4074V",
       "LL5074V",
-      "LL6074V",
       "LL4223",
-      "LL5223",
       "LL6223",
       "LL4233V",
-      "LL5223V",
       "LL6223V"
     ],
     "prerequisites": []
@@ -24923,22 +23242,16 @@
     "name": "Advanced Practicum in International Arbitration",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4338",
-      "LL5338",
-      "LL6338"
+      "LL5338"
     ],
     "prerequisites": [
-      "LL4029",
       "LL5029",
-      "LC5262",
       "LL6029",
       "LL4029V",
       "LL5029V",
       "LC5262V",
       "LL6029V",
-      "LL4285",
       "LL5285",
-      "LC5285",
       "LL6285",
       "LL4285V",
       "LL5285V",
@@ -24951,9 +23264,7 @@
     "name": "Comparative Evidence in International Arbitration",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4339V",
-      "LL5339V",
-      "LL6339V"
+      "LL5339V"
     ],
     "prerequisites": []
   },
@@ -24962,14 +23273,10 @@
     "name": "International Refugee Law",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4340",
-      "LL5340",
-      "LL6340"
+      "LL5340"
     ],
     "prerequisites": [
-      "LL4050",
       "LL5050",
-      "LL6050",
       "LC5050",
       "LL5050V",
       "LL6050V",
@@ -24981,14 +23288,10 @@
     "name": "The Law and Politics of Forced Migration",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4341",
-      "LL5341",
-      "LL6341"
+      "LL5341"
     ],
     "prerequisites": [
-      "LL4050",
       "LL5050",
-      "LL6050",
       "LC5050",
       "LL5050V",
       "LL6050V",
@@ -25000,17 +23303,11 @@
     "name": "Taxation of Cross-Border Commercial Transactions",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4035",
       "LL5035",
-      "LL6035",
       "LC5035",
-      "LC5035A",
       "LC5035B",
-      "LL4035V",
       "LL5035V",
-      "LL6035V",
       "LL4342",
-      "LL5342",
       "LL6342"
     ],
     "prerequisites": []
@@ -25020,9 +23317,7 @@
     "name": "International Regulation of the Global Commons",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4343",
-      "LL5343",
-      "LL6343"
+      "LL5343"
     ],
     "prerequisites": []
   },
@@ -25031,9 +23326,7 @@
     "name": "Public and Private International Copyright Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4344V",
-      "LL5344V",
-      "LL6344V"
+      "LL5344V"
     ],
     "prerequisites": []
   },
@@ -25042,9 +23335,7 @@
     "name": "The Fulfilled Life and the Life of the Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4345V",
-      "LL5345V",
-      "LL6345V"
+      "LL5345V"
     ],
     "prerequisites": []
   },
@@ -25060,9 +23351,7 @@
     "name": "Art & Cultural Heritage Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4347V",
-      "LL5347V",
-      "LL6347V"
+      "LL5347V"
     ],
     "prerequisites": []
   },
@@ -25071,9 +23360,7 @@
     "name": "Monetary Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4348V",
-      "LL5348V",
-      "LL6348V"
+      "LL5348V"
     ],
     "prerequisites": []
   },
@@ -25082,9 +23369,7 @@
     "name": "Energy Arbitration",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4349",
-      "LL5349",
-      "LL6349"
+      "LL5349"
     ],
     "prerequisites": []
   },
@@ -25093,9 +23378,7 @@
     "name": "Privacy & Data Protection Law",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4350",
-      "LL5350",
-      "LL6350"
+      "LL5350"
     ],
     "prerequisites": []
   },
@@ -25104,22 +23387,16 @@
     "name": "Comparative Corporate Law in East Asia",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4351V",
-      "LL5351V",
-      "LL6351V"
+      "LL5351V"
     ],
-    "prerequisites": [
-      "LC2008"
-    ]
+    "prerequisites": []
   },
   {
     "code": "LL5352",
     "name": "China and International Economic Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4352V",
-      "LL5352V",
-      "LL6352V"
+      "LL5352V"
     ],
     "prerequisites": []
   },
@@ -25128,13 +23405,10 @@
     "name": "Character Evidence in the Common Law World",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4353V",
-      "LL5353V",
-      "LL6353V"
+      "LL5353V"
     ],
     "prerequisites": [
-      "LC3001A",
-      "LC3001B"
+      "LC3001A"
     ]
   },
   {
@@ -25142,9 +23416,7 @@
     "name": "Comparative Human Rights Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4354V",
-      "LL5354V",
-      "LL6353V"
+      "LL5354V"
     ],
     "prerequisites": []
   },
@@ -25153,9 +23425,7 @@
     "name": "International Law and Development",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4355V",
-      "LL5355V",
-      "LL6355V"
+      "LL5355V"
     ],
     "prerequisites": []
   },
@@ -25164,17 +23434,13 @@
     "name": "International Investment Law Clinic",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4356",
-      "LL5356",
-      "LL6356"
+      "LL5356"
     ],
     "prerequisites": [
       "LL4032V",
       "LL5032V",
       "LL6032V",
-      "LL4032",
-      "LL5032",
-      "LL6032"
+      "LL5032"
     ]
   },
   {
@@ -25182,9 +23448,7 @@
     "name": "Regulation & Political Economy",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4357",
-      "LL5357",
-      "LL6357"
+      "LL5357"
     ],
     "prerequisites": []
   },
@@ -25284,30 +23548,18 @@
     "name": "Securities and Capital Markets Regulation",
     "creditCount": 8.0,
     "preclusions": [
-      "LL4409",
       "LL5409",
-      "LLD5409",
       "LL6409",
-      "LL4238",
       "LL5238",
-      "LL6238",
       "LL4238V",
-      "LL5238V",
       "LL6238V",
-      "LL4182",
       "LL5182",
-      "LL6182",
       "LL4182V",
-      "LL5182V",
       "LL6182V",
-      "LL5055",
       "LL6055",
-      "LL4055V",
-      "LL5055V",
-      "LL6055V"
+      "LL5055V"
     ],
     "prerequisites": [
-      "LC2008",
       "LLB2008"
     ]
   },
@@ -25316,17 +23568,11 @@
     "name": "Civil Justice and Procedure",
     "creditCount": 8.0,
     "preclusions": [
-      "LL4011",
       "LL5011",
-      "LL6011",
       "LL4011V",
-      "LL5011V",
       "LL6011V",
-      "LL4281",
       "LL5281",
-      "LL6281",
       "LL4281V",
-      "LL5281V",
       "LL6281V"
     ],
     "prerequisites": []
@@ -25335,36 +23581,28 @@
     "code": "LL6002V",
     "name": "Admiralty Law & Practice",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6002"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6003V",
     "name": "China, India and International Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6003"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6004V",
     "name": "Aviation Law & Policy",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6004"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6006V",
     "name": "Banking Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6006"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -25378,9 +23616,7 @@
     "code": "LL6008BV",
     "name": "Charterparties",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6008B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -25394,27 +23630,21 @@
     "code": "LL6013V",
     "name": "Comparative Environmental Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6013"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6014V",
     "name": "Construction Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6014"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6019V",
     "name": "Credit & Security",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6019"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -25428,63 +23658,49 @@
     "code": "LL6022V",
     "name": "Globalization And International Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6022"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6029V",
     "name": "International Commercial Arbitration",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6029"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6030V",
     "name": "International Commercial Litigation",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6030"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6031V",
     "name": "International Environmental Law & Policy",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6031"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6032V",
     "name": "International Investment Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6032"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6033V",
     "name": "International Legal Process",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6033"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6034V",
     "name": "International Regulation of Shipping",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6034"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -25512,18 +23728,14 @@
     "code": "LL6049V",
     "name": "Principles Of Conflict Of Laws",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6049"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6050V",
     "name": "Public International Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6050"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -25538,26 +23750,20 @@
     "name": "Tax Planning And Policy",
     "creditCount": 5.0,
     "preclusions": [],
-    "prerequisites": [
-      "LC2008"
-    ]
+    "prerequisites": []
   },
   {
     "code": "LL6057V",
     "name": "Theoretical Foundations Of Criminal Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6057"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6059V",
     "name": "United Nations Law & Practice",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6059"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -25565,7 +23771,6 @@
     "name": "World Trade Law",
     "creditCount": 8.0,
     "preclusions": [
-      "LL4199A",
       "LL4199B"
     ],
     "prerequisites": []
@@ -25574,9 +23779,7 @@
     "code": "LL6063V",
     "name": "Business & Finance For Lawyers",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6063"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -25597,36 +23800,28 @@
     "code": "LL6070V",
     "name": "Foundations Of Intellectual Property Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6070"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6076V",
     "name": "IT Law I",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6076"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6077V",
     "name": "IT Law II",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6077"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6089V",
     "name": "Chinese Corporate & Securities Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL4089"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -25661,9 +23856,7 @@
     "code": "LL6099V",
     "name": "Maritime Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6099"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -25671,9 +23864,7 @@
     "name": "Arbitration and Dispute Resolution in China",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4100V",
-      "LL5100V",
-      "LL6100V"
+      "LL5100V"
     ],
     "prerequisites": []
   },
@@ -25688,45 +23879,35 @@
     "code": "LL6104V",
     "name": "Jurisprudence",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6104"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6109V",
     "name": "International Law & Asia",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6109"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6133V",
     "name": "Human Rights in Asia",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6133"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6134V",
     "name": "Crossing Borders: Law, Migration & Citizenship",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6134"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6140V",
     "name": "Ocean Law & Policy in Asia",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6140"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -25734,9 +23915,7 @@
     "name": "Secured Transactions Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4019",
       "LL5019",
-      "LL6019",
       "LL4019V",
       "LL5019V",
       "LL6019V"
@@ -25748,9 +23927,7 @@
     "name": "International Investment Law and Arbitration",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4150",
-      "LL5150",
-      "LL6150"
+      "LL5150"
     ],
     "prerequisites": []
   },
@@ -25766,15 +23943,10 @@
     "name": "Climate Change Law and Policy in Asia",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4158",
       "LL5158",
-      "LL6158",
       "LL4221",
-      "LL5221",
       "LL6221",
-      "LL4221V",
-      "LL5221V",
-      "LL6221V"
+      "LL5221V"
     ],
     "prerequisites": []
   },
@@ -25782,18 +23954,14 @@
     "code": "LL6164V",
     "name": "International Projects Law & Practice",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6164"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6173V",
     "name": "Comparative Corporate Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6173"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -25816,7 +23984,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "LC1005",
       "LC2007"
     ]
   },
@@ -25824,27 +23991,21 @@
     "code": "LL6195V",
     "name": "International Economic Law & Relations",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6195"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6197V",
     "name": "Comparative State and Religion in Southeast Asia",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6197"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6202V",
     "name": "ASEAN Economic Community Law and Policy",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6202"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -25858,27 +24019,21 @@
     "code": "LL6205V",
     "name": "Maritime Conflict of Laws",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6205"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6208V",
     "name": "Advanced Criminal Legal Process",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6208"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LL6209V",
     "name": "Legal Argument & Narrative",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6209"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -25906,9 +24061,7 @@
     "code": "LL6233V",
     "name": "European Company Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LL6233"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -25916,9 +24069,7 @@
     "name": "International Contract Law: Principles and Practice",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4235",
-      "LL5235",
-      "LL6235"
+      "LL5235"
     ],
     "prerequisites": []
   },
@@ -25934,11 +24085,8 @@
     "name": "Financial Regulation and Central Banking",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4241",
       "LL5241",
-      "LL6241",
       "LL4241V",
-      "LL5241V",
       "LL6241V"
     ],
     "prerequisites": []
@@ -25948,9 +24096,7 @@
     "name": "Regulation and Geography",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4243",
-      "LL5243",
-      "LL6243"
+      "LL5243"
     ],
     "prerequisites": []
   },
@@ -25959,9 +24105,7 @@
     "name": "Criminal Practice",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4208",
       "LL5208",
-      "LL6208",
       "LL4208V",
       "LL5208V",
       "LL6208V"
@@ -25980,21 +24124,13 @@
     "name": "Personal Property Law",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4047",
       "LL5047",
-      "LL6047",
       "LL4047V",
-      "LL5047V",
       "LL6047V",
-      "LL4168",
       "LL5168",
-      "LL6168",
       "LL4168V",
-      "LL5168V",
       "LL6168V",
-      "LL4411",
-      "LL5411",
-      "LL6411"
+      "LL5411"
     ],
     "prerequisites": []
   },
@@ -26003,11 +24139,8 @@
     "name": "Alternative Investments",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4314",
       "LL5314",
-      "LL6314",
       "LL4314V",
-      "LL5314V",
       "LL6314"
     ],
     "prerequisites": []
@@ -26017,11 +24150,8 @@
     "name": "Alternative Investments",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4314",
       "LL5314",
-      "LL6314",
       "LL4314V",
-      "LL5314V",
       "LL6314"
     ],
     "prerequisites": []
@@ -26031,11 +24161,8 @@
     "name": "Intellectual Property Rights and Competition Policy",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4075V",
       "LL5075V",
-      "LL6075V",
       "LL4075",
-      "LL5075",
       "LL6075"
     ],
     "prerequisites": []
@@ -26045,11 +24172,8 @@
     "name": "Advanced Contract Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4187",
       "LL5187",
-      "LL6187",
       "LL4187V",
-      "LL5187V",
       "LL6187V"
     ],
     "prerequisites": []
@@ -26059,9 +24183,7 @@
     "name": "Medical Law and Ethics",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4400",
-      "LL5400",
-      "LL6400"
+      "LL5400"
     ],
     "prerequisites": []
   },
@@ -26071,15 +24193,11 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "LL4076",
       "LL5076",
-      "LL6076",
       "LL4076V",
       "LL5076V",
       "LL6076V",
-      "LL4077",
       "LL5077",
-      "LL6077",
       "LL4077V",
       "LL5077V",
       "LL6077V"
@@ -26090,9 +24208,7 @@
     "name": "International Dispute Settlement",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4285",
       "LL5285",
-      "LL6285",
       "LC5285"
     ],
     "prerequisites": []
@@ -26116,9 +24232,7 @@
     "name": "The Evolution of International Arbitration",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4289",
-      "LL5289",
-      "LL6289"
+      "LL5289"
     ],
     "prerequisites": []
   },
@@ -26127,9 +24241,7 @@
     "name": "State Responsibility: Theory and Practice",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4292",
-      "LL5292",
-      "LL6292"
+      "LL5292"
     ],
     "prerequisites": []
   },
@@ -26138,9 +24250,7 @@
     "name": "Conflict of Laws in Int\u2019l Commercial Arbitration",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4295V",
-      "LL5295V",
-      "LL6295V"
+      "LL5295V"
     ],
     "prerequisites": []
   },
@@ -26149,9 +24259,7 @@
     "name": "Advanced Issues in the Law & Practice of Int\u2019l Arbitration",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4299V",
-      "LL5299V",
-      "LL6299V"
+      "LL5299V"
     ],
     "prerequisites": []
   },
@@ -26160,9 +24268,7 @@
     "name": "Behavioural Economics, Law & Regulation",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4308",
-      "LL5308",
-      "LL6308"
+      "LL5308"
     ],
     "prerequisites": []
   },
@@ -26174,9 +24280,7 @@
       "LL4309",
       "LL5309",
       "LL6309",
-      "LL4309V",
-      "LL5309V",
-      "LL6309V"
+      "LL5309V"
     ],
     "prerequisites": []
   },
@@ -26185,9 +24289,7 @@
     "name": "Mediation/Conciliation of Inter- & Investor-State Disputes",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4313",
-      "LL5313",
-      "LL6313"
+      "LL5313"
     ],
     "prerequisites": []
   },
@@ -26196,15 +24298,10 @@
     "name": "Restitution of Unjust Enrichment",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4316",
       "LL5316",
-      "LL6316",
       "LL4051",
-      "LL5051",
       "LL6051",
-      "LL4051V",
-      "LL5051V",
-      "LL6051V"
+      "LL5051V"
     ],
     "prerequisites": []
   },
@@ -26213,9 +24310,7 @@
     "name": "International Arbitration in Asian Centres",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4317",
-      "LL5317",
-      "LL6317"
+      "LL5317"
     ],
     "prerequisites": []
   },
@@ -26224,9 +24319,7 @@
     "name": "Public Health Law and Regulation",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4318",
-      "LL5318",
-      "LL6318"
+      "LL5318"
     ],
     "prerequisites": []
   },
@@ -26235,9 +24328,7 @@
     "name": "Current Problems in International Law",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4319",
-      "LL5319",
-      "LL6319"
+      "LL5319"
     ],
     "prerequisites": []
   },
@@ -26246,9 +24337,7 @@
     "name": "International Space Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4320V",
-      "LL5320V",
-      "LL6320V"
+      "LL5320V"
     ],
     "prerequisites": []
   },
@@ -26257,9 +24346,7 @@
     "name": "Trade Finance Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4322V",
-      "LL5322V",
-      "LL6322V"
+      "LL5322V"
     ],
     "prerequisites": []
   },
@@ -26268,9 +24355,7 @@
     "name": "Law of Agency",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4323",
-      "LL5323",
-      "LL6323"
+      "LL5323"
     ],
     "prerequisites": []
   },
@@ -26279,16 +24364,12 @@
     "name": "The Int'l Litigation & Procedure of State Disputes",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4325V",
       "LL5325V",
-      "LL6325V",
       "LL4285V",
       "LL5285V",
       "LC5285V",
       "LL6285V",
-      "LL4285",
       "LL5285",
-      "LC5285",
       "LL6285"
     ],
     "prerequisites": []
@@ -26298,20 +24379,13 @@
     "name": "Mergers and Acquisitions: A Practitioner\u2019s Perspective",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4327",
       "LL5327",
-      "LL6327",
       "LL4074",
-      "LL5074",
       "LL6074",
-      "LL4074V",
       "LL5074V",
-      "LL6074V",
       "LL4223",
-      "LL5223",
       "LL6223",
       "LL4233V",
-      "LL5223V",
       "LL6223V"
     ],
     "prerequisites": []
@@ -26321,22 +24395,16 @@
     "name": "Advanced Practicum in International Arbitration",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4338",
-      "LL5338",
-      "LL6338"
+      "LL5338"
     ],
     "prerequisites": [
-      "LL4029",
       "LL5029",
-      "LC5262",
       "LL6029",
       "LL4029V",
       "LL5029V",
       "LC5262V",
       "LL6029V",
-      "LL4285",
       "LL5285",
-      "LC5285",
       "LL6285",
       "LL4285V",
       "LL5285V",
@@ -26349,9 +24417,7 @@
     "name": "Comparative Evidence in International Arbitration",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4339V",
-      "LL5339V",
-      "LL6339V"
+      "LL5339V"
     ],
     "prerequisites": []
   },
@@ -26360,14 +24426,10 @@
     "name": "International Refugee Law",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4340",
-      "LL5340",
-      "LL6340"
+      "LL5340"
     ],
     "prerequisites": [
-      "LL4050",
       "LL5050",
-      "LL6050",
       "LC5050",
       "LL5050V",
       "LL6050V",
@@ -26379,14 +24441,10 @@
     "name": "The Law and Politics of Forced Migration",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4341",
-      "LL5341",
-      "LL6341"
+      "LL5341"
     ],
     "prerequisites": [
-      "LL4050",
       "LL5050",
-      "LL6050",
       "LC5050",
       "LL5050V",
       "LL6050V",
@@ -26398,17 +24456,11 @@
     "name": "Taxation of Cross-Border Commercial Transactions",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4035",
       "LL5035",
-      "LL6035",
       "LC5035",
-      "LC5035A",
       "LC5035B",
-      "LL4035V",
       "LL5035V",
-      "LL6035V",
       "LL4342",
-      "LL5342",
       "LL6342"
     ],
     "prerequisites": []
@@ -26418,9 +24470,7 @@
     "name": "International Regulation of the Global Commons",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4343",
-      "LL5343",
-      "LL6343"
+      "LL5343"
     ],
     "prerequisites": []
   },
@@ -26429,9 +24479,7 @@
     "name": "Public and Private International Copyright Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4344V",
-      "LL5344V",
-      "LL6344V"
+      "LL5344V"
     ],
     "prerequisites": []
   },
@@ -26440,9 +24488,7 @@
     "name": "The Fulfilled Life and the Life of the Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4345V",
-      "LL5345V",
-      "LL6345V"
+      "LL5345V"
     ],
     "prerequisites": []
   },
@@ -26458,9 +24504,7 @@
     "name": "Art & Cultural Heritage Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4347V",
-      "LL5347V",
-      "LL6347V"
+      "LL5347V"
     ],
     "prerequisites": []
   },
@@ -26469,9 +24513,7 @@
     "name": "Monetary Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4348V",
-      "LL5348V",
-      "LL6348V"
+      "LL5348V"
     ],
     "prerequisites": []
   },
@@ -26480,9 +24522,7 @@
     "name": "Energy Arbitration",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4349",
-      "LL5349",
-      "LL6349"
+      "LL5349"
     ],
     "prerequisites": []
   },
@@ -26491,9 +24531,7 @@
     "name": "Privacy & Data Protection Law",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4350",
-      "LL5350",
-      "LL6350"
+      "LL5350"
     ],
     "prerequisites": []
   },
@@ -26502,22 +24540,16 @@
     "name": "Comparative Corporate Law in East Asia",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4351V",
-      "LL5351V",
-      "LL6351V"
+      "LL5351V"
     ],
-    "prerequisites": [
-      "LC2008"
-    ]
+    "prerequisites": []
   },
   {
     "code": "LL6352",
     "name": "China and International Economic Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4352V",
-      "LL5352V",
-      "LL6352V"
+      "LL5352V"
     ],
     "prerequisites": []
   },
@@ -26526,13 +24558,10 @@
     "name": "Character Evidence in the Common Law World",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4353V",
-      "LL5353V",
-      "LL6353V"
+      "LL5353V"
     ],
     "prerequisites": [
-      "LC3001A",
-      "LC3001B"
+      "LC3001A"
     ]
   },
   {
@@ -26540,9 +24569,7 @@
     "name": "Comparative Human Rights Law",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4354V",
-      "LL5354V",
-      "LL6353V"
+      "LL5354V"
     ],
     "prerequisites": []
   },
@@ -26551,9 +24578,7 @@
     "name": "International Law and Development",
     "creditCount": 4.0,
     "preclusions": [
-      "LL4355V",
-      "LL5355V",
-      "LL6355V"
+      "LL5355V"
     ],
     "prerequisites": []
   },
@@ -26562,17 +24587,13 @@
     "name": "International Investment Law Clinic\n(35 characters",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4356",
-      "LL5356",
-      "LL6356"
+      "LL5356"
     ],
     "prerequisites": [
       "LL4032V",
       "LL5032V",
       "LL6032V",
-      "LL4032",
-      "LL5032",
-      "LL6032"
+      "LL5032"
     ]
   },
   {
@@ -26580,9 +24601,7 @@
     "name": "Regulation & Political Economy",
     "creditCount": 5.0,
     "preclusions": [
-      "LL4357",
-      "LL5357",
-      "LL6357"
+      "LL5357"
     ],
     "prerequisites": []
   },
@@ -26661,30 +24680,18 @@
     "name": "Securities and Capital Markets Regulation",
     "creditCount": 8.0,
     "preclusions": [
-      "LL4409",
       "LL5409",
-      "LLD5409",
       "LL6409",
-      "LL4238",
       "LL5238",
-      "LL6238",
       "LL4238V",
-      "LL5238V",
       "LL6238V",
-      "LL4182",
       "LL5182",
-      "LL6182",
       "LL4182V",
-      "LL5182V",
       "LL6182V",
-      "LL5055",
       "LL6055",
-      "LL4055V",
-      "LL5055V",
-      "LL6055V"
+      "LL5055V"
     ],
     "prerequisites": [
-      "LC2008",
       "LLB2008"
     ]
   },
@@ -26693,17 +24700,11 @@
     "name": "Civil Justice and Procedure",
     "creditCount": 8.0,
     "preclusions": [
-      "LL4011",
       "LL5011",
-      "LL6011",
       "LL4011V",
-      "LL5011V",
       "LL6011V",
-      "LL4281",
       "LL5281",
-      "LL6281",
       "LL4281V",
-      "LL5281V",
       "LL6281V"
     ],
     "prerequisites": []
@@ -26712,18 +24713,14 @@
     "code": "LLD5002V",
     "name": "Admiralty Law & Practice",
     "creditCount": 5.0,
-    "preclusions": [
-      "LLD5002"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LLD5034V",
     "name": "International Regulation of Shipping",
     "creditCount": 5.0,
-    "preclusions": [
-      "LLD5034"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -26744,27 +24741,21 @@
     "code": "LLD5099V",
     "name": "Maritime Law",
     "creditCount": 5.0,
-    "preclusions": [
-      "LLD5099"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LLD5140V",
     "name": "Ocean Law & Policy in Asia",
     "creditCount": 5.0,
-    "preclusions": [
-      "LLD5140"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LLD5205V",
     "name": "Maritime Conflict of Laws",
     "creditCount": 5.0,
-    "preclusions": [
-      "LLD5205"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -26801,8 +24792,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "LSM1301",
-      "LSM1301X"
+      "LSM1301"
     ]
   },
   {
@@ -26811,29 +24801,23 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "LSM1301",
-      "LSM1301X"
+      "LSM1301"
     ]
   },
   {
     "code": "LSM1106",
     "name": "Molecular Cell Biology",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM1101"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "LSM1301",
-      "LSM1301X"
+      "LSM1301"
     ]
   },
   {
     "code": "LSM1301",
     "name": "General Biology",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM1301X"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -26847,27 +24831,21 @@
     "code": "LSM1306",
     "name": "Forensic Science",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEK1542"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LSM1307",
     "name": "Waste and Our Environment",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEK1515"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LSM1401",
     "name": "Fundamentals of Biochemistry",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM1101"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CM1417",
       "CM1417X"
@@ -26887,9 +24865,7 @@
     "code": "LSM2211",
     "name": "Metabolism and Regulation",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM2101"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LSM1106"
     ]
@@ -26898,9 +24874,7 @@
     "code": "LSM2212",
     "name": "Human Anatomy",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM1202"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LSM1102",
       "LSM1106"
@@ -26910,21 +24884,16 @@
     "code": "LSM2231",
     "name": "General Physiology",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM1104"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "LSM1301",
-      "LSM1301X"
+      "LSM1301"
     ]
   },
   {
     "code": "LSM2232",
     "name": "Genes, Genomes and Biomedical Implications",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM2102"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LSM1102",
       "LSM1106"
@@ -26934,9 +24903,7 @@
     "code": "LSM2233",
     "name": "Cell Biology",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM2103"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LSM1106"
     ]
@@ -26947,8 +24914,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "LSM1301",
-      "LSM1301X"
+      "LSM1301"
     ]
   },
   {
@@ -26969,29 +24935,23 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "LSM1301",
-      "LSM1301X"
+      "LSM1301"
     ]
   },
   {
     "code": "LSM2252",
     "name": "Biodiversity",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM1103"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "LSM1301",
-      "LSM1301X"
+      "LSM1301"
     ]
   },
   {
     "code": "LSM2253",
     "name": "Applied Data Analysis in Ecology and Evolution",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM3257"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "ST1232"
     ]
@@ -27049,9 +25009,7 @@
     "code": "LSM3211",
     "name": "Fundamental Pharmacology",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEK2501"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LSM2211",
       "LSM2233"
@@ -27080,9 +25038,7 @@
     "code": "LSM3215",
     "name": "Neuronal Signaling and Memory Mechanisms",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM3213"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LSM2231",
       "LSM2233"
@@ -27092,9 +25048,7 @@
     "code": "LSM3216",
     "name": "Neuronal Development and Diseases",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM3213"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LSM2232",
       "LSM2233"
@@ -27113,9 +25067,7 @@
     "code": "LSM3218",
     "name": "Cardiopulmonary Pharmacology",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM3221"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LSM3211"
     ]
@@ -27124,9 +25076,7 @@
     "code": "LSM3219",
     "name": "Neuropharmacology",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM3221"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LSM3211"
     ]
@@ -27320,9 +25270,7 @@
     "code": "LSM3255",
     "name": "Ecology of Terrestrial Environments",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM3271"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LSM2251"
     ]
@@ -27341,9 +25289,7 @@
     "code": "LSM3258",
     "name": "Comparative Botany",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM3261"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LSM2231",
       "LSM2252"
@@ -27423,18 +25369,14 @@
     "code": "LSM3311",
     "name": "Undergraduate Professional Internship Programme",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3311"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "LSM3312",
     "name": "Enhanced Undergraduate Professional Internship Programme",
     "creditCount": 12.0,
-    "preclusions": [
-      "XX3312"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -27490,7 +25432,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "LSM2101",
       "LSM2102"
     ]
   },
@@ -27536,9 +25477,7 @@
     "name": "Genetic Medicine in the Post-Genomic Era",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "LSM2102"
-    ]
+    "prerequisites": []
   },
   {
     "code": "LSM4226",
@@ -27557,7 +25496,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "LSM2102",
       "LSM2103"
     ]
   },
@@ -27566,9 +25504,7 @@
     "name": "Experimental Models for Human Disease and Therapy",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "LSM2103"
-    ]
+    "prerequisites": []
   },
   {
     "code": "LSM4229",
@@ -27585,18 +25521,14 @@
     "name": "Structural Biology",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "LSM2103"
-    ]
+    "prerequisites": []
   },
   {
     "code": "LSM4232",
     "name": "Advanced Cell Biology",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "LSM2103"
-    ]
+    "prerequisites": []
   },
   {
     "code": "LSM4234",
@@ -27604,7 +25536,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "LSM2102",
       "LSM2103"
     ]
   },
@@ -27613,9 +25544,7 @@
     "name": "Nuclear Mechanics and Genome Regulation",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "LSM2102"
-    ]
+    "prerequisites": []
   },
   {
     "code": "LSM4241",
@@ -27642,18 +25571,14 @@
     "name": "Tumour Biology",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "LSM2103"
-    ]
+    "prerequisites": []
   },
   {
     "code": "LSM4244",
     "name": "Oncogenes and Signal Transduction",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "LSM2103"
-    ]
+    "prerequisites": []
   },
   {
     "code": "LSM4245",
@@ -27717,9 +25642,7 @@
     "code": "LSM4257",
     "name": "Aquatic Vertebrate Diversity",
     "creditCount": 4.0,
-    "preclusions": [
-      "LSM4266"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LSM2252"
     ]
@@ -27737,9 +25660,7 @@
     "code": "LSM4262",
     "name": "Tropical Conservation Biology",
     "creditCount": 4.0,
-    "preclusions": [
-      "ULS2204"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "LSM3272",
       "ENV2101"
@@ -27777,9 +25698,7 @@
     "code": "LSM4299",
     "name": "Applied Project in Life Sciences",
     "creditCount": 16.0,
-    "preclusions": [
-      "XX4199"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -27794,17 +25713,13 @@
     "name": "Fundamental Concepts of Mathematics",
     "creditCount": 4.0,
     "preclusions": [
-      "MA1100S",
       "GM1308",
       "CS1231",
-      "CS1231S",
       "CS1301"
     ],
     "prerequisites": [
-      "GM1101",
       "GM1102",
       "MA1301",
-      "MA1301FC",
       "MA1301X"
     ]
   },
@@ -27813,16 +25728,12 @@
     "name": "Linear Algebra I",
     "creditCount": 4.0,
     "preclusions": [
-      "EG1401",
       "EG1402",
-      "MA1101",
       "MA1311",
-      "MA1506",
       "MA1508"
     ],
     "prerequisites": [
       "MA1301",
-      "MA1301FC",
       "MA1301X"
     ]
   },
@@ -27831,21 +25742,16 @@
     "name": "Calculus",
     "creditCount": 4.0,
     "preclusions": [
-      "EE1401",
       "EE1461",
-      "EG1401",
       "EG1402",
-      "CE1402",
       "MA1102",
       "MA1312",
       "MA1505",
-      "MA1505C",
       "MA1507",
       "MA1521"
     ],
     "prerequisites": [
       "MA1301",
-      "MA1301FC",
       "MA1301X"
     ]
   },
@@ -27856,14 +25762,10 @@
     "preclusions": [
       "MA1101R",
       "MA1102R",
-      "MA1301FC",
       "MA1301X",
       "MA1505",
-      "MA1506",
       "MA1507",
-      "MA1508",
       "MA1521",
-      "MA1311",
       "MA1312",
       "MA1421"
     ],
@@ -27883,13 +25785,11 @@
     "preclusions": [
       "MA1102R",
       "MA1505",
-      "MA1505C",
       "MA1521",
       "MA1511"
     ],
     "prerequisites": [
       "MA1301",
-      "MA1301FC",
       "MA1301X"
     ]
   },
@@ -27901,7 +25801,6 @@
       "MA1102R",
       "MA1312",
       "MA1505",
-      "MA1506",
       "MA1507",
       "MA1521"
     ],
@@ -27919,12 +25818,10 @@
       "MA1521",
       "MA2311",
       "MA2501",
-      "EE1461",
       "PC2174"
     ],
     "prerequisites": [
       "MA1301",
-      "MA1301FC",
       "MA1301X"
     ]
   },
@@ -27934,7 +25831,6 @@
     "creditCount": 4.0,
     "preclusions": [
       "MA1102R",
-      "MA1104",
       "MA1505",
       "MA1511",
       "MA1512",
@@ -27950,9 +25846,7 @@
     "creditCount": 4.0,
     "preclusions": [
       "MA1101R",
-      "MA1311",
       "MA1506",
-      "MA1508",
       "MA1513"
     ],
     "prerequisites": []
@@ -27965,12 +25859,10 @@
       "MA1102R",
       "MA1312",
       "MA1505",
-      "MA1506",
       "MA1507",
       "MA1521",
       "MA2311",
       "MA2501",
-      "EE1461",
       "PC2174"
     ],
     "prerequisites": []
@@ -27980,9 +25872,7 @@
     "name": "Differential Equations for Engineering",
     "creditCount": 2.0,
     "preclusions": [
-      "MA1506",
       "MA1507",
-      "EE1461",
       "PC2174"
     ],
     "prerequisites": []
@@ -27993,9 +25883,7 @@
     "creditCount": 2.0,
     "preclusions": [
       "MA1101R",
-      "MA1311",
       "MA1506",
-      "MA1508",
       "MA1508E"
     ],
     "prerequisites": []
@@ -28014,7 +25902,6 @@
     ],
     "prerequisites": [
       "MA1301",
-      "MA1301FC",
       "MA1301X"
     ]
   },
@@ -28024,16 +25911,12 @@
     "creditCount": 4.0,
     "preclusions": [
       "MA2101S",
-      "MA2101H",
       "MA2201",
-      "MA2203",
       "MQ2201",
-      "MQ2101",
       "MQ2203"
     ],
     "prerequisites": [
       "MA1101R",
-      "MA1506",
       "MA1508",
       "MA1508E",
       "MA1513"
@@ -28045,16 +25928,12 @@
     "creditCount": 5.0,
     "preclusions": [
       "MA2101",
-      "MA2101H",
       "MA2201",
-      "MA2203",
       "MQ2201",
-      "MQ2101",
       "MQ2203"
     ],
     "prerequisites": [
       "MA1101R",
-      "MA1506",
       "MA1508",
       "MA1508E",
       "MA1513"
@@ -28065,7 +25944,6 @@
     "name": "Multivariable Calculus",
     "creditCount": 4.0,
     "preclusions": [
-      "MA1104",
       "MA2311",
       "MA1507"
     ],
@@ -28082,22 +25960,16 @@
     "creditCount": 4.0,
     "preclusions": [
       "MA2108S",
-      "MA2206",
       "MA2208",
-      "MA2221",
       "MA2311",
-      "MQ2202",
       "MQ2102",
-      "MQ2203",
       "CN2401",
-      "EE2401",
       "ME2492"
     ],
     "prerequisites": [
       "MA1102R",
       "MA1505",
       "MA1511",
-      "MA1505C",
       "MA1507",
       "MA1521"
     ]
@@ -28108,22 +25980,16 @@
     "creditCount": 5.0,
     "preclusions": [
       "MA2108",
-      "MA2206",
       "MA2208",
-      "MA2221",
       "MA2311",
-      "MQ2202",
       "MQ2102",
-      "MQ2203",
       "CN2401",
-      "EE2401",
       "ME2492"
     ],
     "prerequisites": [
       "MA1102R",
       "MA1505",
       "MA1511",
-      "MA1505C",
       "MA1507",
       "MA1521"
     ]
@@ -28134,14 +26000,11 @@
     "creditCount": 4.0,
     "preclusions": [
       "MA2202S",
-      "MA3250",
       "MQ3201"
     ],
     "prerequisites": [
       "MA1100",
-      "MA1100S",
-      "CS1231",
-      "CS1231S"
+      "CS1231"
     ]
   },
   {
@@ -28150,14 +26013,11 @@
     "creditCount": 5.0,
     "preclusions": [
       "MA2202",
-      "MA3250",
       "MQ3201"
     ],
     "prerequisites": [
       "MA1100",
-      "MA1100S",
-      "CS1231",
-      "CS1231S"
+      "CS1231"
     ]
   },
   {
@@ -28168,7 +26028,6 @@
       "CE2407",
       "ME3291",
       "CN3421",
-      "CN3411",
       "DSA2102"
     ],
     "prerequisites": [
@@ -28178,13 +26037,9 @@
       "MA1505",
       "MA1521",
       "MA1511",
-      "EG1402",
       "EE1401",
-      "EE1461",
       "MA1101R",
-      "MA1311",
       "MA1508",
-      "MA1506",
       "MA1508E",
       "MA1513"
     ]
@@ -28197,13 +26052,10 @@
     "prerequisites": [
       "MA1100",
       "MA1101R",
-      "MA1311",
       "MA1506",
-      "MA1508",
       "MA1508E",
       "MA1513",
-      "CS1231",
-      "CS1231S"
+      "CS1231"
     ]
   },
   {
@@ -28220,7 +26072,6 @@
       "MA1312",
       "MA1507",
       "MA1505",
-      "MA1505C",
       "MA1511",
       "MA1521"
     ]
@@ -28233,7 +26084,6 @@
     "prerequisites": [
       "MA1100",
       "MA1101R",
-      "MA1506",
       "MA1508",
       "MA1508E",
       "MA1513",
@@ -28267,7 +26117,6 @@
     "name": "Techniques in Advanced Calculus",
     "creditCount": 4.0,
     "preclusions": [
-      "MA1104",
       "MA2104",
       "MA1505",
       "MA1507",
@@ -28288,17 +26137,14 @@
     "creditCount": 4.0,
     "preclusions": [
       "MA1505",
-      "MA1505C",
       "MA1506",
       "MA1512",
       "MA1521",
-      "MA2210",
       "MA2312",
       "MA1511"
     ],
     "prerequisites": [
       "MA1507",
-      "MA1508",
       "MA1508E"
     ]
   },
@@ -28307,12 +26153,9 @@
     "name": "Mathematical Analysis II",
     "creditCount": 4.0,
     "preclusions": [
-      "MA2118",
       "MA2118H",
-      "MA2205",
       "MQ3202",
-      "MA3110S",
-      "ST2236"
+      "MA3110S"
     ],
     "prerequisites": [
       "MA2108",
@@ -28324,9 +26167,7 @@
     "name": "Mathematical Analysis II (S)",
     "creditCount": 5.0,
     "preclusions": [
-      "MA2118",
       "MA2118H",
-      "MA2205",
       "MQ3202",
       "MA3110"
     ],
@@ -28340,11 +26181,9 @@
     "name": "Complex Analysis I",
     "creditCount": 4.0,
     "preclusions": [
-      "MA3111S",
-      "EE3002"
+      "MA3111S"
     ],
     "prerequisites": [
-      "MA1104",
       "MA2104",
       "MA1507",
       "MA3110",
@@ -28356,11 +26195,9 @@
     "name": "Complex Analysis I (S)",
     "creditCount": 5.0,
     "preclusions": [
-      "MA3111",
-      "EE3002"
+      "MA3111"
     ],
     "prerequisites": [
-      "MA1104",
       "MA2104",
       "MA1507",
       "MA3110",
@@ -28386,9 +26223,7 @@
     "preclusions": [],
     "prerequisites": [
       "MA1100",
-      "MA1100S",
-      "CS1231",
-      "CS1231S"
+      "CS1231"
     ]
   },
   {
@@ -28396,13 +26231,11 @@
     "name": "Mathematical Analysis III",
     "creditCount": 4.0,
     "preclusions": [
-      "MA3213",
       "MA3251"
     ],
     "prerequisites": [
       "MA3110",
       "MA3110S",
-      "MA1104",
       "MA2104",
       "MA1507"
     ]
@@ -28413,8 +26246,7 @@
     "creditCount": 4.0,
     "preclusions": [
       "MA2202",
-      "MA2202S",
-      "EE4103"
+      "MA2202S"
     ],
     "prerequisites": [
       "MA2101",
@@ -28426,20 +26258,16 @@
     "name": "Ordinary Differential Equations",
     "creditCount": 4.0,
     "preclusions": [
-      "MA2312",
       "PC2174"
     ],
     "prerequisites": [
-      "MA1104",
       "MA2104",
       "MA1505",
       "MA1507",
       "MA1511",
       "MA1521",
       "MA1101R",
-      "MA1311",
       "MA1506",
-      "MA1508",
       "MA1508E",
       "MA1513",
       "MA2108",
@@ -28455,9 +26283,7 @@
     ],
     "prerequisites": [
       "MA2213",
-      "MA1104",
       "MA2104",
-      "MA1506",
       "MA1507",
       "MA1505",
       "MA1511",
@@ -28483,13 +26309,10 @@
     "name": "Non-Linear Programming",
     "creditCount": 4.0,
     "preclusions": [
-      "DSC3214",
-      "DSN3701"
+      "DSC3214"
     ],
     "prerequisites": [
-      "MA1104",
       "MA2104",
-      "MA1506",
       "MA1507",
       "MA1505",
       "MA1511",
@@ -28504,11 +26327,8 @@
       "ST3236"
     ],
     "prerequisites": [
-      "MA1101",
       "MA1101R",
-      "MA1311",
       "MA1508",
-      "GM1302",
       "MA2216",
       "ST2131"
     ]
@@ -28518,19 +26338,13 @@
     "name": "Linear and Network Optimisation",
     "creditCount": 4.0,
     "preclusions": [
-      "MQ2204",
       "CS3252",
-      "IC2231",
       "DSC3214",
-      "DSN3701",
-      "MA3235",
-      "BH3214"
+      "MA3235"
     ],
     "prerequisites": [
       "MA1101R",
-      "MA1306",
       "MA1311",
-      "MA1508",
       "MA1506",
       "MA1508E",
       "MA1513"
@@ -28544,7 +26358,6 @@
     "prerequisites": [
       "MA2216",
       "MA3233",
-      "MA3501",
       "ST2131",
       "ST2334",
       "LSM2241"
@@ -28556,13 +26369,10 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MA1104",
       "MA2104",
-      "MA1104S",
       "MA1506",
       "MA2108",
       "MA2108S",
-      "MA2221",
       "MA1505",
       "MA1511",
       "MA2311"
@@ -28584,19 +26394,14 @@
     "code": "MA3269",
     "name": "Mathematical Finance I",
     "creditCount": 4.0,
-    "preclusions": [
-      "QF2101"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CS1010",
       "CS1010E",
       "CS1010S",
-      "CS1010FC",
       "IT1006",
-      "CS1101",
       "CS1101C",
       "CS1101S",
-      "IT1002",
       "ST2131",
       "ST2334",
       "MA2216"
@@ -28620,27 +26425,21 @@
     "code": "MA3310",
     "name": "Undergraduate Professional Internship Programme",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3310"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "MA3311",
     "name": "Undergraduate Professional Internship Programme",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3311"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "MA3312",
     "name": "Enhanced Undergraduate Professional Internship Programme",
     "creditCount": 12.0,
-    "preclusions": [
-      "XX3312"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -28669,8 +26468,7 @@
     "prerequisites": [
       "MA3110",
       "MA3110S",
-      "MA3205",
-      "MA3219"
+      "MA3205"
     ]
   },
   {
@@ -28679,7 +26477,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MA3207H",
       "MA3209"
     ]
   },
@@ -28740,9 +26537,7 @@
     "name": "Stochastic Processes II",
     "creditCount": 4.0,
     "preclusions": [
-      "MA3237",
       "MA3239",
-      "GM3310",
       "ST4238"
     ],
     "prerequisites": [
@@ -28754,14 +26549,10 @@
     "code": "MA4254",
     "name": "Discrete Optimization",
     "creditCount": 4.0,
-    "preclusions": [
-      "MA3235"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "MA2215",
       "MA3252",
-      "DSC3214",
-      "DSN3701"
+      "DSC3214"
     ]
   },
   {
@@ -28788,8 +26579,7 @@
       "ST2334",
       "MA3236",
       "MA3252",
-      "DSC3214",
-      "DSN3701"
+      "DSC3214"
     ]
   },
   {
@@ -28835,7 +26625,6 @@
       "MA3236",
       "MA3252",
       "DSC3214",
-      "DSN3701",
       "MA2216",
       "ST2131",
       "ST2334"
@@ -28864,11 +26653,9 @@
     "name": "Mathematical Finance II",
     "creditCount": 4.0,
     "preclusions": [
-      "MA3245",
       "MA4257"
     ],
     "prerequisites": [
-      "MA1104",
       "MA1506",
       "MA1507",
       "MA1511",
@@ -28894,11 +26681,8 @@
     "code": "MA4271",
     "name": "Differential Geometry of Curves and Surfaces",
     "creditCount": 4.0,
-    "preclusions": [
-      "MA3215"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "MA1104",
       "MA2104",
       "MA1507",
       "MA1505",
@@ -28960,9 +26744,7 @@
     "code": "MA5205",
     "name": "Graduate Analysis I",
     "creditCount": 5.0,
-    "preclusions": [
-      "MA5215"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "MA4262"
     ]
@@ -28984,7 +26766,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MA3251",
       "MA4215",
       "MA4266"
     ]
@@ -28996,7 +26777,6 @@
     "preclusions": [],
     "prerequisites": [
       "MA3209",
-      "MA3215",
       "MA3251",
       "MA4266"
     ]
@@ -29008,8 +26788,7 @@
     "preclusions": [],
     "prerequisites": [
       "MA3201",
-      "MA5203",
-      "MA5218"
+      "MA5203"
     ]
   },
   {
@@ -29052,7 +26831,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MA3228",
       "MA4255",
       "MA4230"
     ]
@@ -29092,7 +26870,6 @@
     "preclusions": [],
     "prerequisites": [
       "MA4262",
-      "MA3245",
       "MA4269"
     ]
   },
@@ -29323,7 +27100,6 @@
     "creditCount": 2.0,
     "preclusions": [],
     "prerequisites": [
-      "MDG5227",
       "MDG5236"
     ]
   },
@@ -29332,9 +27108,7 @@
     "name": "Clinical Pharmacology II",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "MDG5238"
-    ]
+    "prerequisites": []
   },
   {
     "code": "MDG5302",
@@ -29355,7 +27129,6 @@
     "name": "Fundamentals of Mechanical Design",
     "creditCount": 4.0,
     "preclusions": [
-      "TM2101",
       "TME2101"
     ],
     "prerequisites": []
@@ -29390,7 +27163,6 @@
     "name": "Mechanics of Materials II",
     "creditCount": 3.0,
     "preclusions": [
-      "TM1111",
       "TME2114"
     ],
     "prerequisites": []
@@ -29402,7 +27174,6 @@
     "preclusions": [],
     "prerequisites": [
       "PC1431",
-      "PC1431FC",
       "PC1431X"
     ]
   },
@@ -29413,7 +27184,6 @@
     "preclusions": [],
     "prerequisites": [
       "PC1431",
-      "PC1431FC",
       "PC1431X"
     ]
   },
@@ -29422,7 +27192,6 @@
     "name": "Engineering Thermodynamics",
     "creditCount": 4.0,
     "preclusions": [
-      "TM1121",
       "TME2121"
     ],
     "prerequisites": []
@@ -29434,7 +27203,6 @@
     "preclusions": [],
     "prerequisites": [
       "PC1431",
-      "PC1431FC",
       "PC1431X"
     ]
   },
@@ -29443,7 +27211,6 @@
     "name": "Fluid Mechanics I",
     "creditCount": 4.0,
     "preclusions": [
-      "TM1131",
       "TME2134"
     ],
     "prerequisites": []
@@ -29462,7 +27229,6 @@
     "name": "Fluid Mechanics II",
     "creditCount": 4.0,
     "preclusions": [
-      "TM2131",
       "TME2135"
     ],
     "prerequisites": [
@@ -29474,16 +27240,13 @@
     "name": "Feedback Control Systems",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "MA1506"
-    ]
+    "prerequisites": []
   },
   {
     "code": "ME2142E",
     "name": "Feedback Control Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3142",
       "TME2142"
     ],
     "prerequisites": [
@@ -29495,7 +27258,6 @@
     "name": "Sensors and Actuators",
     "creditCount": 4.0,
     "preclusions": [
-      "TM2141",
       "TME2143"
     ],
     "prerequisites": []
@@ -29504,9 +27266,7 @@
     "code": "ME2151",
     "name": "Principles of Mechanical Eng. Materials",
     "creditCount": 4.0,
-    "preclusions": [
-      "MLE1101"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -29514,7 +27274,6 @@
     "name": "Principles of Mechanical Eng. Materials",
     "creditCount": 4.0,
     "preclusions": [
-      "TM1151",
       "TME2151"
     ],
     "prerequisites": []
@@ -29538,11 +27297,9 @@
     "name": "Mechanical Systems Design",
     "creditCount": 6.0,
     "preclusions": [
-      "ME3101",
       "ME3102"
     ],
     "prerequisites": [
-      "ME2101",
       "ME2103"
     ]
   },
@@ -29551,7 +27308,6 @@
     "name": "Mechanics of Machines",
     "creditCount": 4.0,
     "preclusions": [
-      "TM2112",
       "TME3112"
     ],
     "prerequisites": []
@@ -29562,9 +27318,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PC1431FC",
-      "PC1431",
-      "PC1431X"
+      "PC1431"
     ]
   },
   {
@@ -29572,7 +27326,6 @@
     "name": "Heat Transfer",
     "creditCount": 4.0,
     "preclusions": [
-      "TM2122",
       "TME3122"
     ],
     "prerequisites": []
@@ -29589,7 +27342,6 @@
     "name": "Manufacturing Processes",
     "creditCount": 4.0,
     "preclusions": [
-      "TM2162",
       "TME3162"
     ],
     "prerequisites": []
@@ -29608,7 +27360,6 @@
     "name": "Mechanics of Solids",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3211",
       "TME3211"
     ],
     "prerequisites": [
@@ -29628,9 +27379,7 @@
     "code": "ME3232",
     "name": "Compressible Flow",
     "creditCount": 4.0,
-    "preclusions": [
-      "ME3231"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "ME2134"
     ]
@@ -29640,7 +27389,6 @@
     "name": "Unsteady Flow in Fluid Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "ME3233",
       "TME3233"
     ],
     "prerequisites": [
@@ -29660,7 +27408,6 @@
     "name": "Microprocessor Applications",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3241",
       "TME3241"
     ],
     "prerequisites": []
@@ -29677,7 +27424,6 @@
     "name": "Automation",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3242",
       "TME3242"
     ],
     "prerequisites": []
@@ -29696,7 +27442,6 @@
     "name": "Materials For Engineers",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3251",
       "TME3251"
     ],
     "prerequisites": [
@@ -29715,7 +27460,6 @@
     "name": "Computer-Aided Design and Manufacturing",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3261",
       "TME3261"
     ],
     "prerequisites": []
@@ -29732,7 +27476,6 @@
     "name": "Design for Manufacturing and Assembly",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3263",
       "TME3263"
     ],
     "prerequisites": []
@@ -29821,7 +27564,6 @@
     "name": "Thermal Environmental Engineering",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3223",
       "TME4223"
     ],
     "prerequisites": [
@@ -29843,7 +27585,6 @@
     "name": "Applied Heat Transfer",
     "creditCount": 4.0,
     "preclusions": [
-      "TM4225",
       "TME4225"
     ],
     "prerequisites": [
@@ -29898,9 +27639,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MA1506",
       "ME2142",
-      "EE2010",
       "EE3331C"
     ]
   },
@@ -29909,12 +27648,10 @@
     "name": "Robot Mechanics and Control",
     "creditCount": 4.0,
     "preclusions": [
-      "TM4245",
       "TME4245"
     ],
     "prerequisites": [
       "ME2142E",
-      "EE2010E",
       "EE3331E"
     ]
   },
@@ -29951,8 +27688,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "ME2151",
-      "ME2143"
+      "ME2151"
     ]
   },
   {
@@ -29980,7 +27716,6 @@
     "name": "Tool Engineering",
     "creditCount": 4.0,
     "preclusions": [
-      "TM4261",
       "TME4261"
     ],
     "prerequisites": []
@@ -29990,9 +27725,7 @@
     "name": "Automation In Manufacturing",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "ME2162"
-    ]
+    "prerequisites": []
   },
   {
     "code": "ME4291",
@@ -30067,9 +27800,7 @@
     "code": "ME5304",
     "name": "Experimental Fluid Mechanics",
     "creditCount": 4.0,
-    "preclusions": [
-      "ME4234"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "ME2135"
     ]
@@ -30078,9 +27809,7 @@
     "code": "ME5309",
     "name": "Jet and Rocket Propulsion",
     "creditCount": 4.0,
-    "preclusions": [
-      "ME5308"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "ME2134"
     ]
@@ -30090,9 +27819,7 @@
     "name": "Linear Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "MCH5201",
-      "EE5101",
-      "EE5101R"
+      "EE5101"
     ],
     "prerequisites": [
       "EE4302",
@@ -30104,9 +27831,7 @@
     "name": "Advanced Robotics",
     "creditCount": 4.0,
     "preclusions": [
-      "MCH5209",
-      "EE5106",
-      "EE5106R"
+      "EE5106"
     ],
     "prerequisites": []
   },
@@ -30116,9 +27841,7 @@
     "creditCount": 4.0,
     "preclusions": [
       "EE5103",
-      "EE5103R",
-      "MCH5103",
-      "TD5241"
+      "MCH5103"
     ],
     "prerequisites": []
   },
@@ -30128,7 +27851,6 @@
     "creditCount": 4.0,
     "preclusions": [
       "EE5904",
-      "EE5904R",
       "MCH5202"
     ],
     "prerequisites": []
@@ -30185,9 +27907,7 @@
     "code": "ME5608",
     "name": "Additive and Non-Conventional Manufacturing Processes",
     "creditCount": 4.0,
-    "preclusions": [
-      "ME6605"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -30219,9 +27939,7 @@
     "code": "ME5612",
     "name": "Computer Aided Product Development",
     "creditCount": 4.0,
-    "preclusions": [
-      "ME6606"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -30249,9 +27967,7 @@
     "code": "ME6205",
     "name": "Advanced Topics in Heat and Mass Transfer",
     "creditCount": 4.0,
-    "preclusions": [
-      "ME5202"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -30300,9 +28016,7 @@
     "code": "MIC2000",
     "name": "Infection and Immunology",
     "creditCount": 3.0,
-    "preclusions": [
-      "MIC1000"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -30310,14 +28024,10 @@
     "name": "Principles of Marketing",
     "creditCount": 4.0,
     "preclusions": [
-      "EC3230",
       "EC2210",
-      "CS3261",
       "IC3243",
       "PR4201",
-      "BK2003",
       "BZ1003",
-      "BH1003",
       "MKT1003",
       "MKT1003"
     ],
@@ -30328,14 +28038,10 @@
     "name": "Principles of Marketing",
     "creditCount": 4.0,
     "preclusions": [
-      "EC3230",
       "EC2210",
-      "CS3261",
       "IC3243",
       "PR4201",
-      "BK2003",
       "BZ1003",
-      "BH1003",
       "MKT1003",
       "MKT1003"
     ],
@@ -30346,14 +28052,10 @@
     "name": "Principles of Marketing",
     "creditCount": 4.0,
     "preclusions": [
-      "EC3230",
       "EC2210",
-      "CS3261",
       "IC3243",
       "PR4201",
-      "BK2003",
       "BZ1003",
-      "BH1003",
       "MKT1003",
       "MKT1003"
     ],
@@ -30364,14 +28066,10 @@
     "name": "Principles of Marketing",
     "creditCount": 4.0,
     "preclusions": [
-      "EC3230",
       "EC2210",
-      "CS3261",
       "IC3243",
       "PR4201",
-      "BK2003",
       "BZ1003",
-      "BH1003",
       "MKT1003",
       "MKT1003"
     ],
@@ -30382,14 +28080,10 @@
     "name": "Principles of Marketing",
     "creditCount": 4.0,
     "preclusions": [
-      "EC3230",
       "EC2210",
-      "CS3261",
       "IC3243",
       "PR4201",
-      "BK2003",
       "BZ1003",
-      "BH1003",
       "MKT1003",
       "MKT1003"
     ],
@@ -30400,14 +28094,10 @@
     "name": "Principles of Marketing",
     "creditCount": 4.0,
     "preclusions": [
-      "EC3230",
       "EC2210",
-      "CS3261",
       "IC3243",
       "PR4201",
-      "BK2003",
       "BZ1003",
-      "BH1003",
       "MKT1003"
     ],
     "prerequisites": []
@@ -30477,17 +28167,12 @@
     "name": "Asian Markets And Marketing Management",
     "creditCount": 4.0,
     "preclusions": [
-      "BH2401",
       "BZ3601",
-      "BK3200",
-      "MKT2401B",
-      "MKT2401"
+      "MKT2401B"
     ],
     "prerequisites": [
       "MKT1003",
-      "BH1003",
-      "BZ1003",
-      "BK2003"
+      "BZ1003"
     ]
   },
   {
@@ -30495,17 +28180,12 @@
     "name": "Asian Markets And Marketing Management",
     "creditCount": 4.0,
     "preclusions": [
-      "BH2401",
       "BZ3601",
-      "BK3200",
-      "MKT2401A",
-      "MKT2401"
+      "MKT2401A"
     ],
     "prerequisites": [
       "MKT1003",
-      "BH1003",
-      "BZ1003",
-      "BK2003"
+      "BZ1003"
     ]
   },
   {
@@ -30513,17 +28193,12 @@
     "name": "Marketing Research",
     "creditCount": 4.0,
     "preclusions": [
-      "BH2413",
       "BZ3614",
-      "BK3202",
-      "MKT2413A",
-      "MKT2413B"
+      "MKT2413A"
     ],
     "prerequisites": [
       "MKT1003",
-      "BH1003",
-      "BZ1003",
-      "BK2003"
+      "BZ1003"
     ]
   },
   {
@@ -30569,17 +28244,13 @@
     "name": "Consumer Behaviour",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3420",
       "BZ3605",
-      "BK3203",
       "MKT3402A",
       "MKT3402B"
     ],
     "prerequisites": [
       "MKT1003",
-      "BH1003",
-      "BZ1003",
-      "BK2003"
+      "BZ1003"
     ]
   },
   {
@@ -30587,17 +28258,13 @@
     "name": "Consumer Behaviour",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3402",
       "BZ3602",
-      "BK3201",
       "MKT3402A",
       "MKT3402B"
     ],
     "prerequisites": [
       "MKT1003",
-      "BH1003",
-      "BZ1003",
-      "BK2003"
+      "BZ1003"
     ]
   },
   {
@@ -30605,17 +28272,13 @@
     "name": "Consumer Behaviour",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3402",
       "BZ3602",
-      "BK3201",
       "MKT3402A",
       "MKT3402B"
     ],
     "prerequisites": [
       "MKT1003",
-      "BH1003",
-      "BZ1003",
-      "BK2003"
+      "BZ1003"
     ]
   },
   {
@@ -30623,17 +28286,13 @@
     "name": "Consumer Behaviour",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3420",
       "BZ3605",
-      "BK3203",
       "MKT3402A",
       "MKT3402B"
     ],
     "prerequisites": [
       "MKT1003",
-      "BH1003",
-      "BZ1003",
-      "BK2003"
+      "BZ1003"
     ]
   },
   {
@@ -30641,19 +28300,13 @@
     "name": "Services Marketing",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3412",
       "BH3412A",
-      "BH3412B",
       "BZ3612",
-      "BK3205",
-      "MKT3412A",
-      "MKT3412B"
+      "MKT3412A"
     ],
     "prerequisites": [
       "MKT1003",
-      "BH1003",
-      "BZ1003",
-      "BK2003"
+      "BZ1003"
     ]
   },
   {
@@ -30669,9 +28322,7 @@
     "code": "MKT3417",
     "name": "Customer Relationship Management",
     "creditCount": 4.0,
-    "preclusions": [
-      "CS4266"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "MKT1003",
       "MKT1003X"
@@ -30682,16 +28333,12 @@
     "name": "Product And Brand Management",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3418",
       "BZ3603",
-      "MKT3418A",
       "MKT3418B"
     ],
     "prerequisites": [
       "MKT1003",
-      "BH1003",
-      "BZ1003",
-      "BK2003"
+      "BZ1003"
     ]
   },
   {
@@ -30736,7 +28383,6 @@
     "name": "Marketing Strategy: Analysis and Practice",
     "creditCount": 4.0,
     "preclusions": [
-      "MKT2401",
       "RE3704"
     ],
     "prerequisites": [
@@ -30816,9 +28462,7 @@
     "code": "MKT3721",
     "name": "Global Marketing",
     "creditCount": 4.0,
-    "preclusions": [
-      "MKT2412"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "MKT1705",
       "MKT1705X"
@@ -30829,7 +28473,6 @@
     "name": "TIM: Wealth Management Marketing",
     "creditCount": 4.0,
     "preclusions": [
-      "MKT3422A",
       "MKT3428"
     ],
     "prerequisites": [
@@ -30843,7 +28486,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MKT2401",
       "MKT2401A",
       "MKT2401B"
     ]
@@ -30853,9 +28495,7 @@
     "name": "Pricing Strategy",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "MKT2401"
-    ]
+    "prerequisites": []
   },
   {
     "code": "MKT4417",
@@ -30876,9 +28516,7 @@
     "name": "Marketing Analytics",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "MKT2401"
-    ]
+    "prerequisites": []
   },
   {
     "code": "MKT4712",
@@ -30888,7 +28526,6 @@
       "MKT4412"
     ],
     "prerequisites": [
-      "MKT3701",
       "RE3704"
     ]
   },
@@ -30901,10 +28538,8 @@
     ],
     "prerequisites": [
       "BSP1703",
-      "BSP1707",
       "EC1101E",
       "EC1301",
-      "MKT3701",
       "RE3704"
     ]
   },
@@ -30916,7 +28551,6 @@
       "MKT4413"
     ],
     "prerequisites": [
-      "MKT3701",
       "RE3704"
     ]
   },
@@ -30925,11 +28559,9 @@
     "name": "Marketing Analytics",
     "creditCount": 4.0,
     "preclusions": [
-      "MKT4415C",
       "MKT4420"
     ],
     "prerequisites": [
-      "MKT3701",
       "RE3704"
     ]
   },
@@ -30955,7 +28587,6 @@
     "prerequisites": [
       "PC1221",
       "PC1222",
-      "MLE1111",
       "MLE1001",
       "MLE1002"
     ]
@@ -30968,7 +28599,6 @@
     "prerequisites": [
       "PC1221",
       "PC1222",
-      "MLE1111",
       "MLE1001",
       "MLE1002"
     ]
@@ -30980,7 +28610,6 @@
     "preclusions": [],
     "prerequisites": [
       "MLE2102",
-      "MLE1111",
       "MLE1001",
       "MLE1002"
     ]
@@ -30991,11 +28620,8 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "EG1109FC",
       "EG1109",
-      "MLE1101",
       "MLE2101",
-      "MLE1111",
       "MLE1001",
       "MLE1002"
     ]
@@ -31008,9 +28634,7 @@
     "prerequisites": [
       "MLE1001",
       "MLE1002",
-      "MLE1101",
-      "MLE2101",
-      "MLE1111"
+      "MLE2101"
     ]
   },
   {
@@ -31019,7 +28643,6 @@
     "creditCount": 3.0,
     "preclusions": [],
     "prerequisites": [
-      "MLE1101",
       "MLE1111",
       "PC1221",
       "PC1222",
@@ -31033,7 +28656,6 @@
     "creditCount": 3.0,
     "preclusions": [],
     "prerequisites": [
-      "MLE1101",
       "MLE2101",
       "MLE1001",
       "MLE1002"
@@ -31045,9 +28667,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MLE1101",
       "MLE2102",
-      "MLE1111",
       "MLE1001",
       "MLE1002"
     ]
@@ -31058,7 +28678,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MLE1101",
       "MLE2104",
       "MLE1001",
       "MLE1002"
@@ -31070,10 +28689,8 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MLE1101",
       "CM1121",
       "CM1501",
-      "MLE1111",
       "MLE1001",
       "MLE1002"
     ]
@@ -31084,9 +28701,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MLE1101",
       "MLE2105",
-      "MLE1111",
       "MLE1001",
       "MLE1002"
     ]
@@ -31107,7 +28722,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MLE1101",
       "MLE1111",
       "MLE1001",
       "MLE1002"
@@ -31118,11 +28732,9 @@
     "name": "Engineering Materials",
     "creditCount": 4.0,
     "preclusions": [
-      "MLE2106",
       "MLE2107"
     ],
     "prerequisites": [
-      "MLE1111",
       "MLE1001",
       "MLE2102",
       "MLE1002"
@@ -31238,8 +28850,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MLE2105",
-      "EE3406"
+      "MLE2105"
     ]
   },
   {
@@ -31248,7 +28859,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MLE2107",
       "MLE2105"
     ]
   },
@@ -31259,8 +28869,7 @@
     "preclusions": [],
     "prerequisites": [
       "MLE3102",
-      "MLE3203",
-      "MLE2106"
+      "MLE3203"
     ]
   },
   {
@@ -31317,16 +28926,11 @@
     "name": "Management And Organisation",
     "creditCount": 4.0,
     "preclusions": [
-      "BE2106",
       "EG1423",
-      "CS1303",
       "BK2002",
-      "BZ1001",
       "BH1001",
       "MNO1001",
-      "HR2001",
       "HR2101",
-      "HR3111",
       "HR3308",
       "MNO1001"
     ],
@@ -31337,16 +28941,11 @@
     "name": "Management And Organisation",
     "creditCount": 4.0,
     "preclusions": [
-      "BE2106",
       "EG1423",
-      "CS1303",
       "BK2002",
-      "BZ1001",
       "BH1001",
       "MNO1001",
-      "HR2001",
       "HR2101",
-      "HR3111",
       "HR3308",
       "MNO1001"
     ],
@@ -31357,16 +28956,11 @@
     "name": "Management And Organisation",
     "creditCount": 4.0,
     "preclusions": [
-      "BE2106",
       "EG1423",
-      "CS1303",
       "BK2002",
-      "BZ1001",
       "BH1001",
       "MNO1001",
-      "HR2001",
       "HR2101",
-      "HR3111",
       "HR3308",
       "MNO1001"
     ],
@@ -31377,16 +28971,11 @@
     "name": "Management And Organisation",
     "creditCount": 4.0,
     "preclusions": [
-      "BE2106",
       "EG1423",
-      "CS1303",
       "BK2002",
-      "BZ1001",
       "BH1001",
       "MNO1001",
-      "HR2001",
       "HR2101",
-      "HR3111",
       "HR3308",
       "MNO1001"
     ],
@@ -31397,16 +28986,11 @@
     "name": "Management And Organisation",
     "creditCount": 4.0,
     "preclusions": [
-      "BE2106",
       "EG1423",
-      "CS1303",
       "BK2002",
-      "BZ1001",
       "BH1001",
       "MNO1001",
-      "HR2001",
       "HR2101",
-      "HR3111",
       "HR3308",
       "MNO1001"
     ],
@@ -31417,16 +29001,11 @@
     "name": "Management And Organisation",
     "creditCount": 4.0,
     "preclusions": [
-      "BE2106",
       "EG1423",
-      "CS1303",
       "BK2002",
-      "BZ1001",
       "BH1001",
       "MNO1001",
-      "HR2001",
       "HR2101",
-      "HR3111",
       "HR3308",
       "MNO1001"
     ],
@@ -31510,22 +29089,15 @@
     "name": "Human Resource Management",
     "creditCount": 4.0,
     "preclusions": [
-      "BH2302",
       "BZ3504",
-      "BK3300",
       "MNO2302A",
-      "PL3239",
-      "PS3245"
+      "PL3239"
     ],
     "prerequisites": [
       "MNO1001",
-      "BH1001",
       "BZ1001",
-      "BK2002",
       "HR2001",
-      "HR2101",
-      "HR3111",
-      "HR3308"
+      "HR3111"
     ]
   },
   {
@@ -31534,7 +29106,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MNO1706",
       "MNO1706X",
       "PL3239"
     ]
@@ -31545,7 +29116,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MNO1706",
       "MNO1706X",
       "PL3239"
     ]
@@ -31556,7 +29126,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MNO1706",
       "MNO1706X",
       "PL3239"
     ]
@@ -31578,20 +29147,14 @@
     "name": "Organisational Behaviour",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3301",
       "BZ3501",
-      "BK3309M",
       "PS3243"
     ],
     "prerequisites": [
       "MNO1001",
-      "BH1001",
       "BZ1001",
-      "BK2002",
       "HR2001",
-      "HR2101",
-      "HR3111",
-      "HR3308"
+      "HR3111"
     ]
   },
   {
@@ -31599,20 +29162,14 @@
     "name": "Organisational Effectiveness",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3303",
       "BZ3502",
-      "BK4309D",
       "BK3309N"
     ],
     "prerequisites": [
       "MNO1001",
-      "BH1001",
       "BZ1001",
-      "BK2002",
       "HR2001",
-      "HR2101",
-      "HR3111",
-      "HR3308"
+      "HR3111"
     ]
   },
   {
@@ -31629,14 +29186,11 @@
     "name": "Managing Change",
     "creditCount": 4.0,
     "preclusions": [
-      "BH3313A",
-      "BZ3503",
-      "BK3305"
+      "BZ3503"
     ],
     "prerequisites": [
       "MNO1001",
       "MNO2007",
-      "AY2009",
       "MNO2007"
     ]
   },
@@ -31648,7 +29202,6 @@
     "prerequisites": [
       "MNO1001",
       "MNO2007",
-      "AY2009",
       "MNO2007"
     ]
   },
@@ -31674,7 +29227,6 @@
       "MNO2302"
     ],
     "prerequisites": [
-      "MNO1706",
       "MNO2705"
     ]
   },
@@ -31686,7 +29238,6 @@
       "MNO2302"
     ],
     "prerequisites": [
-      "MNO1706",
       "MNO1706X",
       "PL3239"
     ]
@@ -31699,7 +29250,6 @@
       "MNO3320"
     ],
     "prerequisites": [
-      "MNO1706",
       "MNO1706X",
       "PL3239"
     ]
@@ -31712,7 +29262,6 @@
       "MNO3323"
     ],
     "prerequisites": [
-      "MNO1706",
       "MNO1706X",
       "PL3239"
     ]
@@ -31732,7 +29281,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MNO1706",
       "MNO1706X"
     ]
   },
@@ -31757,9 +29305,7 @@
     "code": "MS1102E",
     "name": "Malays - Tradition, Conflict and Change",
     "creditCount": 4.0,
-    "preclusions": [
-      "MS1101E"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -31838,18 +29384,14 @@
     "code": "MS3218",
     "name": "The Religious Life of the Malays",
     "creditCount": 4.0,
-    "preclusions": [
-      "MS4203"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "MS3550",
     "name": "Malay Studies Internship",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3550"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -31989,7 +29531,6 @@
     "name": "Engineering Product Development",
     "creditCount": 4.0,
     "preclusions": [
-      "TR3001",
       "EE3031"
     ],
     "prerequisites": []
@@ -32041,7 +29582,6 @@
     "name": "Technology Forecasting & Intelligence",
     "creditCount": 4.0,
     "preclusions": [
-      "MT5010A",
       "MT5010B"
     ],
     "prerequisites": []
@@ -32065,7 +29605,6 @@
     "name": "Mot Research Project",
     "creditCount": 8.0,
     "preclusions": [
-      "MT5910",
       "SDM5990"
     ],
     "prerequisites": []
@@ -32300,18 +29839,14 @@
     "code": "MUA2109",
     "name": "Chamber Music",
     "creditCount": 4.0,
-    "preclusions": [
-      "MUA1116"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "MUA2110",
     "name": "Chamber Music in Mixed Ensemble",
     "creditCount": 4.0,
-    "preclusions": [
-      "MUA1116"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -32395,9 +29930,7 @@
     "name": "Percussion Audition Techniques 2A",
     "creditCount": 2.0,
     "preclusions": [],
-    "prerequisites": [
-      "MUA1150"
-    ]
+    "prerequisites": []
   },
   {
     "code": "MUA2184",
@@ -32484,9 +30017,7 @@
     "code": "MUA2240",
     "name": "Collaborative Piano - Piano Ensemble",
     "creditCount": 4.0,
-    "preclusions": [
-      "MUA2155"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "MUA1112"
     ]
@@ -32496,7 +30027,6 @@
     "name": "Collaborative Piano - Vocal Accompaniment",
     "creditCount": 4.0,
     "preclusions": [
-      "MUA2155",
       "MUA2242",
       "MUA2243"
     ],
@@ -32509,26 +30039,20 @@
     "name": "Collaborative Piano - Instrumental Accompaniment",
     "creditCount": 4.0,
     "preclusions": [
-      "MUA2155",
       "MUA2241",
       "MUA2243"
     ],
-    "prerequisites": [
-      "MUA1116"
-    ]
+    "prerequisites": []
   },
   {
     "code": "MUA2243",
     "name": "Collaborative Piano - Chamber Music",
     "creditCount": 4.0,
     "preclusions": [
-      "MUA2155",
       "MUA2241",
       "MUA2242"
     ],
-    "prerequisites": [
-      "MUA1116"
-    ]
+    "prerequisites": []
   },
   {
     "code": "MUA2255",
@@ -32662,9 +30186,7 @@
     "name": "Audio Postproduction I",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "MUA2171"
-    ]
+    "prerequisites": []
   },
   {
     "code": "MUA3175",
@@ -32712,27 +30234,21 @@
     "name": "Advanced Concepts in Orchestral Repertoire I",
     "creditCount": 2.0,
     "preclusions": [],
-    "prerequisites": [
-      "MUA2181"
-    ]
+    "prerequisites": []
   },
   {
     "code": "MUA3182",
     "name": "Percussion Audition Techniques 3A",
     "creditCount": 2.0,
     "preclusions": [],
-    "prerequisites": [
-      "MUA2183"
-    ]
+    "prerequisites": []
   },
   {
     "code": "MUA3184",
     "name": "Orchestral Repertoire for Double Bass 3A",
     "creditCount": 2.0,
     "preclusions": [],
-    "prerequisites": [
-      "MUA2120"
-    ]
+    "prerequisites": []
   },
   {
     "code": "MUA3188",
@@ -32740,8 +30256,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MUA2170",
-      "MUA2171"
+      "MUA2170"
     ]
   },
   {
@@ -32770,9 +30285,7 @@
     "name": "Jazz Study and Performance 1",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "MUT2118"
-    ]
+    "prerequisites": []
   },
   {
     "code": "MUA3216",
@@ -32838,8 +30351,7 @@
     "creditCount": 2.0,
     "preclusions": [],
     "prerequisites": [
-      "MUA2240",
-      "MUA2155"
+      "MUA2240"
     ]
   },
   {
@@ -32849,7 +30361,6 @@
     "preclusions": [],
     "prerequisites": [
       "MUA2241",
-      "MUA2155",
       "MUA2242",
       "MUA2243"
     ]
@@ -32861,7 +30372,6 @@
     "preclusions": [],
     "prerequisites": [
       "MUA2242",
-      "MUA2155",
       "MUA2241",
       "MUA2243"
     ]
@@ -32873,7 +30383,6 @@
     "preclusions": [],
     "prerequisites": [
       "MUA2243",
-      "MUA2155",
       "MUA2241",
       "MUA2242"
     ]
@@ -32925,9 +30434,7 @@
     "name": "Composition Major Study 4A",
     "creditCount": 8.0,
     "preclusions": [],
-    "prerequisites": [
-      "MUA3102"
-    ]
+    "prerequisites": []
   },
   {
     "code": "MUA4107",
@@ -33021,7 +30528,6 @@
     "preclusions": [],
     "prerequisites": [
       "MUA1170",
-      "MUA1171",
       "MUA2170",
       "MUA2170"
     ]
@@ -33064,8 +30570,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MUA4203",
-      "MUA4204"
+      "MUA4203"
     ]
   },
   {
@@ -33241,9 +30746,7 @@
     "name": "Modern Music",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "MUT2118"
-    ]
+    "prerequisites": []
   },
   {
     "code": "MUT3214",
@@ -33259,9 +30762,7 @@
     "name": "Fundamentals of Composition",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "MUT1121"
-    ]
+    "prerequisites": []
   },
   {
     "code": "MUT3221",
@@ -33326,8 +30827,7 @@
     "name": "Communications, New Media and Society",
     "creditCount": 4.0,
     "preclusions": [
-      "NM1101E",
-      "NM1101FC"
+      "NM1101E"
     ],
     "prerequisites": []
   },
@@ -33454,9 +30954,7 @@
     "code": "NM3203",
     "name": "Copyright and New Media",
     "creditCount": 4.0,
-    "preclusions": [
-      "NM3880A"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -33470,9 +30968,7 @@
     "code": "NM3211",
     "name": "News Reporting and Editing",
     "creditCount": 4.0,
-    "preclusions": [
-      "NM2221"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "NM2220"
     ]
@@ -33541,9 +31037,7 @@
     "code": "NM3233",
     "name": "Strategic Communication: Applications",
     "creditCount": 4.0,
-    "preclusions": [
-      "NM3220"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -33551,7 +31045,6 @@
     "name": "Health Communication",
     "creditCount": 4.0,
     "preclusions": [
-      "NM4880D",
       "NM4220"
     ],
     "prerequisites": []
@@ -33577,7 +31070,6 @@
     "name": "Communications & New Media Internship",
     "creditCount": 12.0,
     "preclusions": [
-      "NM3550",
       "INM3550"
     ],
     "prerequisites": []
@@ -33593,11 +31085,8 @@
     "code": "NM4102",
     "name": "Advanced Communications & New Media Research",
     "creditCount": 5.0,
-    "preclusions": [
-      "NM4101"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "NM2102",
       "NM2103",
       "NM2104",
       "NM2101",
@@ -33610,9 +31099,7 @@
     "name": "Infocomm Technology Policy",
     "creditCount": 5.0,
     "preclusions": [
-      "IF5203",
-      "NM5203",
-      "NM5203R"
+      "NM5203"
     ],
     "prerequisites": []
   },
@@ -33692,9 +31179,7 @@
     "code": "NM4238",
     "name": "Software Studies",
     "creditCount": 5.0,
-    "preclusions": [
-      "NM3238"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -33712,9 +31197,7 @@
       "NM4660"
     ],
     "prerequisites": [
-      "NM4101",
       "NM4102",
-      "NM4101",
       "NM4102"
     ]
   },
@@ -33775,27 +31258,21 @@
     "code": "NM5204",
     "name": "Computer-Mediated Environments",
     "creditCount": 4.0,
-    "preclusions": [
-      "IF5204"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "NM5204R",
     "name": "Computer-Mediated Environments",
     "creditCount": 5.0,
-    "preclusions": [
-      "IF5204"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "NM5660",
     "name": "Independent Study",
     "creditCount": 4.0,
-    "preclusions": [
-      "IF5660"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -33823,9 +31300,7 @@
     "code": "NM6660",
     "name": "Independent Study",
     "creditCount": 4.0,
-    "preclusions": [
-      "IF6660"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -33839,9 +31314,7 @@
     "code": "NUR1107A",
     "name": "Nursing Practice Experience 1.1",
     "creditCount": 2.0,
-    "preclusions": [
-      "NUR1107"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -33863,9 +31336,7 @@
     "name": "Anatomy and Physiology I",
     "creditCount": 4.0,
     "preclusions": [
-      "AY1104",
-      "PY1105",
-      "PY1106"
+      "PY1105"
     ],
     "prerequisites": []
   },
@@ -33874,9 +31345,7 @@
     "name": "Anatomy and Physiology II",
     "creditCount": 4.0,
     "preclusions": [
-      "AY1104",
-      "PY1105",
-      "PY1106"
+      "PY1105"
     ],
     "prerequisites": []
   },
@@ -33884,21 +31353,16 @@
     "code": "NUR1119",
     "name": "Medical-Surgical Nursing I",
     "creditCount": 4.0,
-    "preclusions": [
-      "NUR2114"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "NUR1114",
-      "NUR1108"
+      "NUR1114"
     ]
   },
   {
     "code": "NUR1121",
     "name": "Pathophysiology and Pharmacology for Nurses I",
     "creditCount": 4.0,
-    "preclusions": [
-      "NUR2117"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -33912,9 +31376,7 @@
     "code": "NUR1201C",
     "name": "Health Continuum for Older Adults",
     "creditCount": 4.0,
-    "preclusions": [
-      "NUR1113"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -33928,18 +31390,14 @@
     "code": "NUR2106A",
     "name": "Nursing Practice Experience 2.1",
     "creditCount": 2.0,
-    "preclusions": [
-      "NUR2106"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "NUR2107A",
     "name": "Nursing Practice Experience 2.2",
     "creditCount": 8.0,
-    "preclusions": [
-      "NUR2107"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -33947,9 +31405,7 @@
     "name": "Mental Health Nursing",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "NUR1116"
-    ]
+    "prerequisites": []
   },
   {
     "code": "NUR2118",
@@ -33973,9 +31429,7 @@
     "code": "NUR2122",
     "name": "Psychology for Nurses",
     "creditCount": 4.0,
-    "preclusions": [
-      "NUR1116"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -33983,7 +31437,6 @@
     "name": "Pathophysiology, Pharmacology and Nursing Practice II",
     "creditCount": 8.0,
     "preclusions": [
-      "NUR2116",
       "NUR2118"
     ],
     "prerequisites": []
@@ -33992,18 +31445,14 @@
     "code": "NUR2204C",
     "name": "Women and Children Health",
     "creditCount": 4.0,
-    "preclusions": [
-      "NUR2121"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "NUR3105A",
     "name": "Nursing Practice Experience 3.1",
     "creditCount": 2.0,
-    "preclusions": [
-      "NUR3105"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -34024,9 +31473,7 @@
     "code": "NUR3116A",
     "name": "Transition to Professional Practice Experience",
     "creditCount": 10.0,
-    "preclusions": [
-      "NUR3116"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -34049,28 +31496,21 @@
     "code": "NUR3202C",
     "name": "Research and Evidence-based Healthcare",
     "creditCount": 4.0,
-    "preclusions": [
-      "NUR3109"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "NUR4101B",
     "name": "Evidence-based Health Care Practice",
     "creditCount": 6.0,
-    "preclusions": [
-      "NUR4101"
-    ],
-    "prerequisites": [
-      "NUR3109"
-    ]
+    "preclusions": [],
+    "prerequisites": []
   },
   {
     "code": "NUR4103B",
     "name": "Applied Research Methods",
     "creditCount": 6.0,
     "preclusions": [
-      "NUR4103",
       "NUR4103A"
     ],
     "prerequisites": []
@@ -34079,11 +31519,8 @@
     "code": "NUR4104B",
     "name": "Honours Project in Nursing",
     "creditCount": 14.0,
-    "preclusions": [
-      "NUR4104"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "NUR4102A",
       "NUR4103A"
     ]
   },
@@ -34184,7 +31621,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "NUR5601",
       "NUR5602"
     ]
   },
@@ -34194,7 +31630,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "NUR5601",
       "NUR5602"
     ]
   },
@@ -34211,7 +31646,6 @@
     "creditCount": 8.0,
     "preclusions": [],
     "prerequisites": [
-      "NUR5601",
       "NUR5602"
     ]
   },
@@ -34312,9 +31746,7 @@
     "code": "OT5202",
     "name": "Analysis & Design of Offshore Structures",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE5202"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE2155"
     ]
@@ -34325,9 +31757,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "OT5201",
       "AY2011",
-      "CE5887",
       "AY2010"
     ]
   },
@@ -34337,8 +31767,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CE5307",
-      "OT5201"
+      "CE5307"
     ]
   },
   {
@@ -34366,9 +31795,7 @@
     "code": "OT5206",
     "name": "Offshore Foundations",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE5206"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "CE2112"
     ]
@@ -34464,9 +31891,7 @@
     "name": "Basic Pharmacology",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "NUR5102"
-    ]
+    "prerequisites": []
   },
   {
     "code": "PA2131",
@@ -34481,13 +31906,11 @@
     "creditCount": 4.0,
     "preclusions": [
       "PC1431",
-      "PC1431FC",
       "PC1431X",
       "PC1433"
     ],
     "prerequisites": [
       "PC1221",
-      "PC1221FC",
       "PC1221X",
       "PC1222",
       "PC1222X"
@@ -34499,12 +31922,10 @@
     "creditCount": 4.0,
     "preclusions": [
       "PC1431",
-      "PC1431FC",
       "PC1431X"
     ],
     "prerequisites": [
       "PC1221",
-      "PC1221FC",
       "PC1221X",
       "PC1222",
       "PC1222X"
@@ -34515,12 +31936,10 @@
     "name": "Introduction to Electricity & Magnetism",
     "creditCount": 4.0,
     "preclusions": [
-      "PC1432",
-      "PC1432X"
+      "PC1432"
     ],
     "prerequisites": [
       "PC1221",
-      "PC1221FC",
       "PC1221X",
       "PC1222",
       "PC1222X"
@@ -34531,12 +31950,10 @@
     "name": "Introduction to Modern Physics",
     "creditCount": 4.0,
     "preclusions": [
-      "PC1432",
-      "PC1432X"
+      "PC1432"
     ],
     "prerequisites": [
       "PC1221",
-      "PC1221FC",
       "PC1221X",
       "PC1222",
       "PC1222X"
@@ -34550,9 +31967,7 @@
       "PC1141",
       "PC1142",
       "PC1431",
-      "PC1431FC",
       "PC1431X",
-      "PC1221FC",
       "PC1221X"
     ],
     "prerequisites": []
@@ -34565,10 +31980,8 @@
       "PC1141",
       "PC1142",
       "PC1431",
-      "PC1431FC",
       "PC1431X",
-      "PC1221",
-      "PC1221FC"
+      "PC1221"
     ],
     "prerequisites": []
   },
@@ -34579,8 +31992,7 @@
     "preclusions": [
       "PC1143",
       "PC1144",
-      "PC1432",
-      "PC1432X"
+      "PC1432"
     ],
     "prerequisites": []
   },
@@ -34592,8 +32004,7 @@
       "PC1222",
       "PC1143",
       "PC1144",
-      "PC1432",
-      "PC1432X"
+      "PC1432"
     ],
     "prerequisites": []
   },
@@ -34601,9 +32012,7 @@
     "code": "PC1322",
     "name": "Understanding the Universe",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEH1031"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -34621,12 +32030,10 @@
       "PC1141",
       "PC1142",
       "PC1433",
-      "PC1431FC",
       "PC1431X"
     ],
     "prerequisites": [
       "PC1221",
-      "PC1221FC",
       "PC1221X",
       "PC1222",
       "PC1222X"
@@ -34638,12 +32045,10 @@
     "creditCount": 4.0,
     "preclusions": [
       "PC1143",
-      "PC1144",
-      "PC1432X"
+      "PC1144"
     ],
     "prerequisites": [
       "PC1221",
-      "PC1221FC",
       "PC1221X",
       "PC1222",
       "PC1222X"
@@ -34656,7 +32061,6 @@
     "preclusions": [
       "PC1141",
       "PC1431",
-      "PC1431FC",
       "PC1431X"
     ],
     "prerequisites": []
@@ -34684,7 +32088,6 @@
     "prerequisites": [
       "PC1144",
       "PC1432",
-      "PC1432X",
       "MA1101R",
       "MA1513",
       "MA1508E",
@@ -34704,7 +32107,6 @@
     "prerequisites": [
       "PC1144",
       "PC1432",
-      "PC1432X",
       "PC1433"
     ]
   },
@@ -34716,7 +32118,6 @@
     "prerequisites": [
       "PC1144",
       "PC1432",
-      "PC1432X",
       "MA1101R",
       "MA1513",
       "MA1508E",
@@ -34734,7 +32135,6 @@
     "prerequisites": [
       "PC1144",
       "PC1432",
-      "PC1432X",
       "MA1101R",
       "MA1513",
       "MA1508E",
@@ -34778,10 +32178,8 @@
       "PC1143",
       "PC1144",
       "PC1431",
-      "PC1431FC",
       "PC1431X",
       "PC1432",
-      "PC1432X",
       "PC1433"
     ]
   },
@@ -34794,7 +32192,6 @@
       "PC1142",
       "PC1144",
       "PC1431",
-      "PC1431FC",
       "PC1431X",
       "MA1102R"
     ]
@@ -34804,9 +32201,7 @@
     "name": "Physics for Electrical Engineers",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "EE2011"
-    ]
+    "prerequisites": []
   },
   {
     "code": "PC2239",
@@ -34823,7 +32218,6 @@
     "prerequisites": [
       "PC1143",
       "PC1432",
-      "PC1432X",
       "PC1421"
     ]
   },
@@ -34871,9 +32265,7 @@
     "code": "PC3231",
     "name": "Electricity & Magnetism II",
     "creditCount": 4.0,
-    "preclusions": [
-      "ESP2104"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PC2131"
     ]
@@ -34900,7 +32292,6 @@
     "prerequisites": [
       "PC1144",
       "PC1432",
-      "PC1432X",
       "PC2232",
       "PC2020",
       "PC2130B"
@@ -34921,7 +32312,6 @@
     "name": "Solid State Physics I",
     "creditCount": 4.0,
     "preclusions": [
-      "EE3406",
       "PC2133"
     ],
     "prerequisites": [
@@ -34959,16 +32349,12 @@
     "code": "PC3241",
     "name": "Solid State Devices",
     "creditCount": 4.0,
-    "preclusions": [
-      "EE2004"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PC2131",
-      "PC2231",
       "PC3235",
       "MLE2104",
-      "PC2133",
-      "EE2005"
+      "PC2133"
     ]
   },
   {
@@ -34978,12 +32364,10 @@
     "preclusions": [],
     "prerequisites": [
       "PC2131",
-      "PC2231",
       "PC3130",
       "PC3241",
       "PC3235",
-      "PC2133",
-      "EE2005"
+      "PC2133"
     ]
   },
   {
@@ -35000,12 +32384,9 @@
     "code": "PC3247",
     "name": "Modern Optics",
     "creditCount": 4.0,
-    "preclusions": [
-      "PC2231"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "PC2131",
-      "EE2005"
+      "PC2131"
     ]
   },
   {
@@ -35024,8 +32405,7 @@
     "preclusions": [],
     "prerequisites": [
       "PC2131",
-      "PC2267",
-      "EE2011"
+      "PC2267"
     ]
   },
   {
@@ -35065,18 +32445,14 @@
     "code": "PC3311",
     "name": "Undergraduate Professional Internship",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3311"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "PC3312",
     "name": "Enhanced Undergraduate Professional Internship Programme",
     "creditCount": 12.0,
-    "preclusions": [
-      "XX3312"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -35106,9 +32482,7 @@
     "code": "PC4230",
     "name": "Quantum Mechanics III",
     "creditCount": 4.0,
-    "preclusions": [
-      "PC4130"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PC3130"
     ]
@@ -35200,13 +32574,10 @@
     "code": "PC4253",
     "name": "Thin Film Technology",
     "creditCount": 4.0,
-    "preclusions": [
-      "MLE5201"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PC3235",
-      "PC3241",
-      "PC3242"
+      "PC3241"
     ]
   },
   {
@@ -35216,10 +32587,8 @@
     "preclusions": [],
     "prerequisites": [
       "PC3130",
-      "PC3242",
       "EE2004",
-      "EE3431C",
-      "EE2143"
+      "EE3431C"
     ]
   },
   {
@@ -35298,9 +32667,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PC4130",
-      "PC4230",
-      "PC5201"
+      "PC4230"
     ]
   },
   {
@@ -35309,9 +32676,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PC4244",
-      "PC4212",
-      "PC4261"
+      "PC4212"
     ]
   },
   {
@@ -35330,9 +32695,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PC4130",
       "PC4240",
-      "PC4201",
       "PC4214"
     ]
   },
@@ -35342,8 +32705,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PC4267",
-      "PC4268"
+      "PC4267"
     ]
   },
   {
@@ -35419,9 +32781,7 @@
     "code": "PF1106",
     "name": "Introduction to Measurement",
     "creditCount": 4.0,
-    "preclusions": [
-      "PF1102"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -35437,9 +32797,7 @@
     "code": "PF1108",
     "name": "Introduction to Building Performance",
     "creditCount": 4.0,
-    "preclusions": [
-      "PF1104"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -35497,9 +32855,7 @@
     "code": "PF2110",
     "name": "Fundamentals of Facilities Management",
     "creditCount": 4.0,
-    "preclusions": [
-      "PF1105"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -35520,9 +32876,7 @@
     "code": "PF2205",
     "name": "Project Finance",
     "creditCount": 4.0,
-    "preclusions": [
-      "PF2204"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -35530,7 +32884,6 @@
     "name": "Operations and Maintenance Management",
     "creditCount": 4.0,
     "preclusions": [
-      "PF4309",
       "AY2018"
     ],
     "prerequisites": []
@@ -35540,8 +32893,7 @@
     "name": "Event Management",
     "creditCount": 4.0,
     "preclusions": [
-      "PF4307",
-      "AY2017"
+      "PF4307"
     ],
     "prerequisites": []
   },
@@ -35550,8 +32902,7 @@
     "name": "Event Management Case Studies",
     "creditCount": 4.0,
     "preclusions": [
-      "PF4308",
-      "AY2017"
+      "PF4308"
     ],
     "prerequisites": []
   },
@@ -35567,8 +32918,7 @@
     "name": "Structural Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "PF2102",
-      "AY2018"
+      "PF2102"
     ],
     "prerequisites": []
   },
@@ -35591,7 +32941,6 @@
     "name": "M&E Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "PF2104",
       "PF2503"
     ],
     "prerequisites": []
@@ -35602,9 +32951,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PF2503",
       "PF2505",
-      "AY2014",
       "AY2017"
     ]
   },
@@ -35616,7 +32963,6 @@
     "prerequisites": [
       "PF2102",
       "PF2501",
-      "AY2014",
       "AY2017"
     ]
   },
@@ -35625,9 +32971,7 @@
     "name": "Project Scheduling and Control",
     "creditCount": 4.0,
     "preclusions": [
-      "PF3101",
-      "PF3104",
-      "AY2018"
+      "PF3104"
     ],
     "prerequisites": []
   },
@@ -35651,9 +32995,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PF2503",
       "PF2505",
-      "AY2014",
       "AY2017"
     ]
   },
@@ -35672,7 +33014,6 @@
     "prerequisites": [
       "PF2102",
       "PF2501",
-      "AY2014",
       "AY2017"
     ]
   },
@@ -35709,7 +33050,6 @@
     "name": "Safety, Health and Environmental Mgt",
     "creditCount": 4.0,
     "preclusions": [
-      "PF4208",
       "AY2018"
     ],
     "prerequisites": []
@@ -35733,7 +33073,6 @@
     "name": "Project Risk Management",
     "creditCount": 4.0,
     "preclusions": [
-      "PF3104",
       "AY2018"
     ],
     "prerequisites": []
@@ -35743,7 +33082,6 @@
     "name": "Strategic Facilities Management",
     "creditCount": 4.0,
     "preclusions": [
-      "PF3307",
       "AY2018"
     ],
     "prerequisites": []
@@ -35753,7 +33091,6 @@
     "name": "Green Development",
     "creditCount": 4.0,
     "preclusions": [
-      "PF4502",
       "AY2018"
     ],
     "prerequisites": []
@@ -35770,8 +33107,7 @@
     "name": "Event Management",
     "creditCount": 4.0,
     "preclusions": [
-      "PF2305",
-      "AY2018"
+      "PF2305"
     ],
     "prerequisites": []
   },
@@ -35780,8 +33116,7 @@
     "name": "Event Management Case Studies",
     "creditCount": 4.0,
     "preclusions": [
-      "PF2306",
-      "AY2018"
+      "PF2306"
     ],
     "prerequisites": []
   },
@@ -35854,7 +33189,6 @@
     "name": "Greek Philosophy (Socrates and Plato)",
     "creditCount": 4.0,
     "preclusions": [
-      "PH3209",
       "GEK2036"
     ],
     "prerequisites": []
@@ -35863,18 +33197,14 @@
     "code": "PH2241",
     "name": "Philosophy of Mind",
     "creditCount": 4.0,
-    "preclusions": [
-      "PH3212"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "PH2242",
     "name": "Philosophy of Language",
     "creditCount": 4.0,
-    "preclusions": [
-      "PH3210"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -35912,9 +33242,7 @@
     "preclusions": [],
     "prerequisites": [
       "PH2241",
-      "PH3212",
-      "PH2242",
-      "PH3210"
+      "PH2242"
     ]
   },
   {
@@ -35923,7 +33251,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PH2110",
       "GEM2006"
     ]
   },
@@ -35933,9 +33260,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PH2111",
-      "GEK2048",
-      "PH2243"
+      "GEK2048"
     ]
   },
   {
@@ -35968,9 +33293,7 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "PH2301",
       "PH2302",
-      "PH2301",
       "PH2302"
     ]
   },
@@ -36110,9 +33433,7 @@
     "code": "PL2131",
     "name": "Research and Statistical Methods I",
     "creditCount": 4.0,
-    "preclusions": [
-      "UQF2101B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -36249,9 +33570,7 @@
     "code": "PL3252",
     "name": "Social-Cognitive Perspectives on Emotion",
     "creditCount": 4.0,
-    "preclusions": [
-      "PL3880B"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PL1101E",
       "PL3235"
@@ -36293,9 +33612,7 @@
     "code": "PL3260",
     "name": "Moral Development",
     "creditCount": 4.0,
-    "preclusions": [
-      "YSS4221"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PL1101E",
       "PL2131",
@@ -36420,9 +33737,7 @@
     "code": "PL4201",
     "name": "Psychometrics and Psychological Testing",
     "creditCount": 5.0,
-    "preclusions": [
-      "PL5223"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PL1101E",
       "PL2131",
@@ -36520,9 +33835,7 @@
     "code": "PL4219",
     "name": "Advanced Abnormal Psychology",
     "creditCount": 5.0,
-    "preclusions": [
-      "PL4880A"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PL1101E",
       "PL2131",
@@ -36664,9 +33977,7 @@
     "code": "PL4233",
     "name": "Psychology of Negotiation",
     "creditCount": 5.0,
-    "preclusions": [
-      "SW3208"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PL1101E",
       "PL2131",
@@ -36754,9 +34065,7 @@
     "code": "PL4239",
     "name": "Social Psychology of the Unconscious",
     "creditCount": 5.0,
-    "preclusions": [
-      "PL4880I"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PL1101E",
       "PL2131",
@@ -36964,11 +34273,9 @@
     "name": "Analysis Of Psychological Data Using Glm",
     "creditCount": 4.0,
     "preclusions": [
-      "PL5102",
       "PL6102"
     ],
     "prerequisites": [
-      "PL2101Y",
       "PL2131",
       "PL2132"
     ]
@@ -36978,11 +34285,9 @@
     "name": "Analysis of Psychological Data using GLM",
     "creditCount": 5.0,
     "preclusions": [
-      "PL5102",
       "PL6102"
     ],
     "prerequisites": [
-      "PL2101Y",
       "PL2131",
       "PL2132"
     ]
@@ -36991,13 +34296,9 @@
     "code": "PL5222",
     "name": "Multivariate Statistics in Psychology",
     "creditCount": 4.0,
-    "preclusions": [
-      "PL4204"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "PL2101Y",
       "PL2131",
-      "PL2102Y",
       "PL2132"
     ]
   },
@@ -37005,13 +34306,9 @@
     "code": "PL5222R",
     "name": "Multivariate Statistics in Psychology",
     "creditCount": 5.0,
-    "preclusions": [
-      "PL4204"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "PL2101Y",
       "PL2131",
-      "PL2102Y",
       "PL2132"
     ]
   },
@@ -37021,9 +34318,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PL2101Y",
       "PL2131",
-      "PL2102Y",
       "PL2132",
       "PL5221"
     ]
@@ -37034,9 +34329,7 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "PL2101Y",
       "PL2131",
-      "PL2102Y",
       "PL2132",
       "PL5221"
     ]
@@ -37045,9 +34338,7 @@
     "code": "PL5305",
     "name": "Advanced Social Psychology",
     "creditCount": 4.0,
-    "preclusions": [
-      "PL6223"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PL3235"
     ]
@@ -37056,9 +34347,7 @@
     "code": "PL5305R",
     "name": "Advanced Social Psychology",
     "creditCount": 5.0,
-    "preclusions": [
-      "PL6223"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PL3235"
     ]
@@ -37067,45 +34356,35 @@
     "code": "PL5306",
     "name": "Advanced Clinical Psychology",
     "creditCount": 4.0,
-    "preclusions": [
-      "PL6210"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "PL5306R",
     "name": "Advanced Clinical Psychology",
     "creditCount": 5.0,
-    "preclusions": [
-      "PL6210"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "PL5308",
     "name": "Advanced Social and Cognitive Neuroscience",
     "creditCount": 4.0,
-    "preclusions": [
-      "PL6204"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "PL5308R",
     "name": "Advanced Social and Cognitive Neuroscience",
     "creditCount": 5.0,
-    "preclusions": [
-      "PL6204"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "PL5660",
     "name": "Independent Study",
     "creditCount": 4.0,
-    "preclusions": [
-      "PL5220"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -37127,9 +34406,7 @@
     "name": "Independent Study",
     "creditCount": 4.0,
     "preclusions": [
-      "PL6220",
-      "PL6220A",
-      "PL6220B"
+      "PL6220A"
     ],
     "prerequisites": []
   },
@@ -37201,9 +34478,7 @@
     "name": "Ethics and Professional Issues",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "PLC5011"
-    ]
+    "prerequisites": []
   },
   {
     "code": "PLC5007",
@@ -37211,7 +34486,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PLC5011",
       "PLC5004"
     ]
   },
@@ -37258,9 +34532,7 @@
     "name": "Clinical Placement 3",
     "creditCount": 6.0,
     "preclusions": [],
-    "prerequisites": [
-      "PLC5012"
-    ]
+    "prerequisites": []
   },
   {
     "code": "PLS8001",
@@ -37597,9 +34869,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PP5101",
-      "PP5301",
-      "PP5501"
+      "PP5301"
     ]
   },
   {
@@ -37608,7 +34878,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PP5101",
       "PP5102"
     ]
   },
@@ -37617,7 +34886,6 @@
     "name": "Changes in Singapore Political Economy",
     "creditCount": 4.0,
     "preclusions": [
-      "EC2373",
       "SSA2220"
     ],
     "prerequisites": []
@@ -37633,9 +34901,7 @@
     "code": "PP5217",
     "name": "Innovation",
     "creditCount": 4.0,
-    "preclusions": [
-      "PP5242M"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -37997,17 +35263,13 @@
     "name": "The Economics of Public Policy",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "PP5101"
-    ]
+    "prerequisites": []
   },
   {
     "code": "PP6705",
     "name": "The Politics of Public Policy",
     "creditCount": 4.0,
-    "preclusions": [
-      "PP5268"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -38015,9 +35277,7 @@
     "name": "Quantitative Methods for Public Policy Research",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "PP6701"
-    ]
+    "prerequisites": []
   },
   {
     "code": "PP6707",
@@ -38090,9 +35350,7 @@
     "code": "PR1301",
     "name": "Complementary Medicine and Health",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEK1507"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -38277,9 +35535,7 @@
     "code": "PR3202",
     "name": "Community Health & Preventative Care",
     "creditCount": 4.0,
-    "preclusions": [
-      "PR3122"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "PR2134"
     ]
@@ -38327,12 +35583,9 @@
     "code": "PR4196",
     "name": "Pharmacy Research Project and Scientific Communication",
     "creditCount": 16.0,
-    "preclusions": [
-      "PR4199"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "ES1000",
-      "ES1102",
       "ES1103"
     ]
   },
@@ -38365,9 +35618,7 @@
     "name": "Pharmaceutical Marketing",
     "creditCount": 4.0,
     "preclusions": [
-      "BH1003",
-      "MKT1003",
-      "CS3261"
+      "MKT1003"
     ],
     "prerequisites": [
       "PR1140"
@@ -38495,9 +35746,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PR2104",
-      "PR2143",
-      "PR4203"
+      "PR2143"
     ]
   },
   {
@@ -38506,7 +35755,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PR3101",
       "PR2115"
     ]
   },
@@ -38542,9 +35790,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PR2101",
       "PR3102",
-      "PR4106",
       "PR3117",
       "PR3301"
     ]
@@ -38555,9 +35801,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PR2101",
       "PR3102",
-      "PR4106",
       "PR3117",
       "PR3301"
     ]
@@ -38569,7 +35813,6 @@
     "preclusions": [],
     "prerequisites": [
       "PR2122",
-      "PR3104",
       "PR3301"
     ]
   },
@@ -38579,8 +35822,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PR2122",
-      "PR3104"
+      "PR2122"
     ]
   },
   {
@@ -38589,11 +35831,9 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "PR5115",
       "PR3106",
       "PR3116",
       "LSM3211",
-      "LSM4212",
       "LSM4211"
     ]
   },
@@ -38644,9 +35884,7 @@
     "name": "Introduction to Politics",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM1003K",
-      "GEK1003",
-      "PS1101"
+      "GEK1003"
     ],
     "prerequisites": []
   },
@@ -38655,9 +35893,7 @@
     "name": "Ancient Western Political Thought",
     "creditCount": 4.0,
     "preclusions": [
-      "PS2231",
       "EU2218",
-      "PS2201B",
       "PS2218",
       "EU2203"
     ],
@@ -38676,9 +35912,7 @@
     "code": "PS2234",
     "name": "Introduction to Comparative Politics",
     "creditCount": 4.0,
-    "preclusions": [
-      "PS2204B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -38686,7 +35920,6 @@
     "name": "Introduction to International Relations",
     "creditCount": 4.0,
     "preclusions": [
-      "PS2207",
       "PS2207B"
     ],
     "prerequisites": []
@@ -38695,9 +35928,7 @@
     "code": "PS2240",
     "name": "Introduction to Public Administration",
     "creditCount": 4.0,
-    "preclusions": [
-      "PS2210B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -38714,7 +35945,6 @@
     "name": "Southeast Asian Politics",
     "creditCount": 4.0,
     "preclusions": [
-      "PS2215B",
       "SE2213"
     ],
     "prerequisites": []
@@ -38724,11 +35954,8 @@
     "name": "South Asian Politics",
     "creditCount": 4.0,
     "preclusions": [
-      "PS2214B",
       "PS2217B",
-      "PS3217B",
-      "SN2211",
-      "SN3221"
+      "SN2211"
     ],
     "prerequisites": []
   },
@@ -38737,7 +35964,6 @@
     "name": "Chinese Politics",
     "creditCount": 4.0,
     "preclusions": [
-      "PS3205B",
       "PS3250"
     ],
     "prerequisites": []
@@ -38748,11 +35974,8 @@
     "creditCount": 4.0,
     "preclusions": [
       "GEK2003",
-      "GEM2003K",
       "PS1102",
-      "PS2101",
       "PS2101B",
-      "SS2209PS",
       "SSA2209"
     ],
     "prerequisites": []
@@ -38791,9 +36014,7 @@
     "code": "PS3232",
     "name": "Democratic Theory",
     "creditCount": 4.0,
-    "preclusions": [
-      "PS3202B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -38801,7 +36022,6 @@
     "name": "Ethnicity and Religion in Asian Politics",
     "creditCount": 4.0,
     "preclusions": [
-      "PS3201",
       "PS3206B"
     ],
     "prerequisites": []
@@ -38810,9 +36030,7 @@
     "code": "PS3237",
     "name": "Women and Politics",
     "creditCount": 4.0,
-    "preclusions": [
-      "PS3207B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -38820,9 +36038,7 @@
     "name": "International Political Economy",
     "creditCount": 4.0,
     "preclusions": [
-      "GEK3001",
       "GEM3001K",
-      "PS3207",
       "PS3208B"
     ],
     "prerequisites": []
@@ -38831,9 +36047,7 @@
     "code": "PS3240",
     "name": "International Security",
     "creditCount": 4.0,
-    "preclusions": [
-      "PS3210B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -38841,9 +36055,7 @@
     "name": "Singapore's Foreign Policy",
     "creditCount": 4.0,
     "preclusions": [
-      "PS3219B",
-      "SSA3205",
-      "SS3205PS"
+      "SSA3205"
     ],
     "prerequisites": []
   },
@@ -38852,7 +36064,6 @@
     "name": "International and Regional Organisations",
     "creditCount": 4.0,
     "preclusions": [
-      "PS3254",
       "EU3228"
     ],
     "prerequisites": [
@@ -38865,9 +36076,7 @@
     "name": "Political Inquiry",
     "creditCount": 4.0,
     "preclusions": [
-      "PS2102",
-      "PS2102B",
-      "PS2231B"
+      "PS2102B"
     ],
     "prerequisites": []
   },
@@ -38915,8 +36124,7 @@
     "name": "International Ethics",
     "creditCount": 4.0,
     "preclusions": [
-      "YSS3270",
-      "PS3233"
+      "YSS3270"
     ],
     "prerequisites": []
   },
@@ -38924,9 +36132,7 @@
     "code": "PS3550",
     "name": "Political Science Internship",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3550"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -38985,7 +36191,6 @@
     "name": "Comparative Political Thought",
     "creditCount": 5.0,
     "preclusions": [
-      "PS3201B",
       "PS3231"
     ],
     "prerequisites": []
@@ -38994,9 +36199,7 @@
     "code": "PS4224",
     "name": "State and Society",
     "creditCount": 5.0,
-    "preclusions": [
-      "PS4204"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -39017,9 +36220,7 @@
     "code": "PS4231",
     "name": "Social Theory and International Relations",
     "creditCount": 5.0,
-    "preclusions": [
-      "PS3880B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -39057,9 +36258,7 @@
     "code": "PS4311",
     "name": "International Relations in Political Thought",
     "creditCount": 5.0,
-    "preclusions": [
-      "PS4213"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -39076,8 +36275,7 @@
     "name": "Independent Study",
     "creditCount": 5.0,
     "preclusions": [
-      "PS4401",
-      "PS4401S"
+      "PS4401"
     ],
     "prerequisites": []
   },
@@ -39128,7 +36326,6 @@
     "name": "Research Design In Political Science",
     "creditCount": 4.0,
     "preclusions": [
-      "PS5101",
       "PS6101"
     ],
     "prerequisites": []
@@ -39138,7 +36335,6 @@
     "name": "Research Design in Political Science",
     "creditCount": 5.0,
     "preclusions": [
-      "PS5101",
       "PS6101"
     ],
     "prerequisites": []
@@ -39148,11 +36344,8 @@
     "name": "Seminar In International Relations",
     "creditCount": 4.0,
     "preclusions": [
-      "IZ5102",
       "PS5208",
-      "PS6208",
-      "PS6301A",
-      "PS6401"
+      "PS6301A"
     ],
     "prerequisites": []
   },
@@ -39161,11 +36354,8 @@
     "name": "Seminar in Int'l Relations",
     "creditCount": 5.0,
     "preclusions": [
-      "IZ5102",
       "PS5208",
-      "PS6208",
-      "PS6301A",
-      "PS6401"
+      "PS6301A"
     ],
     "prerequisites": []
   },
@@ -39245,11 +36435,9 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "MA1104",
       "MA1505",
       "MA1507",
       "MA2104",
-      "MA2222",
       "QF2101",
       "MA3269"
     ]
@@ -39258,27 +36446,21 @@
     "code": "QF3310",
     "name": "Undergraduate Professional Internship Programme",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3310"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "QF3311",
     "name": "Undergraduate Professional Internship",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3311"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "QF3312",
     "name": "Enhanced Undergraduate Professional Internship Programme",
     "creditCount": 12.0,
-    "preclusions": [
-      "XX3312"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -39377,9 +36559,7 @@
     "code": "RE1701",
     "name": "Urban Land Use and Development",
     "creditCount": 4.0,
-    "preclusions": [
-      "RE1102"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -39413,36 +36593,28 @@
     "code": "RE1705",
     "name": "Real Estate Finance and Accounting",
     "creditCount": 4.0,
-    "preclusions": [
-      "RE1101"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "RE1706",
     "name": "Design and Construction",
     "creditCount": 4.0,
-    "preclusions": [
-      "RE1105"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "RE1901",
     "name": "Real Estate Wealth Management",
     "creditCount": 4.0,
-    "preclusions": [
-      "RE1301"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "RE2301",
     "name": "GIS for Real Estate",
     "creditCount": 4.0,
-    "preclusions": [
-      "RE3490"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -39450,7 +36622,6 @@
     "name": "Urban Planning",
     "creditCount": 4.0,
     "preclusions": [
-      "RE2103",
       "AR2223"
     ],
     "prerequisites": [
@@ -39461,9 +36632,7 @@
     "code": "RE2702",
     "name": "Land Law",
     "creditCount": 4.0,
-    "preclusions": [
-      "RE2105"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "RE1703"
     ]
@@ -39472,9 +36641,7 @@
     "code": "RE2704",
     "name": "Introduction to Real Estate Valuation",
     "creditCount": 4.0,
-    "preclusions": [
-      "RE1104"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -39482,7 +36649,6 @@
     "name": "Urban Economics",
     "creditCount": 4.0,
     "preclusions": [
-      "RE2102",
       "EC3381"
     ],
     "prerequisites": []
@@ -39491,18 +36657,14 @@
     "code": "RE2706",
     "name": "Real Estate and Infrastructure Finance",
     "creditCount": 4.0,
-    "preclusions": [
-      "RE2104"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "RE2707",
     "name": "Asset and Property Management",
     "creditCount": 4.0,
-    "preclusions": [
-      "RE1103"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "RE1706"
     ]
@@ -39537,30 +36699,21 @@
     "name": "Advanced Real Estate Valuation",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "RE2107"
-    ]
+    "prerequisites": []
   },
   {
     "code": "RE3102",
     "name": "Advanced Topics In Urban Planning",
     "creditCount": 4.0,
-    "preclusions": [
-      "RE4490"
-    ],
-    "prerequisites": [
-      "RE2103"
-    ]
+    "preclusions": [],
+    "prerequisites": []
   },
   {
     "code": "RE3103",
     "name": "Real Estate Development",
     "creditCount": 4.0,
-    "preclusions": [
-      "RE3381"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "RE2101",
       "RE2102"
     ]
   },
@@ -39568,12 +36721,8 @@
     "code": "RE3104",
     "name": "Real Estate Investment Analysis",
     "creditCount": 4.0,
-    "preclusions": [
-      "RE3281"
-    ],
-    "prerequisites": [
-      "RE2104"
-    ]
+    "preclusions": [],
+    "prerequisites": []
   },
   {
     "code": "RE3105",
@@ -39589,19 +36738,14 @@
     "name": "Residential Property Management",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "RE2106"
-    ]
+    "prerequisites": []
   },
   {
     "code": "RE3107",
     "name": "Real Estate Practice And Ethics",
     "creditCount": 4.0,
-    "preclusions": [
-      "RE4180"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "RE2104",
       "RE2107"
     ]
   },
@@ -39613,7 +36757,6 @@
       "RE2801"
     ],
     "prerequisites": [
-      "RE2101",
       "RE2104"
     ]
   },
@@ -39622,9 +36765,7 @@
     "name": "Real Estate Finance Law",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "RE2105"
-    ]
+    "prerequisites": []
   },
   {
     "code": "RE3212",
@@ -39640,9 +36781,7 @@
     "name": "Real Estate Development Law",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "RE2105"
-    ]
+    "prerequisites": []
   },
   {
     "code": "RE3222",
@@ -39657,21 +36796,15 @@
     "code": "RE4000",
     "name": "Dissertation",
     "creditCount": 8.0,
-    "preclusions": [
-      "RE4181"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "RE4001",
     "name": "Real Estate Case Study",
     "creditCount": 4.0,
-    "preclusions": [
-      "RE4182"
-    ],
-    "prerequisites": [
-      "RE4182"
-    ]
+    "preclusions": [],
+    "prerequisites": []
   },
   {
     "code": "RE4202",
@@ -39685,18 +36818,14 @@
     "name": "Topics in Real Estate (Summer Programme)",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "RE2101"
-    ]
+    "prerequisites": []
   },
   {
     "code": "RE4204",
     "name": "Advanced Real Estate Marketing",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "RE2106"
-    ]
+    "prerequisites": []
   },
   {
     "code": "RE4210",
@@ -39752,7 +36881,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "RE2102",
       "RE3102"
     ]
   },
@@ -39769,9 +36897,7 @@
     "code": "RE4301",
     "name": "Housing Markets and Housing Policies",
     "creditCount": 4.0,
-    "preclusions": [
-      "RE4291"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -40039,9 +37165,7 @@
     "code": "SC2214",
     "name": "Media and Culture",
     "creditCount": 4.0,
-    "preclusions": [
-      "IF2214"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -40164,8 +37288,7 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "SC2101",
-      "GL2104"
+      "SC2101"
     ]
   },
   {
@@ -40186,9 +37309,7 @@
     "code": "SC3213",
     "name": "Visual Ethnography: Theory and Practice",
     "creditCount": 4.0,
-    "preclusions": [
-      "IF3213"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -40251,9 +37372,7 @@
     "code": "SC3224",
     "name": "Theory and Practice in Cultural Studies",
     "creditCount": 4.0,
-    "preclusions": [
-      "XD3101"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -40365,36 +37484,28 @@
     "code": "SC4221",
     "name": "Comparative Analysis of Human Rights",
     "creditCount": 5.0,
-    "preclusions": [
-      "SC4208A"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SC4222",
     "name": "Body and Society",
     "creditCount": 5.0,
-    "preclusions": [
-      "SC4208B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SC4223",
     "name": "Health and Social Behaviour",
     "creditCount": 5.0,
-    "preclusions": [
-      "SC4214A"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SC4224",
     "name": "Welfare and Social Justice",
     "creditCount": 5.0,
-    "preclusions": [
-      "SC4215D"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -40440,9 +37551,7 @@
     "code": "SC4880",
     "name": "Selected Topics in Socio'gy & Anthrop'gy",
     "creditCount": 5.0,
-    "preclusions": [
-      "SC4208"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -40456,54 +37565,42 @@
     "code": "SC4881",
     "name": "Selected Topics in Health & Society",
     "creditCount": 5.0,
-    "preclusions": [
-      "SC4214"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SC4882",
     "name": "Issues in State and Society",
     "creditCount": 5.0,
-    "preclusions": [
-      "SC4215"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SC4882A",
     "name": "Perspectives on State & Society",
     "creditCount": 5.0,
-    "preclusions": [
-      "SC4215A"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SC4882B",
     "name": "Citizenship, Nation and Globalization",
     "creditCount": 5.0,
-    "preclusions": [
-      "SC4215B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SC4883",
     "name": "Selected Topics in Law and Justice",
     "creditCount": 5.0,
-    "preclusions": [
-      "SC4216"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SC5101",
     "name": "Graduate Research Methods",
     "creditCount": 4.0,
-    "preclusions": [
-      "SC6101"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -40517,27 +37614,21 @@
     "code": "SC5102",
     "name": "Quantitative Data Analysis",
     "creditCount": 4.0,
-    "preclusions": [
-      "SC6101"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SC5102R",
     "name": "Quantitative Data Analysis",
     "creditCount": 5.0,
-    "preclusions": [
-      "SC6101"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SC5219",
     "name": "Tourism: Culture, Society and the Environment",
     "creditCount": 4.0,
-    "preclusions": [
-      "SC5211D"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -40560,9 +37651,7 @@
     "code": "SC6212",
     "name": "Global Transformations",
     "creditCount": 4.0,
-    "preclusions": [
-      "SC6211A"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -40629,8 +37718,7 @@
     "name": "Systems Engineering Project Management",
     "creditCount": 4.0,
     "preclusions": [
-      "IE5208",
-      "DTS5720"
+      "IE5208"
     ],
     "prerequisites": []
   },
@@ -40638,9 +37726,7 @@
     "code": "SDM5010",
     "name": "Model-Based Systems Engineering",
     "creditCount": 4.0,
-    "preclusions": [
-      "DTS5725"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -40648,7 +37734,6 @@
     "name": "Sdm Research Project",
     "creditCount": 8.0,
     "preclusions": [
-      "MT5910",
       "MT5900"
     ],
     "prerequisites": []
@@ -40659,9 +37744,7 @@
     "creditCount": 4.0,
     "preclusions": [
       "GEK1008",
-      "GEM1008K",
-      "SSA1202",
-      "SS1203SE"
+      "SSA1202"
     ],
     "prerequisites": []
   },
@@ -40669,9 +37752,7 @@
     "code": "SE2210",
     "name": "Popular Culture in Southeast Asia",
     "creditCount": 4.0,
-    "preclusions": [
-      "SE4215"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -40686,9 +37767,7 @@
     "name": "Politics in Southeast Asia",
     "creditCount": 4.0,
     "preclusions": [
-      "SE2281",
       "SSA2207",
-      "SS2207SE",
       "SC2207"
     ],
     "prerequisites": []
@@ -40764,9 +37843,7 @@
     "code": "SE3218",
     "name": "Industrialising Singapore and SE Asia",
     "creditCount": 4.0,
-    "preclusions": [
-      "SE2215"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -40801,18 +37878,14 @@
     "code": "SE3233",
     "name": "Martial Arts in Southeast Asia",
     "creditCount": 4.0,
-    "preclusions": [
-      "SE3880B"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SE3550",
     "name": "Southeast Asian Studies Internship",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3550"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -41032,9 +38105,7 @@
     "name": "Software Analysis & Design",
     "creditCount": 8.0,
     "preclusions": [],
-    "prerequisites": [
-      "SG4101"
-    ]
+    "prerequisites": []
   },
   {
     "code": "SG5103",
@@ -41152,9 +38223,7 @@
     "code": "SH5108",
     "name": "Chemical Hazard Management",
     "creditCount": 4.0,
-    "preclusions": [
-      "SH5004"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -41168,9 +38237,7 @@
     "code": "SH5110",
     "name": "Chemical Hazard Evaluation",
     "creditCount": 4.0,
-    "preclusions": [
-      "SH5004"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -41214,9 +38281,7 @@
     "code": "SH5401",
     "name": "Safety, Health, Environment & Quality Management System",
     "creditCount": 4.0,
-    "preclusions": [
-      "ESE5602"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -41323,9 +38388,7 @@
     "code": "SN2275",
     "name": "Contemporary Tamil Literature",
     "creditCount": 4.0,
-    "preclusions": [
-      "SN2291"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -41402,9 +38465,7 @@
     "code": "SN3550",
     "name": "Internship",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3550"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -41472,7 +38533,6 @@
     "name": "Exploring Science Communication through Popular Science",
     "creditCount": 4.0,
     "preclusions": [
-      "SP1203",
       "ENV1202",
       "SP2171",
       "ES1541",
@@ -41516,10 +38576,8 @@
     "prerequisites": [
       "PC1144",
       "PC1432",
-      "PC1432X",
       "CM1101",
       "CM1131",
-      "PC1321",
       "GEK1509"
     ]
   },
@@ -41553,9 +38611,7 @@
     "name": "Evidence in Forensic Science",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "GEK1542"
-    ]
+    "prerequisites": []
   },
   {
     "code": "SP3203",
@@ -41651,7 +38707,6 @@
       "DSC2008",
       "EC2303",
       "PL2131",
-      "PR1142",
       "PR2103",
       "SC3209",
       "ST1131",
@@ -41711,7 +38766,6 @@
     "name": "Public Health Research Methods",
     "creditCount": 8.0,
     "preclusions": [
-      "CO5102",
       "CO5103"
     ],
     "prerequisites": []
@@ -41720,30 +38774,23 @@
     "code": "SPH5003",
     "name": "Health Behaviour and Communication",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5203"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5004",
     "name": "Introduction to Health Policy and Policy Analysis",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5104"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5005",
     "name": "Practicum",
     "creditCount": 8.0,
-    "preclusions": [
-      "CO5210"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "SPH5002",
-      "CO5102",
       "CO5103"
     ]
   },
@@ -41751,11 +38798,8 @@
     "code": "SPH5101",
     "name": "Advanced Quantitative Methods I",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5218"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "CO5103",
       "SPH5002"
     ]
   },
@@ -41763,12 +38807,9 @@
     "code": "SPH5102",
     "name": "Design, Conduct and Analysis of Clinical Trials",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5220"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "SPH5002",
-      "CO5102",
       "CO5103"
     ]
   },
@@ -41776,51 +38817,39 @@
     "code": "SPH5103",
     "name": "Collection, Management & Analysis of Quantitative Data",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5232"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5104",
     "name": "Healthcare Analytics",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5237"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "SPH5002",
-      "CO5103"
+      "SPH5002"
     ]
   },
   {
     "code": "SPH5201",
     "name": "Control of Communicable Diseases",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5201"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5202",
     "name": "Control of Non-Communicable Diseases",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5201"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5203",
     "name": "Advanced Epidemiology I",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5215"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "SPH5002",
-      "CO5102",
       "CO5103"
     ]
   },
@@ -41828,9 +38857,7 @@
     "code": "SPH5204",
     "name": "Nutrition and Health - Fundamentals and Applications",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5229"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -41844,9 +38871,7 @@
     "code": "SPH5301",
     "name": "Occupational Health Practice",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5304"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -41854,7 +38879,6 @@
     "name": "Occupational Toxicology and Industrial Hygiene",
     "creditCount": 4.0,
     "preclusions": [
-      "CO5305",
       "CO5306"
     ],
     "prerequisites": []
@@ -41863,11 +38887,8 @@
     "code": "SPH5303",
     "name": "Workplace Assessment",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5317"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "CO5305",
       "CO5306",
       "SPH5302"
     ]
@@ -41876,27 +38897,21 @@
     "code": "SPH5304",
     "name": "Occupational Ergonomics",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5312"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5305",
     "name": "Clinical Occupational Medicine",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5307"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5306",
     "name": "Environmental Health",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5202"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -41910,48 +38925,37 @@
     "code": "SPH5401",
     "name": "Health Economics and Financing",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5204"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5402",
     "name": "Management of Healthcare Organisations",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5205"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5403",
     "name": "Medical & Humanitarian Emergencies",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5206"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5404",
     "name": "Measuring and Managing Quality of Care",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5208"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5405",
     "name": "Introduction to Health Services Research",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5214"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "SPH5002",
-      "CO5102",
       "CO5103"
     ]
   },
@@ -41959,21 +38963,16 @@
     "code": "SPH5406",
     "name": "Contemporary Global Health Issues",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5221"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5407",
     "name": "Programme Evaluation",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5222"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "SPH5002",
-      "CO5102",
       "CO5103"
     ]
   },
@@ -41981,45 +38980,35 @@
     "code": "SPH5408",
     "name": "Public Health and Ageing",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5230"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5409",
     "name": "Qualitative Methods in Public Health",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5233"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5410",
     "name": "Developing health proposals using DME skills & tools",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5234"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5411",
     "name": "Information Technology in Healthcare",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5235"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5412",
     "name": "Economic Methods in Health Technology Assessment",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5236"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -42040,11 +39029,8 @@
     "code": "SPH5501",
     "name": "Public Health Communication",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5226"
-    ],
+    "preclusions": [],
     "prerequisites": [
-      "CO5203",
       "SPH5003"
     ]
   },
@@ -42052,135 +39038,105 @@
     "code": "SPH5801",
     "name": "Field Practice",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5231"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5880A",
     "name": "Special Topics in Epidemiology and Disease Control",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5880"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5880B",
     "name": "Special Topics in Quantitative Methods",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5880"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5880C",
     "name": "Special Topics in Environmental/Occupational Health",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5880"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5880D",
     "name": "Special Topics in Health Policy and Systems",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5880"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5880E",
     "name": "Special Topics in Health Services Research",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5880"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5880F",
     "name": "Special Topics in Health Promotion",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5880"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5880G",
     "name": "Special Topics in Global Health",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5880"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5890A",
     "name": "Independent Study in Epidemiology and Disease Control",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5223"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5890B",
     "name": "Independent Study in Quantitative Methods",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5223"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5890C",
     "name": "Independent Study in Environmental / Occupational Health",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5223"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5890D",
     "name": "Independent Study in Health Policy and Systems",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5223"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5890E",
     "name": "Independent Study in Health Services Research",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5223"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5890F",
     "name": "Independent Study in Health Promotion",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5223"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "SPH5890G",
     "name": "Independent Study in Global Health Programs: Planning and Evaluation",
     "creditCount": 4.0,
-    "preclusions": [
-      "CO5223"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -42189,7 +39145,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "CO5102",
       "CO5103"
     ]
   },
@@ -42198,9 +39153,7 @@
     "name": "Advanced Quantitative Methods II",
     "creditCount": 4.0,
     "preclusions": [],
-    "prerequisites": [
-      "CO5103"
-    ]
+    "prerequisites": []
   },
   {
     "code": "SPH6004",
@@ -42329,9 +39282,7 @@
     "creditCount": 4.0,
     "preclusions": [
       "GEK1008",
-      "GEM1008K",
-      "SE1101E",
-      "SS1203SE"
+      "SE1101E"
     ],
     "prerequisites": []
   },
@@ -42349,7 +39300,6 @@
     "name": "Singapore Literature in English: Selected Texts",
     "creditCount": 4.0,
     "preclusions": [
-      "SSA1207FC",
       "GES1025"
     ],
     "prerequisites": []
@@ -42378,7 +39328,6 @@
     "name": "Singapore\u2019s Business History",
     "creditCount": 4.0,
     "preclusions": [
-      "HY2239",
       "GES1009"
     ],
     "prerequisites": []
@@ -42388,7 +39337,6 @@
     "name": "Nation-Building in Singapore",
     "creditCount": 4.0,
     "preclusions": [
-      "HY2229",
       "GES1010"
     ],
     "prerequisites": []
@@ -42398,7 +39346,6 @@
     "name": "Singapore and Japan: Historical and Contemporary Relationships",
     "creditCount": 4.0,
     "preclusions": [
-      "JS2224",
       "GES1015"
     ],
     "prerequisites": []
@@ -42408,8 +39355,7 @@
     "name": "Islam and Contemporary Malay Society",
     "creditCount": 4.0,
     "preclusions": [
-      "GES1014",
-      "MS2205"
+      "GES1014"
     ],
     "prerequisites": []
   },
@@ -42419,7 +39365,6 @@
     "creditCount": 4.0,
     "preclusions": [
       "SE2213",
-      "SE2281",
       "SS2207SE"
     ],
     "prerequisites": []
@@ -42430,12 +39375,9 @@
     "creditCount": 4.0,
     "preclusions": [
       "GEK2003",
-      "GEM2003K",
       "PS1102",
-      "PS2101B",
       "PS2101",
-      "PS2249",
-      "SS2209PS"
+      "PS2249"
     ],
     "prerequisites": []
   },
@@ -42471,7 +39413,6 @@
     "name": "Singapore Film: Performance of Identity",
     "creditCount": 4.0,
     "preclusions": [
-      "TS2238",
       "GES1029"
     ],
     "prerequisites": []
@@ -42490,7 +39431,6 @@
     "name": "Global Economic Dimensions of Singapore",
     "creditCount": 4.0,
     "preclusions": [
-      "EC2373",
       "PP5215",
       "GES1002",
       "SSA2220T",
@@ -42503,7 +39443,6 @@
     "name": "Global Economic Dimensions Of Singapore",
     "creditCount": 4.0,
     "preclusions": [
-      "EC2202",
       "EC2373",
       "GES1002T",
       "SSA2220",
@@ -42516,7 +39455,6 @@
     "name": "Popular Culture in Singapore",
     "creditCount": 4.0,
     "preclusions": [
-      "HY2254",
       "GES1012"
     ],
     "prerequisites": []
@@ -42554,7 +39492,6 @@
     "name": "Singapore's Foreign Policy",
     "creditCount": 4.0,
     "preclusions": [
-      "PS3219B",
       "SS3205PS",
       "PS3249"
     ],
@@ -42565,7 +39502,6 @@
     "name": "Labour Law In Singapore",
     "creditCount": 4.0,
     "preclusions": [
-      "SSB1204",
       "GES1000",
       "GES1000T"
     ],
@@ -42578,7 +39514,6 @@
     "preclusions": [
       "BSP1004",
       "BSP1004X",
-      "SSB2212",
       "GES1024"
     ],
     "prerequisites": []
@@ -42588,7 +39523,6 @@
     "name": "Managing Singapore's Built Environment",
     "creditCount": 4.0,
     "preclusions": [
-      "RE1102",
       "GES1019"
     ],
     "prerequisites": []
@@ -42625,19 +39559,15 @@
     "name": "Introduction to Statistics",
     "creditCount": 4.0,
     "preclusions": [
-      "ST1131A",
       "ST1232",
       "ST2334",
       "CE2407",
       "CN3421",
-      "EC2231",
       "EC2303",
-      "PR2103",
       "DSC2008"
     ],
     "prerequisites": [
       "MA1301",
-      "MA1301FC",
       "MA1301X"
     ]
   },
@@ -42647,13 +39577,10 @@
     "creditCount": 4.0,
     "preclusions": [
       "ST1131",
-      "ST1131A",
       "ST2334",
       "CE2407",
       "CN3421",
-      "EC2231",
       "EC2303",
-      "PR2103",
       "DSC2008"
     ],
     "prerequisites": []
@@ -42668,12 +39595,10 @@
       "CE2407"
     ],
     "prerequisites": [
-      "MA1102",
       "MA1102R",
       "MA1312",
       "MA1507",
       "MA1505",
-      "MA1505C",
       "MA1521"
     ]
   },
@@ -42695,7 +39620,6 @@
     "preclusions": [],
     "prerequisites": [
       "ST1131",
-      "ST1131A",
       "ST1232",
       "ST2334",
       "ST2131",
@@ -42728,16 +39652,12 @@
     "creditCount": 4.0,
     "preclusions": [
       "ST1131",
-      "ST1131A",
       "ST1232",
       "ST2131",
       "MA2216",
       "CE2407",
-      "EC2231",
       "EC2303",
-      "PR2103",
-      "DSC2008",
-      "ME4273"
+      "DSC2008"
     ],
     "prerequisites": [
       "MA1102R",
@@ -42752,7 +39672,6 @@
     "name": "Regression Analysis",
     "creditCount": 4.0,
     "preclusions": [
-      "ST2335",
       "EC3303"
     ],
     "prerequisites": [
@@ -42789,9 +39708,7 @@
       "MA3238"
     ],
     "prerequisites": [
-      "MA1101",
       "MA1101R",
-      "MA1311",
       "MA1508",
       "ST2131",
       "MA2216"
@@ -42876,7 +39793,6 @@
       "CS1010",
       "CS1010E",
       "CS1010S",
-      "CS1010FC",
       "IT1006"
     ]
   },
@@ -42884,9 +39800,7 @@
     "code": "ST3248",
     "name": "Statistical Learning I",
     "creditCount": 4.0,
-    "preclusions": [
-      "ST4240"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "ST2132",
       "ST2334"
@@ -42910,9 +39824,7 @@
     "code": "ST3312",
     "name": "Enhanced Undergraduate Professional Internship Programme",
     "creditCount": 12.0,
-    "preclusions": [
-      "XX3312"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -43002,9 +39914,7 @@
     "code": "ST4248",
     "name": "Statistical Learning II",
     "creditCount": 4.0,
-    "preclusions": [
-      "ST4240"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "ST3131",
       "ST3248"
@@ -43035,9 +39945,7 @@
     "code": "ST5202",
     "name": "Applied Regression Analysis",
     "creditCount": 4.0,
-    "preclusions": [
-      "ST5318"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -43080,9 +39988,7 @@
     "code": "ST5214",
     "name": "Advanced Probability Theory",
     "creditCount": 4.0,
-    "preclusions": [
-      "MA5259"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "ST2131"
     ]
@@ -43111,8 +40017,7 @@
     "name": "Probability and Stochastic Processes",
     "creditCount": 4.0,
     "preclusions": [
-      "ST5214",
-      "MA5259"
+      "ST5214"
     ],
     "prerequisites": [
       "ST2131"
@@ -43311,13 +40216,11 @@
       "SW2104",
       "SW2105",
       "SW3104",
-      "SW4000",
       "SW1101E",
       "SW2101",
       "SW2104",
       "SW2105",
-      "SW3104",
-      "SW4000"
+      "SW3104"
     ]
   },
   {
@@ -43369,13 +40272,11 @@
       "SW2104",
       "SW2105",
       "SW3104",
-      "SW4000",
       "SW1101E",
       "SW2101",
       "SW2104",
       "SW2105",
-      "SW3104",
-      "SW4000"
+      "SW3104"
     ]
   },
   {
@@ -43389,13 +40290,11 @@
       "SW2104",
       "SW2105",
       "SW3104",
-      "SW4000",
       "SW1101E",
       "SW2101",
       "SW2104",
       "SW2105",
-      "SW3104",
-      "SW4000"
+      "SW3104"
     ]
   },
   {
@@ -43409,13 +40308,11 @@
       "SW2104",
       "SW2105",
       "SW3104",
-      "SW4000",
       "SW1101E",
       "SW2101",
       "SW2104",
       "SW2105",
-      "SW3104",
-      "SW4000"
+      "SW3104"
     ]
   },
   {
@@ -43447,13 +40344,11 @@
       "SW2104",
       "SW2105",
       "SW3104",
-      "SW4000",
       "SW1101E",
       "SW2101",
       "SW2104",
       "SW2105",
-      "SW3104",
-      "SW4000"
+      "SW3104"
     ]
   },
   {
@@ -43611,9 +40506,7 @@
     "code": "SW6660",
     "name": "Independent Study",
     "creditCount": 4.0,
-    "preclusions": [
-      "SW6262"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -43648,9 +40541,7 @@
     "code": "SWD5120",
     "name": "Social Work Practicum",
     "creditCount": 4.0,
-    "preclusions": [
-      "SW5120"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "SWD5103"
     ]
@@ -43757,9 +40648,7 @@
     "code": "TCE1109",
     "name": "Statics And Mechanics of Materials",
     "creditCount": 4.0,
-    "preclusions": [
-      "CE1109"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -43802,9 +40691,7 @@
     "code": "TCE2184",
     "name": "Infrastructure & the Environment",
     "creditCount": 4.0,
-    "preclusions": [
-      "CE2184"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -43865,7 +40752,6 @@
     "name": "Chemical Engineering Principles",
     "creditCount": 4.0,
     "preclusions": [
-      "TC1101",
       "CN1111E"
     ],
     "prerequisites": []
@@ -43893,7 +40779,6 @@
     "name": "Chemical Kinetics And Reactor Design",
     "creditCount": 4.0,
     "preclusions": [
-      "TC2106",
       "CN2116E"
     ],
     "prerequisites": [
@@ -43905,7 +40790,6 @@
     "name": "Chemical Engineering Thermodynamics",
     "creditCount": 4.0,
     "preclusions": [
-      "TC2111",
       "CN2121E"
     ],
     "prerequisites": [
@@ -43917,7 +40801,6 @@
     "name": "Fluid Mechanics",
     "creditCount": 4.0,
     "preclusions": [
-      "TC2112",
       "CN2122E"
     ],
     "prerequisites": [
@@ -43929,7 +40812,6 @@
     "name": "Heat And Mass Transfer",
     "creditCount": 4.0,
     "preclusions": [
-      "TC2115",
       "CN2125E"
     ],
     "prerequisites": [
@@ -43944,7 +40826,6 @@
       "TC2411"
     ],
     "prerequisites": [
-      "CN1411",
       "TCN1411"
     ]
   },
@@ -43953,7 +40834,6 @@
     "name": "Process Dynamics & Control",
     "creditCount": 4.0,
     "preclusions": [
-      "TC3111",
       "CN3121E"
     ],
     "prerequisites": [
@@ -43965,7 +40845,6 @@
     "name": "Particle Technology",
     "creditCount": 4.0,
     "preclusions": [
-      "TC3114",
       "CN3124E"
     ],
     "prerequisites": [
@@ -43977,7 +40856,6 @@
     "name": "Separation Processes",
     "creditCount": 5.0,
     "preclusions": [
-      "TC2113",
       "CN3132E"
     ],
     "prerequisites": [
@@ -44003,7 +40881,6 @@
     "name": "Process Modeling & Numerical Simulation",
     "creditCount": 4.0,
     "preclusions": [
-      "TC3411",
       "CN3421E"
     ],
     "prerequisites": [
@@ -44046,10 +40923,8 @@
       "CN4208E"
     ],
     "prerequisites": [
-      "TC2106",
       "CN2116E",
       "TCN2116",
-      "TC2112",
       "CN2122E",
       "TCN2122"
     ]
@@ -44059,7 +40934,6 @@
     "name": "Membrane Science And Engineering",
     "creditCount": 4.0,
     "preclusions": [
-      "TC4210",
       "CN4210E"
     ],
     "prerequisites": []
@@ -44069,7 +40943,6 @@
     "name": "Food Technology and Engineering",
     "creditCount": 4.0,
     "preclusions": [
-      "TC4215",
       "CN4215E"
     ],
     "prerequisites": [
@@ -44082,7 +40955,6 @@
     "name": "Electronic Materials Science",
     "creditCount": 4.0,
     "preclusions": [
-      "TC4216",
       "CN4216E"
     ],
     "prerequisites": [
@@ -44094,7 +40966,6 @@
     "name": "Advanced Process Control",
     "creditCount": 4.0,
     "preclusions": [
-      "TC4227",
       "CN4227E"
     ],
     "prerequisites": [
@@ -44109,7 +40980,6 @@
       "CN4233R",
       "PR2143",
       "PR3145",
-      "PR4206",
       "CN4233E"
     ],
     "prerequisites": [
@@ -44155,7 +41025,6 @@
       "TEE2002"
     ],
     "prerequisites": [
-      "TE2102",
       "TG1401"
     ]
   },
@@ -44164,7 +41033,6 @@
     "name": "Advanced Mathematics for Engineers",
     "creditCount": 4.0,
     "preclusions": [
-      "TE2401",
       "TEE2003"
     ],
     "prerequisites": [
@@ -44176,7 +41044,6 @@
     "name": "Programming Methodology",
     "creditCount": 4.0,
     "preclusions": [
-      "TE1122",
       "TEE2101",
       "TIC1001"
     ],
@@ -44201,7 +41068,6 @@
       "TEE3801"
     ],
     "prerequisites": [
-      "EE2005E",
       "EE2021E",
       "TEE2027",
       "TE2003"
@@ -44224,7 +41090,6 @@
       "TE2002"
     ],
     "prerequisites": [
-      "TE2102",
       "TTG1401"
     ]
   },
@@ -44233,7 +41098,6 @@
     "name": "Advanced Mathematics for Engineers",
     "creditCount": 4.0,
     "preclusions": [
-      "TE2401",
       "TE2003"
     ],
     "prerequisites": [
@@ -44256,7 +41120,6 @@
     "name": "Signals and Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "EE2009E",
       "EE2010E",
       "EE2023E"
     ],
@@ -44269,21 +41132,16 @@
     "name": "Digital Design",
     "creditCount": 4.0,
     "preclusions": [
-      "EE2020E",
       "TEE2020"
     ],
-    "prerequisites": [
-      "EE1002"
-    ]
+    "prerequisites": []
   },
   {
     "code": "TEE2027",
     "name": "Electronic Circuits",
     "creditCount": 4.0,
     "preclusions": [
-      "EE2004E",
       "EE2005E",
-      "EE2021E",
       "TEE2021"
     ],
     "prerequisites": [
@@ -44295,12 +41153,9 @@
     "name": "Microcontroller Programming and Interfacing",
     "creditCount": 4.0,
     "preclusions": [
-      "EE2007E",
-      "EE2024E",
-      "TEE2024"
+      "EE2024E"
     ],
     "prerequisites": [
-      "EE2020E",
       "TEE2020",
       "TEE2026"
     ]
@@ -44310,9 +41165,7 @@
     "name": "Integrated System Lab",
     "creditCount": 4.0,
     "preclusions": [
-      "EE2031E",
       "EE2032E",
-      "TEE2031",
       "TEE2032"
     ],
     "prerequisites": [
@@ -44320,7 +41173,6 @@
       "TEE2023",
       "EE2011E",
       "TEE2011",
-      "EE2021E",
       "TEE2021",
       "TEE2027"
     ]
@@ -44330,7 +41182,6 @@
     "name": "Programming Methodology",
     "creditCount": 4.0,
     "preclusions": [
-      "TE1122",
       "TE2101",
       "TIC1001"
     ],
@@ -44341,9 +41192,7 @@
     "name": "Innovation & Enterprise I",
     "creditCount": 4.0,
     "preclusions": [
-      "TM4209",
       "TME4209",
-      "EE3001E",
       "EE3031E"
     ],
     "prerequisites": []
@@ -44353,7 +41202,6 @@
     "name": "Communication Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "EE3103E",
       "EE3131E"
     ],
     "prerequisites": [
@@ -44379,7 +41227,6 @@
       "EE3207E"
     ],
     "prerequisites": [
-      "TEE2024",
       "TEE2028"
     ]
   },
@@ -44388,7 +41235,6 @@
     "name": "Feedback Control Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "EE2010E",
       "EE3331E"
     ],
     "prerequisites": [
@@ -44403,7 +41249,6 @@
       "EE3408E"
     ],
     "prerequisites": [
-      "TEE2021",
       "TEE2027"
     ]
   },
@@ -44412,7 +41257,6 @@
     "name": "Microelectronics Materials and Devices",
     "creditCount": 4.0,
     "preclusions": [
-      "EE3406E",
       "EE2004E",
       "EE3431E"
     ],
@@ -44426,7 +41270,6 @@
       "EE3501E"
     ],
     "prerequisites": [
-      "TEE2021",
       "TEE2027"
     ]
   },
@@ -44438,7 +41281,6 @@
       "TE3801"
     ],
     "prerequisites": [
-      "TEE2021",
       "TEE2027",
       "TEE2003"
     ]
@@ -44481,7 +41323,6 @@
     "preclusions": [
       "CS2105",
       "CS3103",
-      "EE3204E",
       "TEE3204",
       "EE4204E"
     ],
@@ -44511,7 +41352,6 @@
     ],
     "prerequisites": [
       "TEE2101",
-      "TEE2024",
       "TEE2028"
     ]
   },
@@ -44520,7 +41360,6 @@
     "name": "Industrial Control Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "EE3302E",
       "TEE3302",
       "EE4303E"
     ],
@@ -44544,12 +41383,10 @@
     "name": "Analog Electronics",
     "creditCount": 4.0,
     "preclusions": [
-      "EE3407E",
       "TEE3407",
       "EE4407E"
     ],
     "prerequisites": [
-      "TEE2021",
       "TEE2027"
     ]
   },
@@ -44561,7 +41398,6 @@
       "EE4415E"
     ],
     "prerequisites": [
-      "TEE2020",
       "TEE2026"
     ]
   },
@@ -44570,12 +41406,10 @@
     "name": "Modern Transistors and Memory Devices",
     "creditCount": 4.0,
     "preclusions": [
-      "EE4408E",
       "EE4412E",
       "EE4435E"
     ],
     "prerequisites": [
-      "TEE2021",
       "TEE2027"
     ]
   },
@@ -44584,11 +41418,9 @@
     "name": "Fabrication Process Technology",
     "creditCount": 4.0,
     "preclusions": [
-      "EE4411E",
       "EE4436E"
     ],
     "prerequisites": [
-      "TEE2021",
       "TEE2027"
     ]
   },
@@ -44597,7 +41429,6 @@
     "name": "Engineering Mathematics I",
     "creditCount": 4.0,
     "preclusions": [
-      "TE2102",
       "TM1401",
       "TTG1401"
     ],
@@ -44619,8 +41450,7 @@
     "preclusions": [
       "TG3002",
       "TTG3002",
-      "TTG3001",
-      "TIC3901"
+      "TTG3001"
     ],
     "prerequisites": []
   },
@@ -44631,8 +41461,7 @@
     "preclusions": [
       "TG3001",
       "TTG3001",
-      "TTG3002",
-      "TIC3901"
+      "TTG3002"
     ],
     "prerequisites": []
   },
@@ -44744,7 +41573,6 @@
     "name": "Introduction to Industrial System",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3161",
       "IE2010E"
     ],
     "prerequisites": []
@@ -44765,7 +41593,6 @@
     "creditCount": 4.0,
     "preclusions": [
       "DSC3214",
-      "MA2215",
       "MA3236",
       "IE2110E"
     ],
@@ -44786,7 +41613,6 @@
     "name": "Quality Engineering I",
     "creditCount": 4.0,
     "preclusions": [
-      "TM4271",
       "IE2130E"
     ],
     "prerequisites": []
@@ -44841,7 +41667,6 @@
     "name": "Simulation",
     "creditCount": 5.0,
     "preclusions": [
-      "DSC3221",
       "IE3110E"
     ],
     "prerequisites": []
@@ -44922,9 +41747,7 @@
     "creditCount": 4.0,
     "preclusions": [
       "TE2002",
-      "TC2401",
       "TC1402",
-      "TM1402",
       "TME2401"
     ],
     "prerequisites": []
@@ -44937,7 +41760,6 @@
       "TME3101"
     ],
     "prerequisites": [
-      "TM2101",
       "ME2101E"
     ]
   },
@@ -45002,7 +41824,6 @@
     "name": "Probability and Statistics",
     "creditCount": 4.0,
     "preclusions": [
-      "IE2120",
       "TIE2120",
       "TIE3101",
       "IE3101E"
@@ -45016,7 +41837,6 @@
     "name": "Fundamentals of Mechanical Design",
     "creditCount": 4.0,
     "preclusions": [
-      "TM2101",
       "ME2101E"
     ],
     "prerequisites": []
@@ -45026,7 +41846,6 @@
     "name": "Mechanics of Materials II",
     "creditCount": 3.0,
     "preclusions": [
-      "TM1111",
       "ME2114E"
     ],
     "prerequisites": []
@@ -45036,7 +41855,6 @@
     "name": "Engineering Thermodynamics",
     "creditCount": 4.0,
     "preclusions": [
-      "TM1121",
       "ME2121E"
     ],
     "prerequisites": []
@@ -45046,7 +41864,6 @@
     "name": "Fluid Mechanics I",
     "creditCount": 4.0,
     "preclusions": [
-      "TM1131",
       "ME2134E"
     ],
     "prerequisites": []
@@ -45056,7 +41873,6 @@
     "name": "Fluid Mechanics II",
     "creditCount": 4.0,
     "preclusions": [
-      "TM2131",
       "ME2135E"
     ],
     "prerequisites": [
@@ -45068,7 +41884,6 @@
     "name": "Feedback Control Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3142",
       "ME2142E"
     ],
     "prerequisites": [
@@ -45080,7 +41895,6 @@
     "name": "Sensors and Actuators",
     "creditCount": 4.0,
     "preclusions": [
-      "TM2141",
       "ME2143E"
     ],
     "prerequisites": []
@@ -45090,7 +41904,6 @@
     "name": "Principles of Mechanical Engineering Materials",
     "creditCount": 4.0,
     "preclusions": [
-      "TM1151",
       "ME2151E"
     ],
     "prerequisites": []
@@ -45102,9 +41915,7 @@
     "preclusions": [
       "TE2002",
       "TEE2002",
-      "TC2401",
-      "TC1402",
-      "TM1402"
+      "TC1402"
     ],
     "prerequisites": []
   },
@@ -45124,7 +41935,6 @@
     "name": "Mechanics of Machines",
     "creditCount": 4.0,
     "preclusions": [
-      "TM2112",
       "ME3112E"
     ],
     "prerequisites": []
@@ -45134,7 +41944,6 @@
     "name": "Heat Transfer",
     "creditCount": 4.0,
     "preclusions": [
-      "TM2122",
       "ME3122E"
     ],
     "prerequisites": []
@@ -45144,7 +41953,6 @@
     "name": "Manufacturing Processes",
     "creditCount": 4.0,
     "preclusions": [
-      "TM2162",
       "ME3162E"
     ],
     "prerequisites": []
@@ -45154,7 +41962,6 @@
     "name": "Mechanics of Solids",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3211",
       "ME3211E"
     ],
     "prerequisites": [
@@ -45166,7 +41973,6 @@
     "name": "Unsteady Flow in Fluid Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "ME3233",
       "ME3233E"
     ],
     "prerequisites": [
@@ -45178,7 +41984,6 @@
     "name": "Microprocessor Applications",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3241",
       "ME3241E"
     ],
     "prerequisites": []
@@ -45188,7 +41993,6 @@
     "name": "Automation",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3242",
       "ME3242E"
     ],
     "prerequisites": []
@@ -45198,7 +42002,6 @@
     "name": "Materials For Engineers",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3251",
       "ME3251E"
     ],
     "prerequisites": [
@@ -45210,7 +42013,6 @@
     "name": "Computer-Aided Design and Manufacturing",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3261",
       "ME3261E"
     ],
     "prerequisites": []
@@ -45220,7 +42022,6 @@
     "name": "Design for Manufacturing and Assembly",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3261",
       "ME3263E"
     ],
     "prerequisites": []
@@ -45240,7 +42041,6 @@
     "name": "Thermal Environmental Engineering",
     "creditCount": 4.0,
     "preclusions": [
-      "TM3223",
       "ME4223E"
     ],
     "prerequisites": [
@@ -45253,7 +42053,6 @@
     "name": "Applied Heat Transfer",
     "creditCount": 4.0,
     "preclusions": [
-      "TM4225",
       "ME4225E"
     ],
     "prerequisites": [
@@ -45265,7 +42064,6 @@
     "name": "Robot Mechanics and Control",
     "creditCount": 4.0,
     "preclusions": [
-      "TM4245",
       "ME4245E"
     ],
     "prerequisites": [
@@ -45291,7 +42089,6 @@
     "name": "Tool Engineering",
     "creditCount": 4.0,
     "preclusions": [
-      "TM4261",
       "ME4261E"
     ],
     "prerequisites": []
@@ -45318,18 +42115,14 @@
     "code": "TP5025",
     "name": "Intelligent Transportation Systems",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE5025"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "TP5026",
     "name": "Transportation Management & Policy",
     "creditCount": 4.0,
-    "preclusions": [
-      "TCE5026"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -45350,18 +42143,14 @@
     "code": "TR2201",
     "name": "Entrepreneurial Marketing",
     "creditCount": 4.0,
-    "preclusions": [
-      "TR3003"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "TR2201Y",
     "name": "Entrepreneurial Marketing",
     "creditCount": 4.0,
-    "preclusions": [
-      "TR3003"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -45369,7 +42158,6 @@
     "name": "New Venture Creation",
     "creditCount": 4.0,
     "preclusions": [
-      "TR3004",
       "TR3005"
     ],
     "prerequisites": []
@@ -45379,7 +42167,6 @@
     "name": "New Venture Creation",
     "creditCount": 4.0,
     "preclusions": [
-      "TR3004",
       "TR3005"
     ],
     "prerequisites": []
@@ -45395,9 +42182,7 @@
     "code": "TR3203N",
     "name": "Start-up Case Study & Analysis",
     "creditCount": 8.0,
-    "preclusions": [
-      "TR3103"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -45411,9 +42196,7 @@
     "code": "TR3203T",
     "name": "Start-up Case Study & Analysis",
     "creditCount": 8.0,
-    "preclusions": [
-      "TR3103"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -45520,9 +42303,7 @@
     "code": "TS2243",
     "name": "Film Genres: Stars and Styles",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM2026"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -45536,9 +42317,7 @@
     "code": "TS3222",
     "name": "Applied Theatre",
     "creditCount": 4.0,
-    "preclusions": [
-      "TS4880B"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "TS1101E",
       "GEM1003"
@@ -45744,7 +42523,6 @@
     "name": "Engineering Mathematics I",
     "creditCount": 4.0,
     "preclusions": [
-      "TE2102",
       "TM1401",
       "TG1401"
     ],
@@ -45766,8 +42544,7 @@
     "preclusions": [
       "TG3002",
       "TTG3002",
-      "TG3001",
-      "TIC3901"
+      "TG3001"
     ],
     "prerequisites": []
   },
@@ -45778,8 +42555,7 @@
     "preclusions": [
       "TG3001",
       "TTG3001",
-      "TG3002",
-      "TIC3901"
+      "TG3002"
     ],
     "prerequisites": []
   },
@@ -46203,7 +42979,6 @@
     "name": "Junior Seminar: The Darwinian Revolution",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM1902B",
       "GEM1536",
       "GET1020"
     ],
@@ -46213,18 +42988,14 @@
     "code": "UTC1102G",
     "name": "Junior Seminar: Proof: What\u2019s Truth got to do with it?",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM1902G"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "UTC1102U",
     "name": "Junior Seminar: Disasters",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM1902U"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -46239,9 +43010,7 @@
     "name": "Junior Seminar: Radiation and Society",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM2910",
-      "GEM2910X",
-      "UTC2110"
+      "GEM2910X"
     ],
     "prerequisites": []
   },
@@ -46256,36 +43025,28 @@
     "code": "UTC1402",
     "name": "Jr Sem: Generation Y: Transitions to Adulthood",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM1035"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "UTC1403",
     "name": "Jr Sem: Hidden Communities",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM1904"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "UTC1404",
     "name": "Jr Sem: Power and Ideas",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM1905"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "UTC1408",
     "name": "Jr Sem: Technology and Human Progress",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM1909"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -46293,7 +43054,6 @@
     "name": "Jr Sem: The Pursuit of Happiness",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM1910",
       "UQF2101J"
     ],
     "prerequisites": []
@@ -46310,21 +43070,14 @@
     "name": "Thinking in Systems: Diseases and Healthcare",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM1919",
-      "GEM1914",
-      "GEM1915",
-      "GEM1918",
       "GET1011",
-      "UTC1411",
       "UTC1701",
-      "UTC1700",
       "UTC1701",
       "GEM1914",
       "GEM1915",
       "GEM1918",
       "GEM1919",
       "GET1011",
-      "UTC1411",
       "UTC1700"
     ],
     "prerequisites": []
@@ -46334,14 +43087,10 @@
     "name": "Thinking in Systems: Sustainability and Us",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM1914",
       "GEM1915",
-      "GEM1918",
       "GEM1919",
       "GET1011",
-      "UTC1411",
       "UTC1700",
-      "UTC1701",
       "UTC1702"
     ],
     "prerequisites": []
@@ -46351,14 +43100,10 @@
     "name": "Thinking in Systems: Population Dynamics",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM1914",
       "GEM1915",
-      "GEM1918",
       "GEM1919",
       "GET1011",
-      "UTC1411",
       "UTC1700",
-      "UTC1701",
       "UTC1702"
     ],
     "prerequisites": []
@@ -46368,18 +43113,13 @@
     "name": "Thinking in Systems: Energy Systems",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM1915",
       "GEM1914",
-      "GEM1915",
       "GEM1918",
-      "GEM1919",
       "GET1011",
-      "UTC1411",
       "UTC1702A",
       "UTC1702B",
       "UTC1702C",
-      "UTC1702D",
-      "UTC1702"
+      "UTC1702D"
     ],
     "prerequisites": []
   },
@@ -46388,12 +43128,9 @@
     "name": "Thinking in Systems: Disaster Resilience",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM1915",
       "GEM1914",
-      "GEM1918",
       "GEM1919",
       "GET1011",
-      "UTC1411",
       "UTC1702A",
       "UTC1702B",
       "UTC1702C",
@@ -46405,27 +43142,21 @@
     "code": "UTC2102",
     "name": "Climate Change",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM2902"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "UTC2107",
     "name": "Senior Seminar: Negotiating in a Complex World",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM2907"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "UTC2400",
     "name": "Community Leadership",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM2903"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -46433,7 +43164,6 @@
     "name": "Environment and Civil Society in Singapore",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM2906",
       "SSU2005"
     ],
     "prerequisites": []
@@ -46443,7 +43173,6 @@
     "name": "Citizenship in a Changing World",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM2028",
       "SSU2007"
     ],
     "prerequisites": []
@@ -46573,27 +43302,21 @@
     "code": "UTC3102",
     "name": "Tembusu Undergraduate Research Opportunity (UROP)",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM3901"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "UTC3400",
     "name": "Independent Study",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM3902"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "UTC3401",
     "name": "CAPT Undergraduate Research Opportunity (UROP)",
     "creditCount": 4.0,
-    "preclusions": [
-      "GEM3903"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -46608,7 +43331,6 @@
     "name": "Singapore as \u2018Model\u2019 City?",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM2905",
       "SSU2004"
     ],
     "prerequisites": []
@@ -46617,9 +43339,7 @@
     "code": "UTS2400",
     "name": "Identities in Asia",
     "creditCount": 4.0,
-    "preclusions": [
-      "SSU2002"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -46627,7 +43347,6 @@
     "name": "Environment and Civil Society in Singapore",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM2906",
       "SSU2005"
     ],
     "prerequisites": []
@@ -46637,7 +43356,6 @@
     "name": "Citizenship in a Changing World",
     "creditCount": 4.0,
     "preclusions": [
-      "GEM2028",
       "SSU2007"
     ],
     "prerequisites": []
@@ -46653,9 +43371,7 @@
     "code": "UTS2500",
     "name": "College 3 Capstone Experience",
     "creditCount": 4.0,
-    "preclusions": [
-      "SSU2001"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -46735,9 +43451,7 @@
     "name": "Eating Right(s): The Politics of Food",
     "creditCount": 4.0,
     "preclusions": [
-      "IEM1201",
-      "UTW1001",
-      "ES1501"
+      "UTW1001"
     ],
     "prerequisites": []
   },
@@ -46746,9 +43460,7 @@
     "name": "Public Persona and Self-presentations",
     "creditCount": 4.0,
     "preclusions": [
-      "IEM1201",
-      "UTW1001",
-      "ES1501"
+      "UTW1001"
     ],
     "prerequisites": []
   },
@@ -46757,9 +43469,7 @@
     "name": "Heroes",
     "creditCount": 4.0,
     "preclusions": [
-      "IEM1201",
-      "UTW1001",
-      "ES1501"
+      "UTW1001"
     ],
     "prerequisites": []
   },
@@ -46768,9 +43478,7 @@
     "name": "Women in Film",
     "creditCount": 4.0,
     "preclusions": [
-      "IEM1201",
-      "UTW1001",
-      "ES1501"
+      "UTW1001"
     ],
     "prerequisites": []
   },
@@ -46779,9 +43487,7 @@
     "name": "The Detective",
     "creditCount": 4.0,
     "preclusions": [
-      "IEM1201",
-      "UTW1001",
-      "ES1501"
+      "UTW1001"
     ],
     "prerequisites": []
   },
@@ -46790,9 +43496,7 @@
     "name": "The Online Politician: The Use of Social Media in Political Communication",
     "creditCount": 4.0,
     "preclusions": [
-      "IEM1201",
-      "UTW1001",
-      "ES1501"
+      "UTW1001"
     ],
     "prerequisites": []
   },
@@ -46801,9 +43505,7 @@
     "name": "Algorithmic Culture and its Discontents",
     "creditCount": 4.0,
     "preclusions": [
-      "IEM1201",
-      "UTW1001",
-      "ES1501"
+      "UTW1001"
     ],
     "prerequisites": []
   },
@@ -46812,9 +43514,7 @@
     "name": "Colour: Theory, meaning and practice",
     "creditCount": 4.0,
     "preclusions": [
-      "IEM1201",
-      "UTW1001",
-      "ES1501"
+      "UTW1001"
     ],
     "prerequisites": []
   },
@@ -46823,11 +43523,9 @@
     "name": "Public Memory, Identity and Rhetoric",
     "creditCount": 4.0,
     "preclusions": [
-      "IEM2201",
       "UTW2001"
     ],
     "prerequisites": [
-      "IEM1201",
       "UTW1001"
     ]
   },
@@ -46836,11 +43534,9 @@
     "name": "Sport and Socialization",
     "creditCount": 4.0,
     "preclusions": [
-      "IEM2201",
       "UTW2001"
     ],
     "prerequisites": [
-      "IEM1201",
       "UTW1001"
     ]
   },
@@ -46849,11 +43545,9 @@
     "name": "Science Fiction and Empire",
     "creditCount": 4.0,
     "preclusions": [
-      "IEM2201",
       "UTW2001"
     ],
     "prerequisites": [
-      "IEM1201",
       "UTW1001"
     ]
   },
@@ -46876,11 +43570,9 @@
     "name": "Nobodiness: The Self as Story",
     "creditCount": 4.0,
     "preclusions": [
-      "IEM2201",
       "UTW2001"
     ],
     "prerequisites": [
-      "IEM1201",
       "UTW1001"
     ]
   },
@@ -47007,9 +43699,7 @@
     ],
     "prerequisites": [
       "EC4301",
-      "EC4101",
-      "EC4302",
-      "EC4102"
+      "EC4302"
     ]
   },
   {
@@ -47021,9 +43711,7 @@
     ],
     "prerequisites": [
       "EC4301",
-      "EC4101",
-      "EC4302",
-      "EC4102"
+      "EC4302"
     ]
   },
   {
@@ -47045,7 +43733,6 @@
     "name": "Integrated Honours Thesis",
     "creditCount": 12.0,
     "preclusions": [
-      "CS4101",
       "CS4349"
     ],
     "prerequisites": []
@@ -47294,45 +43981,35 @@
     "code": "YHU2290",
     "name": "History and Culture of Southeast Asia",
     "creditCount": 5.0,
-    "preclusions": [
-      "YHU1202"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "YHU2291",
     "name": "Introduction to Arts",
     "creditCount": 5.0,
-    "preclusions": [
-      "YHU1209"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "YHU2292",
     "name": "Introduction to Writing Poetry",
     "creditCount": 5.0,
-    "preclusions": [
-      "YHU1210"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "YHU2293",
     "name": "Introduction to Fiction Writing",
     "creditCount": 5.0,
-    "preclusions": [
-      "YHU1212"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "YHU2295",
     "name": "The Global Short Story",
     "creditCount": 5.0,
-    "preclusions": [
-      "EN4880C"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -47473,9 +44150,7 @@
     "code": "YHU3267",
     "name": "Classical Indian Philosophy of Language",
     "creditCount": 5.0,
-    "preclusions": [
-      "YHU2251"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "YCC1113",
       "YCC1114"
@@ -47492,9 +44167,7 @@
     "code": "YHU3276",
     "name": "The Historian\u2019s Craft",
     "creditCount": 5.0,
-    "preclusions": [
-      "YHU2217"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -47535,9 +44208,7 @@
     "code": "YHU3290",
     "name": "Dante\u2019s Divine Comedy",
     "creditCount": 5.0,
-    "preclusions": [
-      "YHU2230"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "YCC1111",
       "YCC1112"
@@ -47554,18 +44225,14 @@
     "code": "YHU3292",
     "name": "Life Drawing",
     "creditCount": 5.0,
-    "preclusions": [
-      "YHU4213"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "YHU3293",
     "name": "Japanese Woodblock Prints",
     "creditCount": 5.0,
-    "preclusions": [
-      "YHU1211"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -47664,9 +44331,7 @@
     "code": "YHU3308",
     "name": "Embodied Script Analysis",
     "creditCount": 5.0,
-    "preclusions": [
-      "YHU2259"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "YCC1111",
       "YCC1113",
@@ -47678,9 +44343,7 @@
     "code": "YHU3309",
     "name": "Living in Sound",
     "creditCount": 5.0,
-    "preclusions": [
-      "YHU2263"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -47736,9 +44399,7 @@
     "code": "YHU4214",
     "name": "Advanced Creative Nonfiction",
     "creditCount": 5.0,
-    "preclusions": [
-      "YHU3206"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "YHU2202"
     ]
@@ -47748,9 +44409,7 @@
     "name": "Advanced Poetry Writing",
     "creditCount": 5.0,
     "preclusions": [],
-    "prerequisites": [
-      "YHU1210"
-    ]
+    "prerequisites": []
   },
   {
     "code": "YHU4218",
@@ -47765,9 +44424,7 @@
     "code": "YHU4226",
     "name": "China and the West",
     "creditCount": 5.0,
-    "preclusions": [
-      "YHU3204"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -47775,9 +44432,7 @@
     "name": "Oceanic Frameworks: Shifting Currents in Lit. Studies",
     "creditCount": 5.0,
     "preclusions": [],
-    "prerequisites": [
-      "YHU3210"
-    ]
+    "prerequisites": []
   },
   {
     "code": "YHU4234",
@@ -47819,9 +44474,7 @@
     "code": "YHU4238",
     "name": "The Female Image in Japanese Art and Literature",
     "creditCount": 5.0,
-    "preclusions": [
-      "YHU3232"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -47861,11 +44514,9 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "YHU3201",
       "YHU3288",
       "YHU3216",
-      "YHU2223",
-      "YHU3273"
+      "YHU2223"
     ]
   },
   {
@@ -47957,9 +44608,7 @@
     "code": "YID3214",
     "name": "Urban Ecological Systems",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSS3272"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -47999,9 +44648,7 @@
     "name": "Directed Language Study: Intermediate Sanskrit",
     "creditCount": 5.0,
     "preclusions": [],
-    "prerequisites": [
-      "YIL1201S"
-    ]
+    "prerequisites": []
   },
   {
     "code": "YIR3311",
@@ -48130,7 +44777,6 @@
     "name": "Advanced Readings in Chinese: Cinematic and Literary Texts",
     "creditCount": 5.0,
     "preclusions": [
-      "YLC3201",
       "AY2016"
     ],
     "prerequisites": [
@@ -48142,7 +44788,6 @@
     "name": "Advanced Chinese: Readings in Modern Chinese Literature",
     "creditCount": 5.0,
     "preclusions": [
-      "YLC3202",
       "AY2016"
     ],
     "prerequisites": [
@@ -48153,9 +44798,7 @@
     "code": "YLG1201",
     "name": "Beginning Ancient Greek",
     "creditCount": 5.0,
-    "preclusions": [
-      "YLG2201"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -48164,8 +44807,7 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "YLG1201",
-      "YLG2201"
+      "YLG1201"
     ]
   },
   {
@@ -48180,9 +44822,7 @@
     "name": "Intermediate Latin",
     "creditCount": 5.0,
     "preclusions": [
-      "YLL1202",
       "YLL2202",
-      "YLL1202",
       "YLL2202"
     ],
     "prerequisites": [
@@ -48285,7 +44925,6 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "YSC1121",
       "YSC1213"
     ]
   },
@@ -48293,9 +44932,7 @@
     "code": "YSC2209",
     "name": "Proof",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSC1203"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -48312,7 +44949,6 @@
     "name": "Instrumental Analysis with Laboratory",
     "creditCount": 5.0,
     "preclusions": [
-      "YSC2207",
       "YSC2208"
     ],
     "prerequisites": [
@@ -48339,7 +44975,6 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "YC1122",
       "YC1131"
     ]
   },
@@ -48370,9 +45005,7 @@
     "code": "YSC2224",
     "name": "Organic Chemistry with Laboratory",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSC2206"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "YSC1207"
     ]
@@ -48393,8 +45026,7 @@
     "creditCount": 2.0,
     "preclusions": [
       "YSC3217",
-      "YSC3232",
-      "YSC3207"
+      "YSC3232"
     ],
     "prerequisites": [
       "YSC2221",
@@ -48405,9 +45037,7 @@
     "code": "YSC2228",
     "name": "Statistical Thermodynamics",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSC3224"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "YSC1207",
       "YSC1213"
@@ -48417,9 +45047,7 @@
     "code": "YSC2229",
     "name": "Introductory Data Structures and Algorithms",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSC2204"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "YSC1212"
     ]
@@ -48428,47 +45056,35 @@
     "code": "YSC2230",
     "name": "Probability and Statistics",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSC1204"
-    ],
-    "prerequisites": [
-      "YSC1211"
-    ]
+    "preclusions": [],
+    "prerequisites": []
   },
   {
     "code": "YSC2231",
     "name": "Foundations of Neuroscience",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSC2211"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "YSC2232",
     "name": "Linear Algebra",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSC3205"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "YSC2233",
     "name": "Genetics",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSC3201"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "YSC2234",
     "name": "Human Biology",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSC1201"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -48483,9 +45099,7 @@
     "name": "Advanced Algorithms and Data Structures",
     "creditCount": 5.0,
     "preclusions": [],
-    "prerequisites": [
-      "YSC2204"
-    ]
+    "prerequisites": []
   },
   {
     "code": "YSC3206",
@@ -48503,8 +45117,7 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "YSC2203",
-      "YSC2205"
+      "YSC2203"
     ]
   },
   {
@@ -48512,9 +45125,7 @@
     "name": "Introduction to Electrodynamics",
     "creditCount": 5.0,
     "preclusions": [],
-    "prerequisites": [
-      "YSC2205"
-    ]
+    "prerequisites": []
   },
   {
     "code": "YSC3213",
@@ -48543,8 +45154,7 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "YCC1122",
-      "YSC1206"
+      "YCC1122"
     ]
   },
   {
@@ -48553,7 +45163,6 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "YCC2221",
       "YSC1212"
     ]
   },
@@ -48562,9 +45171,7 @@
     "name": "Computer Vision and Deep Learning",
     "creditCount": 5.0,
     "preclusions": [],
-    "prerequisites": [
-      "YSC3205"
-    ]
+    "prerequisites": []
   },
   {
     "code": "YSC3227",
@@ -48580,9 +45187,7 @@
     "name": "Inorganic Chemistry with Laboratory",
     "creditCount": 5.0,
     "preclusions": [],
-    "prerequisites": [
-      "YSC2206"
-    ]
+    "prerequisites": []
   },
   {
     "code": "YSC3230",
@@ -48595,9 +45200,7 @@
     "code": "YSC3232",
     "name": "Object-Oriented Programming",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSC3207"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "YSC2221",
       "YSC1212"
@@ -48626,12 +45229,10 @@
       "YCC1122",
       "YCC1131",
       "YSC2231",
-      "YSC2211",
       "YSC2216",
       "YSS2201",
       "YCC1122",
       "YSC2231",
-      "YSC2211",
       "YSC2216",
       "YSS2201"
     ]
@@ -48650,7 +45251,6 @@
     "name": "Introduction to Modern Algebra",
     "creditCount": 5.0,
     "preclusions": [
-      "YSC3220",
       "YSC3204",
       "YSC3237"
     ],
@@ -48669,9 +45269,7 @@
     "code": "YSC3240",
     "name": "Foundations of Applied Mathematics",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSC2205"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -48745,10 +45343,8 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "YSC2205",
       "YSC2203",
-      "YSC2224",
-      "YSC2206"
+      "YSC2224"
     ]
   },
   {
@@ -48758,7 +45354,6 @@
     "preclusions": [],
     "prerequisites": [
       "YSC3233",
-      "YSC3238",
       "YSC2233",
       "YSC3214"
     ]
@@ -48784,9 +45379,7 @@
     "code": "YSC4215",
     "name": "Designing Interactive Systems",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSC3226"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "YSC3232"
     ]
@@ -48881,18 +45474,14 @@
     "code": "YSS2220",
     "name": "Introduction to Urban Studies",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSS1207"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "YSS2221",
     "name": "International Security",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSS3210"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -49156,9 +45745,7 @@
     "code": "YSS3270",
     "name": "Ethics and Global Affairs",
     "creditCount": 5.0,
-    "preclusions": [
-      "PS3233"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -49195,9 +45782,7 @@
     "code": "YSS3277",
     "name": "The Anthropological Imagination",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSS2209"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "YCC2121",
       "YCC1121"
@@ -49217,9 +45802,7 @@
     "code": "YSS3281",
     "name": "Urban Mobilities",
     "creditCount": 5.0,
-    "preclusions": [
-      "YSS3216A"
-    ],
+    "preclusions": [],
     "prerequisites": [
       "YSS2220"
     ]
@@ -49409,8 +45992,7 @@
     "creditCount": 5.0,
     "preclusions": [],
     "prerequisites": [
-      "YSS2201",
-      "YSS3214"
+      "YSS2201"
     ]
   },
   {
@@ -49483,18 +46065,14 @@
     "code": "ZB3311",
     "name": "Undergraduate Professional Internship",
     "creditCount": 4.0,
-    "preclusions": [
-      "XX3311"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
     "code": "ZB3312",
     "name": "Enhanced Undergraduate Professional Internship Programme",
     "creditCount": 12.0,
-    "preclusions": [
-      "XX3312"
-    ],
+    "preclusions": [],
     "prerequisites": []
   },
   {
@@ -49503,7 +46081,6 @@
     "creditCount": 4.0,
     "preclusions": [],
     "prerequisites": [
-      "LSM2104",
       "LSM2241",
       "LSM3241",
       "CS2220"

--- a/data/moduleInfo.json
+++ b/data/moduleInfo.json
@@ -1,0 +1,49519 @@
+[
+  {
+    "code": "ACC1002",
+    "name": "Financial Accounting",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FNA1002",
+      "ACC1002"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ACC1002X",
+    "name": "Financial Accounting",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS1304",
+      "EC3212",
+      "BK1003",
+      "BZ1002",
+      "BH1002",
+      "BZ1002E",
+      "BH1002E",
+      "FNA1002E",
+      "FNA1002X",
+      "ACC1002X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ACC1006",
+    "name": "Accounting Information Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FNA1006",
+      "ACC1006"
+    ],
+    "prerequisites": [
+      "FNA1002",
+      "ACC1002"
+    ]
+  },
+  {
+    "code": "ACC1701",
+    "name": "Accounting for Decision Makers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ACC1002",
+      "ACC1002X",
+      "EC2204"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ACC1701X",
+    "name": "Accounting for Decision Makers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ACC1002",
+      "ACC1002X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ACC2002",
+    "name": "Managerial Accounting",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH2002",
+      "BZ3102",
+      "BK2001",
+      "FNA2002",
+      "IE4242"
+    ],
+    "prerequisites": [
+      "BK1003",
+      "BZ1002",
+      "BH1002",
+      "FNA1002",
+      "FNA1002X",
+      "FNA1002E",
+      "ACC1002",
+      "ACC1002X",
+      "BH1002E",
+      "CS1304",
+      "EC3212",
+      "EG1422",
+      "ACC2002"
+    ]
+  },
+  {
+    "code": "ACC2706",
+    "name": "Managerial Accounting",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ACC2002"
+    ],
+    "prerequisites": [
+      "ACC1701",
+      "ACC1701X",
+      "EC2204"
+    ]
+  },
+  {
+    "code": "ACC2707",
+    "name": "Corporate Accounting & Reporting I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ACC3601"
+    ],
+    "prerequisites": [
+      "ACC1701",
+      "ACC1701X",
+      "EC2204",
+      "AC1002",
+      "ACC1002X"
+    ]
+  },
+  {
+    "code": "ACC2708",
+    "name": "Corporate Accounting & Reporting II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ACC3601"
+    ],
+    "prerequisites": [
+      "ACC2707"
+    ]
+  },
+  {
+    "code": "ACC2709",
+    "name": "Accounting Information Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ACC1006"
+    ],
+    "prerequisites": [
+      "ACC1701",
+      "ACC1701X",
+      "EC2204"
+    ]
+  },
+  {
+    "code": "ACC3601",
+    "name": "Corporate Accounting and Reporting",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3111",
+      "BZ3101",
+      "BK3106",
+      "FNA3111"
+    ],
+    "prerequisites": [
+      "FNA1002",
+      "ACC1002"
+    ]
+  },
+  {
+    "code": "ACC3603",
+    "name": "Assurance and Attestation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FNA3121",
+      "ACC3603"
+    ],
+    "prerequisites": [
+      "FNA1002",
+      "ACC1002",
+      "FNA2002"
+    ]
+  },
+  {
+    "code": "ACC3604",
+    "name": "Corporate and Securities Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FNA3122",
+      "LL4055",
+      "ACC3604"
+    ],
+    "prerequisites": [
+      "BSP1004"
+    ]
+  },
+  {
+    "code": "ACC3605",
+    "name": "Taxation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FNA3127",
+      "LL4056",
+      "ACC3605"
+    ],
+    "prerequisites": [
+      "FNA1002",
+      "ACC1002",
+      "BSP1004"
+    ]
+  },
+  {
+    "code": "ACC3606",
+    "name": "Advanced Corporate Accounting and Reporting",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FNA3123",
+      "ACC3606"
+    ],
+    "prerequisites": [
+      "FNA3111",
+      "ACC3601"
+    ]
+  },
+  {
+    "code": "ACC3614",
+    "name": "Valuation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FNA3126",
+      "ACC3614"
+    ],
+    "prerequisites": [
+      "FNA2004",
+      "FIN2004"
+    ]
+  },
+  {
+    "code": "ACC3616",
+    "name": "Corporate Governance and Risk Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ACC3611",
+      "ACC3612",
+      "AY2014"
+    ],
+    "prerequisites": [
+      "ACC1002",
+      "BSP1004",
+      "FIN2004"
+    ]
+  },
+  {
+    "code": "ACC3619",
+    "name": "Integrated Perspective in Accounting and Business",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ACC3701",
+    "name": "Assurance and Attestation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ACC3603"
+    ],
+    "prerequisites": [
+      "ACC2707",
+      "ACC2709"
+    ]
+  },
+  {
+    "code": "ACC3703",
+    "name": "Taxation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ACC3605",
+      "LL4056"
+    ],
+    "prerequisites": [
+      "ACC1701",
+      "ACC1701X",
+      "EC2204",
+      "BSP1702",
+      "BSP1702X"
+    ]
+  },
+  {
+    "code": "ACC4611",
+    "name": "Advanced Taxation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FNA4114",
+      "ACC4611"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ACC4612A",
+    "name": "SIA: Internal Auditing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ACC3603",
+      "ACC3616",
+      "ACC3603",
+      "ACC3611",
+      "ACC3612"
+    ]
+  },
+  {
+    "code": "ACC4612E",
+    "name": "SIA: Risk Management Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ACC4615",
+    "name": "Advanced Assurance and Attestation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FNA3128",
+      "ACC3613",
+      "ACC4615"
+    ],
+    "prerequisites": [
+      "FNA3121",
+      "ACC3603"
+    ]
+  },
+  {
+    "code": "ACC4619",
+    "name": "Advanced Independent Study in Accounting",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ACC4629",
+    "name": "Advanced Independent Study in Accounting",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ACC5001",
+    "name": "Business Analysis and Valuation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AH2101",
+    "name": "Introduction to Art History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AH2201",
+    "name": "Chinese Painting: Styles and Masters",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AH2101"
+    ]
+  },
+  {
+    "code": "AH2202",
+    "name": "Modern Art: A Critical Introduction",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AH2101"
+    ]
+  },
+  {
+    "code": "AH2203",
+    "name": "Empire and Art: India, Singapore, Malaya",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AH2101"
+    ]
+  },
+  {
+    "code": "AH3201",
+    "name": "A History of Contemporary Art",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AH2101"
+    ]
+  },
+  {
+    "code": "AH3202",
+    "name": "Time Traveller: The Curatorial in Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AH2101"
+    ]
+  },
+  {
+    "code": "AH3203",
+    "name": "Collecting Art in Europe and Asia (1500 CE \u2013 2000 CE)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AH2101"
+    ]
+  },
+  {
+    "code": "AH3204",
+    "name": "Methods and Approaches to Art History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AH2101"
+    ]
+  },
+  {
+    "code": "ALS1010",
+    "name": "Learning to Learn Better",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ALS1010CP",
+    "name": "Learning to Learn Better",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ALS1020",
+    "name": "Learning to Choose Better",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR1101",
+    "name": "Design I",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR1102",
+    "name": "Design 2",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR1327",
+    "name": "Structural Principles",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR1328",
+    "name": "The Tropical Envelope",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR2101",
+    "name": "Design 3",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR1101",
+      "AR1102"
+    ]
+  },
+  {
+    "code": "AR2102",
+    "name": "Design 4",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR1101",
+      "AR1102"
+    ]
+  },
+  {
+    "code": "AR2221",
+    "name": "History and Theory of Southeast Asia Architecture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR2222",
+    "name": "History & Theory Of Western Architecture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR2224",
+    "name": "Ideas and Approaches in Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR2225",
+    "name": "Reading Visual Images",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2044"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "AR2327",
+    "name": "Architectural Tectonics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR2522",
+    "name": "Computational Thinking: Performance Based Design",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR2524",
+    "name": "Spatial Computational Thinking",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR2723",
+    "name": "Strategies for Sustainable Architecture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR3101",
+    "name": "Design 5",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR2101",
+      "AR2102"
+    ]
+  },
+  {
+    "code": "AR3101A",
+    "name": "Design 5 (Landscape Architecture Emphasis)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR2101",
+      "AR2102"
+    ]
+  },
+  {
+    "code": "AR3102",
+    "name": "Design 6",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR2101",
+      "AR2102"
+    ]
+  },
+  {
+    "code": "AR3102A",
+    "name": "Design 6 (Landscape Architecture Emphasis)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR2101",
+      "AR2102"
+    ]
+  },
+  {
+    "code": "AR3151",
+    "name": "Design - ISM",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR3223",
+    "name": "Introduction to Urbanism",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR3411",
+    "name": "Architecture Internship Programme",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR3101",
+      "AR3102"
+    ]
+  },
+  {
+    "code": "AR3412",
+    "name": "Work Experience Internship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR3421",
+    "name": "Introduction to Architectural Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR3721",
+    "name": "Environmental Systems and Construction",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR1326",
+      "AR1731",
+      "AR2326",
+      "AR2723"
+    ]
+  },
+  {
+    "code": "AR4001",
+    "name": "Advanced Architectural Study 1",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR4002",
+    "name": "Advanced Architectural Study 2",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR4103",
+    "name": "Architectural & Technology Design 1",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR3101",
+      "AR3102"
+    ]
+  },
+  {
+    "code": "AR4421",
+    "name": "Architecture Internship Programme",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR3101",
+      "AR3102"
+    ]
+  },
+  {
+    "code": "AR5011",
+    "name": "Research Methodology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5121",
+    "name": "Special Topics In Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5221",
+    "name": "Contemporary Theories",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5312",
+    "name": "Typo-Morphology In Architecture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5321",
+    "name": "Advanced Architectural Integration",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5322",
+    "name": "Renewable Resources and Architecture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5423",
+    "name": "Architectural Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5601",
+    "name": "Urban Design Theory and Praxis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5770",
+    "name": "Graduate Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5801",
+    "name": "Options Design Research Studio 1",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR3101",
+      "AR3102"
+    ]
+  },
+  {
+    "code": "AR5802",
+    "name": "Options Design Research Studio 2",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR3101",
+      "AR3102"
+    ]
+  },
+  {
+    "code": "AR5803",
+    "name": "Architectural & Technology Design 1",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR3101",
+      "AR3102"
+    ]
+  },
+  {
+    "code": "AR5804",
+    "name": "Architectural & Technology Design 2",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR3101",
+      "AR3102"
+    ]
+  },
+  {
+    "code": "AR5806",
+    "name": "Architectural Design Research Report",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5807",
+    "name": "Architectural Design Thesis",
+    "creditCount": 20.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5808",
+    "name": "Final Design Project",
+    "creditCount": 20.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5951",
+    "name": "Topics in History & Theory of Architecture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5951A",
+    "name": "Topics in History and Theory of Architecture 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5951B",
+    "name": "Topics in History & Theory of Architecture 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5951C",
+    "name": "Topics in History and Theory of Architecture 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5951D",
+    "name": "Topics in History & Theory of Architecture 4",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5951L",
+    "name": "Topics in History and Theory of Architecture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5952A",
+    "name": "Topics in Urban Studies 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5952B",
+    "name": "Topics in Urban Studies 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5952C",
+    "name": "Special Topics in Urban Studies 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5952D",
+    "name": "Topics in Urban Studies 4",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5952E",
+    "name": "Topics in Urban Studies 5",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5952F",
+    "name": "Topics in Urban Studies 6",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5952G",
+    "name": "Topics in Urban Studies 7",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5953",
+    "name": "Topics in Design Technology 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5953A",
+    "name": "Topics in Design Technology 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5953B",
+    "name": "Topics in Design Technology 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5953C",
+    "name": "Topics in Design Technology 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5953D",
+    "name": "Topics in Design Technology 4",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5954",
+    "name": "Topics in Landscape Architecture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5954A",
+    "name": "Topics in Landscape Architecture 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5954B",
+    "name": "Topics in Landscape Architecture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5954C",
+    "name": "Topics in Landscape Architecture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5955",
+    "name": "Topics in Architectural Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5955A",
+    "name": "Topics in Research by Design 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5956A",
+    "name": "Topics in Design and Built Environment 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5956B",
+    "name": "Topics in Design and Built Environment 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5956C",
+    "name": "Topics in Design and Built Environment 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5956D",
+    "name": "Topics in Design and Built Environment 4",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5956E",
+    "name": "Topics in Design and Built Environment 5",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5957A",
+    "name": "Topics in History and Theory of Architecture 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5957B",
+    "name": "Topics in History and Theory of Architecture 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5957C",
+    "name": "Topics in History and Theory of Architecture 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5957D",
+    "name": "Topics in History and Theory of Architecture 4",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5957E",
+    "name": "Topics in History and Theory of Architecture 5",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5957F",
+    "name": "Topics in History and Theory of Architecture 6",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5958A",
+    "name": "Topics in Urbanism 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5958B",
+    "name": "Topics in Urbanism 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5958C",
+    "name": "Topics in Urbanism 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5959A",
+    "name": "Topics in Design Technology 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5959B",
+    "name": "Topics in Design Technology 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5959C",
+    "name": "Topics in Design Technology 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5959D",
+    "name": "Topics in Design Technology 4",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR5959E",
+    "name": "Topics in Design Technology 5",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AR6770",
+    "name": "Phd Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ASP1201CH",
+    "name": "H3 Humanities & Soc Sci Research Prog",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ASP1201EC",
+    "name": "H3 Humanities & Soc Sci Research Prog",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ASP1201EN",
+    "name": "H3 Humanities & Soc Sci Research Prog",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ASP1201GE",
+    "name": "H3 Humanities & Soc Sci Research Prog",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ASP1201HY",
+    "name": "H3 Humanities & Soc Sci Research Prog",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ASP1201MS",
+    "name": "H3 Humanities & Soc Sci Research Prog",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "AUD5114",
+    "name": "Electrophysiological Assessment B",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AUD5102",
+      "AUD5103",
+      "AUD5106",
+      "AUD5107",
+      "AUD5108"
+    ]
+  },
+  {
+    "code": "AUD5216",
+    "name": "Vestibular Assessment and Management B",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AUD5102",
+      "AUD5103",
+      "AUD5110"
+    ]
+  },
+  {
+    "code": "AUD5217",
+    "name": "Hearing Devices and Rehabilitation B (Part 1)",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AUD5101",
+      "AUD5104",
+      "AUD5105",
+      "AUD5111",
+      "AUD5106",
+      "AUD5112"
+    ]
+  },
+  {
+    "code": "AUD5218",
+    "name": "Clinical Audiology B (Part 1)",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AUD5105",
+      "AUD5111",
+      "AUD5106",
+      "AUD5112",
+      "AUD5107",
+      "AUD5113",
+      "AUD5108",
+      "AUD5114"
+    ]
+  },
+  {
+    "code": "AUD5219",
+    "name": "Paediatric Audiology B - Part 1",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AUD5105",
+      "AUD5111",
+      "AUD5107",
+      "AUD5113",
+      "AUD5108",
+      "AUD5114"
+    ]
+  },
+  {
+    "code": "AUD5220",
+    "name": "Independent Studies in Audiology (Research project - part 1)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AUD5115"
+    ]
+  },
+  {
+    "code": "AUD5221",
+    "name": "Hearing Devices and Rehabilitation B (Part 2)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AUD5101",
+      "AUD5104",
+      "AUD5105",
+      "AUD5111",
+      "AUD5106",
+      "AUD5112"
+    ]
+  },
+  {
+    "code": "AUD5222",
+    "name": "Clinical Audiology B (Part 2)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AUD5105",
+      "AUD5218"
+    ]
+  },
+  {
+    "code": "AUD5223",
+    "name": "Paediatric Audiology B - Part 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AUD5105",
+      "AUD5218"
+    ]
+  },
+  {
+    "code": "AUD5224",
+    "name": "Independent Studies in Audiology (Research project - part 2)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AUD5220"
+    ]
+  },
+  {
+    "code": "AY1130",
+    "name": "Human Anatomy and Physiology I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BAA6001",
+    "name": "Accounting Research Seminars I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BAA6002",
+    "name": "Accounting Research Seminars II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BAA6001"
+    ]
+  },
+  {
+    "code": "BBP5000",
+    "name": "Global Strategic Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BBP6782B",
+    "name": "Seminar in Behavioural Strategic Management",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BBP6794",
+    "name": "Seminar in Innovation and Entrepreneurship",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BBP6781"
+    ]
+  },
+  {
+    "code": "BDC5101",
+    "name": "Deterministic Operations Research Models",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BDC6111",
+    "name": "Foundations of Optimization",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE6001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BDC6112",
+    "name": "Stochastic Processes I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE6004"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BDC6302",
+    "name": "Discrete Optimization and Algorithms",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BDC6111",
+      "IE6001"
+    ]
+  },
+  {
+    "code": "BDC6304",
+    "name": "Robust modelling and optimization",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BDC6306",
+    "name": "Stochastic Processes II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE6505"
+    ],
+    "prerequisites": [
+      "BDC6112",
+      "IE6004"
+    ]
+  },
+  {
+    "code": "BHD4001",
+    "name": "Honours Dissertation",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3001A",
+    "name": "Business Internship I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3001B",
+    "name": "Business Internship I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3001C",
+    "name": "Business Internship I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3001D",
+    "name": "Business Internship I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3001E",
+    "name": "Business Internship I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3001F",
+    "name": "Business Internship I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3001G",
+    "name": "Business Internship I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3002A",
+    "name": "Business Internship II",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3002B",
+    "name": "Business Internship II",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3002C",
+    "name": "Business Internship II",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3002D",
+    "name": "Business Internship II",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3003",
+    "name": "Work Experience Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BI3001",
+      "BI3002",
+      "BI3003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3003A",
+    "name": "Work Experience Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BI3001",
+      "BI3002",
+      "BI3003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3003B",
+    "name": "Work Experience Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BI3001",
+      "BI3002",
+      "BI3003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3003C",
+    "name": "Work Experience Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BI3001",
+      "BI3002",
+      "BI3003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BI3003D",
+    "name": "Work Experience Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BI3001",
+      "BI3002",
+      "BI3003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BIS3001",
+    "name": "Independent Study Module in Business",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BIS3001A",
+    "name": "Independent Study Module in Business",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5102",
+    "name": "Environmental Science",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5198",
+    "name": "Graduate Seminar Module In Biological Sciences",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5201",
+    "name": "Structural Biology And Proteomics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5202A",
+    "name": "Biophysical Methods In Life Sciences",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5203",
+    "name": "Molecular Recognition And Interactions",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5207A",
+    "name": "Topics In Developmental Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5209",
+    "name": "Directed Studies in Molecular Ecology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5210",
+    "name": "Biogeography",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5213",
+    "name": "Protein Design & Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5215",
+    "name": "Macromolecular X-Ray Crystallography",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5216",
+    "name": "Advanced Genetics And Genome Sciences",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5217",
+    "name": "Population Genomics and Phylogenomics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5218",
+    "name": "Directed Studies in Behavioural Ecology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5220",
+    "name": "Advanced Animal Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5221",
+    "name": "Plant And Microbial Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5222",
+    "name": "Cellular Mechanisms",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5223",
+    "name": "Advanced Molecular Genetics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5224",
+    "name": "Special topics in Biological Sciences",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5228",
+    "name": "Advances in Cell and Molecular Biology",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5229",
+    "name": "Fundamentals in Biophysical Sciences",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5232",
+    "name": "Introduction to Bioimaging",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5232B",
+    "name": "Practical Bioimaging B: Light Microscopy",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BL5232"
+    ]
+  },
+  {
+    "code": "BL5232C",
+    "name": "Practical Bioimaging C: Hands-on Microscopy",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BL5232"
+    ]
+  },
+  {
+    "code": "BL5233",
+    "name": "Biological data analysis with R",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5234",
+    "name": "Theoretical Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5236",
+    "name": "Introduction to Electron Microscopy for Life Sciences",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BL5237",
+    "name": "Computational Biology: Sequences, Structures, Functions",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BLD3002",
+    "name": "CEOs as Leaders",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MNO1706",
+      "MNO1706X",
+      "PL3239",
+      "MNO2705"
+    ]
+  },
+  {
+    "code": "BLD3003",
+    "name": "Personal Leadership Development",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MNO1706",
+      "MNO1706X",
+      "PL3239",
+      "MNO2705"
+    ]
+  },
+  {
+    "code": "BLD3004",
+    "name": "Topics in Leadership Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MNO1706",
+      "MNO1706X",
+      "PL3239",
+      "MNO2705"
+    ]
+  },
+  {
+    "code": "BMA5001",
+    "name": "Managerial Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5002",
+    "name": "Analytics For Managers",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5003",
+    "name": "Financial Accounting",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5004A",
+    "name": "Management & Organization",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5005",
+    "name": "Management Accounting",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BMA5003"
+    ]
+  },
+  {
+    "code": "BMA5008",
+    "name": "Financial Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5009",
+    "name": "Marketing Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5010A",
+    "name": "Managing Operations",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5011",
+    "name": "Macroeconomics in the Global Economy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5013",
+    "name": "Corporate Strategy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5016A",
+    "name": "Leadership In Organizations",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5017",
+    "name": "Managerial Operations and Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5102",
+    "name": "Legal Issues In Business",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BMS5111"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5104",
+    "name": "Global Strategic Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5108",
+    "name": "New Venture Creation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5112",
+    "name": "Asian Business Environments",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5122",
+    "name": "Macroeconomics and Finance: Perspectives from Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5126",
+    "name": "Strategy and Big Data",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BMA5013"
+    ]
+  },
+  {
+    "code": "BMA5127",
+    "name": "Consulting: Process, Industry and Innovation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5128",
+    "name": "Venture Capital",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5129",
+    "name": "Leading with Strategy in Digital Firms",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5236",
+    "name": "Global Operations Strategy In The Digital Economy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5237",
+    "name": "Managing Global Value Chains and Networks",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5271",
+    "name": "Operations Leadership: Supply Chain and Service Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5302",
+    "name": "Investment Analysis And Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5309",
+    "name": "Fund Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5313",
+    "name": "Private Equity",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5313A",
+    "name": "Valuation and Mergers & Acquisitions",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5314",
+    "name": "Entrepreneurial Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5323",
+    "name": "Applied Portfolio Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5324",
+    "name": "Value Investing In Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5332",
+    "name": "Financial Regulation in a Digital Age",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5404",
+    "name": "Entrepreneurship & Innovation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5405",
+    "name": "Managing Change",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5406",
+    "name": "Negotiations and Conflict Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5411",
+    "name": "Talent Management and development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5506",
+    "name": "Product & Brand Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5511",
+    "name": "Channels And Pricing Strategy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5524",
+    "name": "Marketing Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5528",
+    "name": "Business To Business Marketing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5530",
+    "name": "Design Thinking & Product Innovations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5533",
+    "name": "Marketing in the Digital Age",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5801",
+    "name": "Management Communication",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5802",
+    "name": "Management Skills",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BMA5801"
+    ]
+  },
+  {
+    "code": "BMA5901",
+    "name": "Management Practicum",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5902",
+    "name": "Entrepreneurship Practicum",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMA5903",
+    "name": "MBA Internship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5001A",
+    "name": "Leadership",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5001B",
+    "name": "Managerial Skills",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5002A",
+    "name": "Corporate Strategy",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5002B",
+    "name": "Contemporary Issues in Strategy",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5003A",
+    "name": "Decision Making",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5003B",
+    "name": "Information Management",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5004A",
+    "name": "Managerial Economics",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5004B",
+    "name": "Asian Markets and Industries",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5005A",
+    "name": "International Business",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5005B",
+    "name": "International Business Law",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5006A",
+    "name": "Marketing Management",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5006B",
+    "name": "Contemporary Issues in Marketing",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5007A",
+    "name": "Accounting",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5007B",
+    "name": "Financial Management",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5008A",
+    "name": "Organizational Behavior and Human Resource Management",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5008B",
+    "name": "Contemporary Issues in Human Resouce Managment and Organuzational Behavior",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5009A",
+    "name": "Systems & Operations Management",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5009B",
+    "name": "Supply Chain Management",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5010A",
+    "name": "Corporate Finance",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5010B",
+    "name": "Corporate Governance",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5011A",
+    "name": "Contemporary Issues in Business 1",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5011B",
+    "name": "Contemporary Issues in Business 2",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMC5012",
+    "name": "Advanced Study Project",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5001",
+    "name": "Leadership",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5002",
+    "name": "Corporate Strategy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5003",
+    "name": "Business Analytics for Decision Makers",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5004",
+    "name": "Managerial Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5006",
+    "name": "Strategic Marketing and Brand Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5007",
+    "name": "Accounting",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5008",
+    "name": "Power, Politics, and Influence",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5009",
+    "name": "Strategic Operations Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5010",
+    "name": "Management of Technology and Innovation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5011",
+    "name": "Services Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5012",
+    "name": "Scenario Planning",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5014",
+    "name": "Legal Issues in Business",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5015",
+    "name": "Macroeconomics and International Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5018",
+    "name": "Managing Business For Sustainability",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5019",
+    "name": "Corporate Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5020",
+    "name": "Entrepreneurship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5021",
+    "name": "Corporate Governance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5022",
+    "name": "Business Strategy Simulation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BME5033",
+    "name": "Leadership: Exploration, Assessment & Development",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMF5001",
+    "name": "Financial Management of Family Business",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMF5321",
+    "name": "Financial Modelling",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMF5322",
+    "name": "Introduction to Finance",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMF5323",
+    "name": "Accounting for Finance Professionals",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMF5331",
+    "name": "Applied Corporate Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BMF5322"
+    ]
+  },
+  {
+    "code": "BMF5332",
+    "name": "Foundation of Investments",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BMF5322"
+    ]
+  },
+  {
+    "code": "BMF5333",
+    "name": "Options and Fixed Income",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BMF5322"
+    ]
+  },
+  {
+    "code": "BMF5334",
+    "name": "International Finance and Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BMF5322"
+    ]
+  },
+  {
+    "code": "BMK5003",
+    "name": "Behavioral Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMK5004",
+    "name": "Design Thinking & Business Innovations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMK5006",
+    "name": "Consumer Culture Theory",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT3423"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMK6102",
+    "name": "Marketing Seminar: Consumer Information Processing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMK6104",
+    "name": "Marketing Seminar: Marketing Theory & Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMK6106",
+    "name": "Empirical Modeling in Marketing (I)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMK6111O",
+    "name": "Marketing Strategy",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMM5001",
+    "name": "Leadership and Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMM5002",
+    "name": "Asia-Pacific Economic and Business Environment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMM5003",
+    "name": "Business Finance & Growth Economics for Policy Makers",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMM5101",
+    "name": "Judgment and Decision-Making for Modern Policy Makers",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMM5105",
+    "name": "Real Estate Fundamentals and City Planning",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMO5003",
+    "name": "Workplace and Corporate Deviance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMO5004",
+    "name": "Special Topics in Organizational Behavior",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMO6011A",
+    "name": "Organizational Behavior Seminar: Work, employee and organizational well-being",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMO6015A",
+    "name": "Organizational Behavior Seminar: Entrepreneurship and Innovation",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMO6016A",
+    "name": "Human Resource Management Seminar: Foundations",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMP5001",
+    "name": "Venture Capital",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMP5002",
+    "name": "Asian Business Environment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5105",
+    "name": "Strategy and Big Data",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5107",
+    "name": "Ethical Leadership and Corporate Strategy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5108",
+    "name": "Macroeconomics and Finance: Perspectives from Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5109",
+    "name": "Strategy: Bridging the Planning \u2013 Implementation Divide",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5110",
+    "name": "Managerial Economics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BMA5001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5111",
+    "name": "Legal Issues in Business",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BMA5102"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5202",
+    "name": "Global Supply Chain Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC5211A"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5203",
+    "name": "The Knowledge & Innovation Economy 4.0",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5204",
+    "name": "Cross-Border Business Management in the Digital Age",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5205",
+    "name": "Business Analytics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BMA5002"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5303",
+    "name": "Valuation and Mergers & Acquisitions",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FIN4116"
+    ],
+    "prerequisites": [
+      "FIN2004",
+      "FIN2004X"
+    ]
+  },
+  {
+    "code": "BMS5304",
+    "name": "Selected Topics in Finance: Private Equity",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BMA5313"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5306",
+    "name": "International Financial Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FIN3115",
+      "BMA5301"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5307",
+    "name": "Financial Markets and Institutions",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FIN3103",
+      "FIN3701"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5308",
+    "name": "Personal Finance and Wealth Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FIN4113",
+      "FIN4713"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5403",
+    "name": "Global Management Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5404",
+    "name": "Becoming Future Prepared Global Leaders",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5405",
+    "name": "New Venture Creation Practicum: Lean Startup Method",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5406",
+    "name": "Asian Leadership",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BMA5420"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5503",
+    "name": "Pricing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT4413"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5504",
+    "name": "Marketing Analysis and Decision Making",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT3421"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5505",
+    "name": "Marketing in the Digital Age",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT3415",
+      "BMA5533"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5900",
+    "name": "Block Seminar (with emphasis on Asian context)",
+    "creditCount": 2.0,
+    "preclusions": [
+      "BMO5000"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5901",
+    "name": "Business Project",
+    "creditCount": 10.0,
+    "preclusions": [
+      "BMO5002"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMS5902",
+    "name": "Entrepreneurship Practicum",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BMA5902",
+      "BMS5405"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BMU5003",
+    "name": "Economic Analysis For Managers",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMU5004",
+    "name": "Macroeconomics and International Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMU5006",
+    "name": "Marketing Strategy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMU5007",
+    "name": "Corporate Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMU5008",
+    "name": "Corporate Governance, Business Law & Ethics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMU5014",
+    "name": "Contemporary Issues In Business",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMU5015",
+    "name": "Competitive Strategy & Business Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BMU5017",
+    "name": "Management Practicum",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN1101",
+    "name": "Engineering Principles and Practice I",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN1102",
+    "name": "Engineering Principles and Practice II",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN2001",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN2102",
+    "name": "Bioengineering Data Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1506"
+    ]
+  },
+  {
+    "code": "BN2201",
+    "name": "Quantitative Physiology for Bioengineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM3212",
+      "PY1105",
+      "PY1106"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BN2202",
+    "name": "Introduction to Biotransport",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1505",
+      "MA1506"
+    ]
+  },
+  {
+    "code": "BN2204",
+    "name": "Fundamentals of Biomechanics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EG1109",
+      "EG1109M"
+    ],
+    "prerequisites": [
+      "PC1431"
+    ]
+  },
+  {
+    "code": "BN2301",
+    "name": "Biochemistry and Biomaterials for Bioengineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM1401"
+    ],
+    "prerequisites": [
+      "CM1501"
+    ]
+  },
+  {
+    "code": "BN2403",
+    "name": "Fundamentals of Biosignals and Bioinstrumentation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EG1108"
+    ],
+    "prerequisites": [
+      "PC1432",
+      "BN1102"
+    ]
+  },
+  {
+    "code": "BN3101",
+    "name": "Biomedical Engineering Design",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN3202",
+    "name": "Musculoskeletal Biomechanics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BN3201"
+    ],
+    "prerequisites": [
+      "BN2204"
+    ]
+  },
+  {
+    "code": "BN3301",
+    "name": "Introduction To Biomaterials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM1121",
+      "CM1501",
+      "LSM1101",
+      "LSM1401",
+      "MLE1101",
+      "MLE3104"
+    ]
+  },
+  {
+    "code": "BN3401",
+    "name": "Biomedical Electronics & Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BN2402"
+    ]
+  },
+  {
+    "code": "BN3402",
+    "name": "Bio-Analytical Methods In Bioengineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM1121",
+      "CM1501",
+      "LSM1101",
+      "LSM1401"
+    ]
+  },
+  {
+    "code": "BN3501",
+    "name": "Equilibrium and Kinetic Bioprocesses",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1506",
+      "PC1432",
+      "CN2122",
+      "ME2134",
+      "BN2202"
+    ]
+  },
+  {
+    "code": "BN4101",
+    "name": "B.Eng. Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN4101R",
+    "name": "B.Eng. Dissertation",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN4201",
+    "name": "Tissue Biomechanics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BN2204"
+    ]
+  },
+  {
+    "code": "BN4202",
+    "name": "Biofluids Dynamics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN2122",
+      "ME2134",
+      "BN2202"
+    ]
+  },
+  {
+    "code": "BN4203",
+    "name": "Rehabilitation Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BN3201"
+    ]
+  },
+  {
+    "code": "BN4301",
+    "name": "Principles Of Tissue Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BN3301"
+    ]
+  },
+  {
+    "code": "BN4402",
+    "name": "Electrophysiology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EG1108",
+      "PC1432"
+    ]
+  },
+  {
+    "code": "BN4403",
+    "name": "Cellular Bioengineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2103"
+    ]
+  },
+  {
+    "code": "BN4404",
+    "name": "Bioelectromechanical Systems - Biomems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN4406",
+    "name": "Biophotonics And Bioimaging",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BN2401"
+    ]
+  },
+  {
+    "code": "BN4501",
+    "name": "Engineering Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1505",
+      "MA1506",
+      "LSM1401"
+    ]
+  },
+  {
+    "code": "BN5101",
+    "name": "Biomedical Engineering Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN5102",
+    "name": "Clinical Instrumentation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN5104",
+    "name": "Quantitative Physiology Principles In Bioengineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN5201",
+    "name": "Advanced Biomaterials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN5202",
+    "name": "Advanced Tissue Biomechanics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN5203",
+    "name": "Advanced Tissue Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN5205",
+    "name": "Computational Biomechanics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN5207",
+    "name": "Medical Imaging Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MDG5225"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BN5208",
+    "name": "Biomedical Quality and Regulatory Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BN5401"
+    ]
+  },
+  {
+    "code": "BN5210",
+    "name": "Biosensors And Biochips",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN5501",
+    "name": "The Singapore-Stanford Biodesign Process",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN5511",
+    "name": "Introduction to Global Medical Device Regulation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN5512",
+    "name": "Medical Device Regulation in the US and EU",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN5666",
+    "name": "Industrial Attachment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN5999",
+    "name": "Graduate Seminars",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN6202",
+    "name": "Advanced Human Motion Biomechanics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN6209",
+    "name": "Neurotechnology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN6401",
+    "name": "Advanced Quantitative Fluorescence Microscopy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BN6999",
+    "name": "Doctoral Seminars",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BPM1701",
+    "name": "Calculus and Statistics",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BPM1702",
+    "name": "Microsoft Excel Skills for Business",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BPM1705",
+    "name": "Understanding How Business Works",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BPS5000",
+    "name": "Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BPS5111",
+    "name": "Integrated Building Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BPS5101",
+      "BPS5111"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BPS5112",
+    "name": "Green Building Integration and Evaluation Studio",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BPS5221",
+    "name": "Microclimate Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BPS5102",
+      "BPS5221"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BPS5222",
+    "name": "Indoor Environmental Quality",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BPS5201",
+      "BPS5202",
+      "BPS5222"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BPS5223",
+    "name": "Building Energy Performance - Passive Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BPS5204",
+      "BPS5223"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BPS5224",
+    "name": "Building Energy Performance - Active Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BPS5204",
+      "BPS5224"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BPS5225",
+    "name": "Building Energy Audit and Performance Measurement and Verification",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BPS5226",
+    "name": "Smart Buildings and Facilities",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BPS5227",
+    "name": "Maintainability and Green Facilities Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BPS5205",
+      "BPS5227"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BPS5228",
+    "name": "Advanced Building Materials and Structures",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BPS5300",
+    "name": "Topics in Building Performance and Sustainability",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BRP6551",
+    "name": "Graduate Research Seminar 1",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BRP6552",
+    "name": "Graduate Research Seminar 2",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BS5770",
+    "name": "Graduate Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BS6770",
+    "name": "Phd Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BSN3702",
+    "name": "New Venture Creation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BSP1004",
+    "name": "Legal Environment Of Business",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSB2212",
+      "BH1004",
+      "BZ1004",
+      "BK1006",
+      "GEK1009",
+      "GEM1009",
+      "SSD1203",
+      "BSP1004A",
+      "BSP1004B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BSP1004X",
+    "name": "Legal Environment Of Business",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSB2212",
+      "BH1004",
+      "BZ1004",
+      "BK1006",
+      "GEK1009",
+      "GEM1009",
+      "SSD1203",
+      "BSP1004A",
+      "BSP1004B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BSP1005",
+    "name": "Managerial Economics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH1005",
+      "BZ1006",
+      "BK1008"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BSP1702",
+    "name": "Legal Environment of Business",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BSP1004",
+      "BSP1004X",
+      "RE1703"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BSP1702X",
+    "name": "Legal Environment of Business",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BSP1004",
+      "BSP1004X",
+      "RE1703"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BSP1703",
+    "name": "Managerial Economics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BSP1005",
+      "EC2101",
+      "EC1101E",
+      "EC1301"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BSP2001",
+    "name": "Macro And International Economics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH2001",
+      "BZ2001",
+      "EC1101",
+      "EC1101E",
+      "EC1310",
+      "EC1301",
+      "EC3341",
+      "EC4102",
+      "EC2102"
+    ],
+    "prerequisites": [
+      "BSP1005",
+      "BH1005",
+      "BZ1006",
+      "BK1008"
+    ]
+  },
+  {
+    "code": "BSP2005",
+    "name": "Asian Business Environments",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH2005",
+      "BZ2005"
+    ],
+    "prerequisites": [
+      "BSP2001"
+    ]
+  },
+  {
+    "code": "BSP2701",
+    "name": "Global Economy",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BSP1703",
+      "BSP1707",
+      "EC1101E",
+      "EC1301"
+    ]
+  },
+  {
+    "code": "BSP3001",
+    "name": "Strategic Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BSP3001A",
+      "BSP3001B",
+      "BSP3001C",
+      "BSP3001D",
+      "BSP3001E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BSP3513",
+    "name": "Family Business",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BSP4513",
+    "name": "Econometrics: Theory and Practical Business Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC2303",
+      "EC3303",
+      "EC3304",
+      "EC4305"
+    ],
+    "prerequisites": [
+      "BSP1005",
+      "IS3240"
+    ]
+  },
+  {
+    "code": "BSP4515",
+    "name": "Managing Social Networks in Markets and Organizations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MNO1001"
+    ]
+  },
+  {
+    "code": "BT1101",
+    "name": "Introduction to Business Analytics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC1007",
+      "DSC1007X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "BT2101",
+    "name": "Decision Making Methods and Tools",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1010",
+      "MA1521",
+      "MA1102R",
+      "BT1101"
+    ]
+  },
+  {
+    "code": "BT2102",
+    "name": "Data Management and Visualisation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1010",
+      "BT1101"
+    ]
+  },
+  {
+    "code": "BT3101",
+    "name": "Business Analytics Capstone Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BT2101",
+      "BT2102",
+      "IS2101"
+    ]
+  },
+  {
+    "code": "BT3102",
+    "name": "Computational Methods for Business Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BT2101",
+      "CS1020",
+      "CS2020",
+      "CS2030",
+      "CS2103",
+      "CS2113"
+    ]
+  },
+  {
+    "code": "BT3103",
+    "name": "Application Systems Development for Business Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BT2102"
+    ]
+  },
+  {
+    "code": "BT4012",
+    "name": "Fraud Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BT3102"
+    ]
+  },
+  {
+    "code": "BT4013",
+    "name": "Analytics for Capital Market Trading and Investment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BT3102"
+    ]
+  },
+  {
+    "code": "BT4014",
+    "name": "Analytics Driven Design of Adaptive Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BT2102"
+    ]
+  },
+  {
+    "code": "BT4016",
+    "name": "Risk Analytics for Financial Services",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BT2101",
+      "BT2102"
+    ]
+  },
+  {
+    "code": "BT4101",
+    "name": "B.Sc. (Business Analytics) Dissertation",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BT4211",
+    "name": "Data-Driven Marketing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MKT1705X",
+      "BT3101",
+      "BT3102"
+    ]
+  },
+  {
+    "code": "BT4212",
+    "name": "Search Engine Optimization and Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1010S",
+      "BT2101",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "BT4221",
+    "name": "Big Data Techniques and Technologies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BT2101",
+      "BT2102",
+      "CS2010",
+      "CS2020",
+      "CS2040"
+    ]
+  },
+  {
+    "code": "BT4222",
+    "name": "Mining Web Data for Business Insights",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BT2102",
+      "CS1020",
+      "CS2030",
+      "CS2103",
+      "CS2113"
+    ]
+  },
+  {
+    "code": "BT4240",
+    "name": "Machine Learning for Predictive Data Analytics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IS4240"
+    ],
+    "prerequisites": [
+      "MA1311",
+      "MA1101R",
+      "MA1521",
+      "MA1102R",
+      "BT2101"
+    ]
+  },
+  {
+    "code": "BT5110",
+    "name": "Data Management and Warehousing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BT5126",
+    "name": "Hands-on with Business Analytics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IS5126"
+    ],
+    "prerequisites": [
+      "DSC5103"
+    ]
+  },
+  {
+    "code": "BT5152",
+    "name": "Decision Making Technology for Business",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IS5152"
+    ],
+    "prerequisites": [
+      "DSC5103"
+    ]
+  },
+  {
+    "code": "BX5101",
+    "name": "Business And The Environment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BZD6000",
+    "name": "Applied Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BZD6001",
+    "name": "Model Building Workshop I: Static Models",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC6101"
+    ]
+  },
+  {
+    "code": "BZD6003",
+    "name": "Applied Econometrics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BZD6004",
+    "name": "Applied Econometrics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BZD6003"
+    ]
+  },
+  {
+    "code": "BZD6008",
+    "name": "Cognition and Affect",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BZD6009",
+    "name": "Motivation and Interpersonal Processes",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BZD6010",
+    "name": "Seminar In Research Methodology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BZD6011",
+    "name": "Advanced Quantitative Research Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "BZD6012",
+    "name": "Experimental Methods for Behavioral Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CAS5101",
+    "name": "Theorizing from Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CAS6101",
+    "name": "Asian Studies in Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CAS6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CDM5102",
+    "name": "Translational Cancer Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CDM5101"
+    ]
+  },
+  {
+    "code": "CDM5103",
+    "name": "Advanced Topics in RNA Biology and Human Diseases",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE1101",
+    "name": "Civil Engineering Principles and Practice",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE1102",
+    "name": "Principles & Practice in Infrastructure and Environment",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE2112",
+    "name": "Soil Mechanics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE2112"
+    ],
+    "prerequisites": [
+      "EG1109"
+    ]
+  },
+  {
+    "code": "CE2134",
+    "name": "Hydraulics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ME2134",
+      "TCE2134"
+    ],
+    "prerequisites": [
+      "EG1109FC",
+      "EG1109",
+      "CE1109X"
+    ]
+  },
+  {
+    "code": "CE2155",
+    "name": "Structural Mechanics and Materials",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE2155"
+    ],
+    "prerequisites": [
+      "EG1109FC",
+      "EG1109"
+    ]
+  },
+  {
+    "code": "CE2183",
+    "name": "Construction Project Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE2183"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CE2407",
+    "name": "Engineering & Uncertainty Analyses",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE2407"
+    ],
+    "prerequisites": [
+      "MA1505",
+      "MA1506"
+    ]
+  },
+  {
+    "code": "CE2409",
+    "name": "Computer Applications in Civil Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE2408"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CE3101",
+    "name": "Integrated Infrastructure Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE3102",
+    "name": "Socio-economically sustainable developments",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE3115",
+    "name": "Geotechnical Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE3115"
+    ],
+    "prerequisites": [
+      "CE2112"
+    ]
+  },
+  {
+    "code": "CE3116",
+    "name": "Foundation Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE3116"
+    ],
+    "prerequisites": [
+      "CE2112"
+    ]
+  },
+  {
+    "code": "CE3121",
+    "name": "Transportation Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE3121"
+    ],
+    "prerequisites": [
+      "CE2407"
+    ]
+  },
+  {
+    "code": "CE3132",
+    "name": "Water Resources Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE3132"
+    ],
+    "prerequisites": [
+      "CE2134"
+    ]
+  },
+  {
+    "code": "CE3155",
+    "name": "Structural Analysis",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE3155"
+    ],
+    "prerequisites": [
+      "EG1109FC",
+      "EG1109",
+      "CE1109X"
+    ]
+  },
+  {
+    "code": "CE3165",
+    "name": "Structural Concrete Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE3165"
+    ],
+    "prerequisites": [
+      "CE3155"
+    ]
+  },
+  {
+    "code": "CE3166",
+    "name": "Structural Steel Design and System",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE3166"
+    ],
+    "prerequisites": [
+      "CE2155",
+      "CE3155"
+    ]
+  },
+  {
+    "code": "CE4103",
+    "name": "Design Project",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE4103"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CE4104",
+    "name": "B. Eng. Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [
+      "TCE4104"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CE4221",
+    "name": "Design of Land Transport Infrastructures",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE4221"
+    ],
+    "prerequisites": [
+      "CE3121"
+    ]
+  },
+  {
+    "code": "CE4257",
+    "name": "Linear Finite Element Analysis",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE4257"
+    ],
+    "prerequisites": [
+      "CE3155"
+    ]
+  },
+  {
+    "code": "CE4257A",
+    "name": "Finite Element Concepts & Applications",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE4257B",
+    "name": "Finite Element Analysis for Civil Engineering",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE4257A"
+    ]
+  },
+  {
+    "code": "CE4258",
+    "name": "Structural Stability & Dynamics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE4258"
+    ],
+    "prerequisites": [
+      "CE2407",
+      "CE3155"
+    ]
+  },
+  {
+    "code": "CE4282",
+    "name": "Building Information Modeling for Project Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE4282"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5001",
+    "name": "Research Project",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5101",
+    "name": "Seepage & Consolidation of Soils",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5104",
+    "name": "Underground Space",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE2112"
+    ]
+  },
+  {
+    "code": "CE5104A",
+    "name": "Tunnelling in Soils",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5104B",
+    "name": "Tunnelling in Rocks",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5105",
+    "name": "Analytical & Numerical Methods In Foundation Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE2112"
+    ]
+  },
+  {
+    "code": "CE5106",
+    "name": "Ground Improvement",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE5106"
+    ],
+    "prerequisites": [
+      "CE2112"
+    ]
+  },
+  {
+    "code": "CE5106A",
+    "name": "Ground Improvement for Soft Soils",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5106B",
+    "name": "Advanced Ground Improvement for Difficult Ground",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE5106A"
+    ]
+  },
+  {
+    "code": "CE5107",
+    "name": "Pile Foundations",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE5107"
+    ],
+    "prerequisites": [
+      "CE2112",
+      "CE3116"
+    ]
+  },
+  {
+    "code": "CE5107A",
+    "name": "Principles of Pile Foundation Design",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5107B",
+    "name": "Pile Foundation Problems and EC7 Impact",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE5107A"
+    ]
+  },
+  {
+    "code": "CE5108",
+    "name": "Earth Retaining Structures",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE5108"
+    ],
+    "prerequisites": [
+      "CE2112"
+    ]
+  },
+  {
+    "code": "CE5108A",
+    "name": "Lateral Earth Pressures and Retaining Wall Design via Eurocode 7",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5108B",
+    "name": "Deep Excavations Design Using Eurocode 7",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE5108A"
+    ]
+  },
+  {
+    "code": "CE5111",
+    "name": "Underground Construction Design Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5112",
+    "name": "Structural Support Systems for Excavation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE5108"
+    ]
+  },
+  {
+    "code": "CE5113",
+    "name": "Geotechnical Investigation & Monitoring",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE5113"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5113A",
+    "name": "Geotechnical Investigation according to EC7",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5113B",
+    "name": "Geophysical Methods & Geotechnical Monitoring",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE5113A"
+    ]
+  },
+  {
+    "code": "CE5203",
+    "name": "Traffic Flow & Control",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE3121"
+    ]
+  },
+  {
+    "code": "CE5204",
+    "name": "Pavement Design & Rehabilitation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5205",
+    "name": "Transportation Planning",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE3121"
+    ]
+  },
+  {
+    "code": "CE5207",
+    "name": "Pavement Network Management Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE3121"
+    ]
+  },
+  {
+    "code": "CE5307",
+    "name": "Wave Hydrodynamics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "OT5201"
+    ],
+    "prerequisites": [
+      "CE2134"
+    ]
+  },
+  {
+    "code": "CE5308",
+    "name": "Coastal Processes & Sediment Transport",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE5307"
+    ]
+  },
+  {
+    "code": "CE5310",
+    "name": "Hydroinformatics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5312",
+    "name": "River Mechanics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE3132"
+    ]
+  },
+  {
+    "code": "CE5314",
+    "name": "HEWRM Project",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5377",
+    "name": "Numerical Methods in Mechanics & Envr. Flows",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE5311",
+      "CE6003",
+      "CE6077"
+    ],
+    "prerequisites": [
+      "EG1109",
+      "CE1109",
+      "CE2134"
+    ]
+  },
+  {
+    "code": "CE5509",
+    "name": "Advanced Structural Steel Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE5509"
+    ],
+    "prerequisites": [
+      "CE3166"
+    ]
+  },
+  {
+    "code": "CE5509A",
+    "name": "Advanced Structural Steel Design to EC3",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5509B",
+    "name": "Design of Composite Steel and Concrete Structures to EC4",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5510",
+    "name": "Advanced Structural Concrete Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE5510"
+    ],
+    "prerequisites": [
+      "CE3165"
+    ]
+  },
+  {
+    "code": "CE5510A",
+    "name": "Structural Concrete Design to EC2",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5510B",
+    "name": "Advanced Structural Concrete Design to EC2",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE5510A"
+    ]
+  },
+  {
+    "code": "CE5513",
+    "name": "Plastic Analysis Of Structures",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE5885A"
+    ],
+    "prerequisites": [
+      "CE2155"
+    ]
+  },
+  {
+    "code": "CE5603",
+    "name": "Engineering Economics & Project Evaluation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5604",
+    "name": "Advanced Concrete Technology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE5604"
+    ],
+    "prerequisites": [
+      "CE2155"
+    ]
+  },
+  {
+    "code": "CE5610",
+    "name": "Assessment and Retrofit of Concrete Structures",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE3165"
+    ]
+  },
+  {
+    "code": "CE5610A",
+    "name": "Concrete and Cementitious Composites",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5610B",
+    "name": "Repair and Retrofit of Concrete Structures",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5611",
+    "name": "Precast Concrete Technology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE5610",
+      "AY2008",
+      "TCE5611"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5611A",
+    "name": "Specifying Concrete to EN 206",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5611B",
+    "name": "Precast Concrete Design",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5666",
+    "name": "Industrial Attachment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5804",
+    "name": "Global Infrastructure Project Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE2183"
+    ]
+  },
+  {
+    "code": "CE5805",
+    "name": "DfMA & Productivity Analytics in Construction",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE5805"
+    ],
+    "prerequisites": [
+      "CE2183"
+    ]
+  },
+  {
+    "code": "CE5806",
+    "name": "Advanced Project Management with Lean Construction",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE2183"
+    ]
+  },
+  {
+    "code": "CE5881",
+    "name": "Topics In Geotechnical Engineering: Soil Dynamics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5883A",
+    "name": "Topics in Hydraulic & Water Resources - Environmental Hydraulics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE5999",
+    "name": "Graduate Seminars",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE6001",
+    "name": "Operations & Management Of Infrastructure Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE6002",
+    "name": "Analysis Of Civil Engineering Experiments",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE6006",
+    "name": "Advanced Finite Element Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE6077",
+    "name": "Advanced Numerical Methods in Mechanics & Envr. Flows",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE5311",
+      "CE6003",
+      "CE5377"
+    ],
+    "prerequisites": [
+      "EG1109",
+      "CE1109",
+      "CE2134"
+    ]
+  },
+  {
+    "code": "CE6101",
+    "name": "Geotechnical Constitutive Modeling",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE6102",
+    "name": "Geotechnical Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CE6999",
+    "name": "Doctoral Seminars",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CFG1002",
+    "name": "Career Catalyst",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CFG1010",
+    "name": "Roots and Wings - Personal and Interpersonal Effectiveness 1.0",
+    "creditCount": 2.0,
+    "preclusions": [
+      "CFG1020"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CG1111",
+    "name": "Engineering Principles and Practice I",
+    "creditCount": 6.0,
+    "preclusions": [
+      "CG1108",
+      "EG1112"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CG1112",
+    "name": "Engineering Principles and Practice II",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1010",
+      "CG1111"
+    ]
+  },
+  {
+    "code": "CG2023",
+    "name": "Signals and Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2023"
+    ],
+    "prerequisites": [
+      "MA1506",
+      "MA1512"
+    ]
+  },
+  {
+    "code": "CG2027",
+    "name": "Transistor-level Digital Circuits",
+    "creditCount": 2.0,
+    "preclusions": [
+      "EE2021"
+    ],
+    "prerequisites": [
+      "CG1111",
+      "CG1108",
+      "EG1112"
+    ]
+  },
+  {
+    "code": "CG2028",
+    "name": "Computer Organization",
+    "creditCount": 2.0,
+    "preclusions": [
+      "EE2024"
+    ],
+    "prerequisites": [
+      "CS1010",
+      "EE2026",
+      "EE2020"
+    ]
+  },
+  {
+    "code": "CG2271",
+    "name": "Real-Time Operating Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2106"
+    ],
+    "prerequisites": [
+      "CS1020",
+      "CS2040"
+    ]
+  },
+  {
+    "code": "CG3002",
+    "name": "Embedded Systems Design Project",
+    "creditCount": 6.0,
+    "preclusions": [
+      "EE3032",
+      "EE3208"
+    ],
+    "prerequisites": [
+      "EE2024",
+      "CG2271",
+      "CS2113"
+    ]
+  },
+  {
+    "code": "CG3207",
+    "name": "Computer Architecture",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3207E",
+      "TEE3207"
+    ],
+    "prerequisites": [
+      "EE2024",
+      "AY2016",
+      "CG2028",
+      "EE2028",
+      "AY2017"
+    ]
+  },
+  {
+    "code": "CG4001",
+    "name": "B. Eng. Dissertation",
+    "creditCount": 12.0,
+    "preclusions": [
+      "EE4001",
+      "CP4101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CH1101E",
+    "name": "Retelling Chinese Stories: Change and Continuity",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH1731",
+    "name": "Department Exchange Module",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH2121",
+    "name": "History of Chinese Literature",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CL2121"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CH2141",
+    "name": "General History of China",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CL2241",
+      "CL2141"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CH2161",
+    "name": "Traditional Chinese Taxonomy of Learning",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CH1101E",
+      "CH2121",
+      "CL2121",
+      "CH2141",
+      "CL2241"
+    ]
+  },
+  {
+    "code": "CH2221",
+    "name": "Modern Chinese Literature",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CH3226"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CH2243",
+    "name": "Chinese in Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH2244",
+    "name": "Chinese Women: Traditions and Transformations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH2274",
+    "name": "Discovering the Chinese Business Environment",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CH2271"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CH2275",
+    "name": "Chinese Pop Music in East Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH2293",
+    "name": "Introduction to Chinese Art (taught in English)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CH2272"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CH2391",
+    "name": "Strangers in Chinese Literature (in English)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH3221",
+    "name": "Selected Readings in Chinese Verse",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CL3221"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CH3222",
+    "name": "Chinese Drama",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH3225",
+    "name": "Chinese Literature in S'pore & M'sia II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH3228",
+    "name": "Classical Poetry: Writing and Criticism",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH3231",
+    "name": "Chinese Fiction",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CH2223"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CH3246",
+    "name": "Socio-Political History of Modern China",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH3273",
+    "name": "Modern and Contemporary Chinese Popular Literature",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH3295",
+    "name": "Understanding China: Past and Present (in English)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH3297",
+    "name": "Chinese Business Enterprises and Management (in English)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH4204",
+    "name": "Selected Topics in Chinese Linguistics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH4207",
+    "name": "History of Chinese Language",
+    "creditCount": 5.0,
+    "preclusions": [
+      "CL3206"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CH4223",
+    "name": "Chinese Literary Criticism",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH4226",
+    "name": "The City in Modern Chinese Literature",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH4247",
+    "name": "Print Culture in Modern China",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH4261",
+    "name": "Prescribed Text: Zhuangzi",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH4262",
+    "name": "Transregional Chinese Literary Connections",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH4281",
+    "name": "Translation Studies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CL3281",
+      "CL3281"
+    ]
+  },
+  {
+    "code": "CH4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "CH4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CH4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "CH4401",
+      "CH4401S"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CH4882A",
+    "name": "Personalities in Modern Chinese History",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH5210",
+    "name": "Chinese Lexical Semantics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH5210R",
+    "name": "Chinese Lexical Semantics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH5211",
+    "name": "Seminar in Chinese Pragmatics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH5211R",
+    "name": "Seminar In Chinese Pragmatics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH5212",
+    "name": "THEORIES IN PHONOLOGY (Taught in English)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH5212R",
+    "name": "Theories In Phonology (Taught In English)",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH5213",
+    "name": "Cognitive Linguistics & Chinese Language",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CH6201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CH5213R",
+    "name": "Cognitive Linguistics & Chinese Language",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH5224",
+    "name": "Prescribed Texts In Literature",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH5224R",
+    "name": "Prescribed Texts in Literature",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH5660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH5880",
+    "name": "Topics in Applied Chinese Linguistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH5880R",
+    "name": "Topics in Applied Chinese Linguistics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH6201",
+    "name": "Topics In Chinese Linguistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH6203",
+    "name": "Grammaticalization and Chinese Grammar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH6221",
+    "name": "Topics In Classical Chinese Literature",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH6241",
+    "name": "Topics In Chinese History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH6243",
+    "name": "Seminar In Se Asian Chinese Studies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH6261",
+    "name": "Chinese Studies In The West",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH6262",
+    "name": "Independent Study In Chinese Studies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH6263",
+    "name": "Translation: Formal, Cultural, Political",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CH6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5101",
+    "name": "Contemporary Research in Chinese Studies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5102",
+    "name": "Contemporary Research in Chinese Language",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5301",
+    "name": "History and Civilizations of the Tang Empire",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5302",
+    "name": "Chinese Buddhist Proselytic Literature",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5303",
+    "name": "Traditional Chinese Culture in Singapore and Malaysia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5304",
+    "name": "Society and Culture of the Ming Dynasty",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5305",
+    "name": "Prominent Nanyang Chinese in Modern China",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5306",
+    "name": "Chinese Intellectual History, 10th \u2013 19th Century",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5307",
+    "name": "Major Themes in Chinese History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5309",
+    "name": "Economic & Management Thought in Pre-Modern China",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5310",
+    "name": "Chinese Rhapsody",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5312",
+    "name": "Tang-Song Poetry and Poetics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5313",
+    "name": "Thematics in Chinese Literature",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5314",
+    "name": "Chinese Religion",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5315",
+    "name": "Neo-Taoism",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5322",
+    "name": "Pragmatics and Politeness",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CHC5323",
+    "name": "Special Topics in Chinese Linguistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CL1101E",
+    "name": "Chinese Language: Its Past and Present",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CL2101",
+    "name": "The Chinese Script : History and Issues",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CL2201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CL2102",
+    "name": "Chinese Phonetics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CL2202"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CL2103",
+    "name": "Chinese Grammar",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CL2203"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CL2104",
+    "name": "Reading/Writing Chinese",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CL2121",
+    "name": "History of Chinese Literature",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CH2121"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CL2241",
+    "name": "General History of China",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CH2141",
+      "CL2141"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CL2280",
+    "name": "Basic Translation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CL2281",
+    "name": "Translation and Interpretation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CL3203",
+    "name": "Chinese Pragmatics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CL3204",
+    "name": "Classical Chinese",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CL1101E"
+    ]
+  },
+  {
+    "code": "CL3211",
+    "name": "The Standardization of the Chinese Language",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CL3214",
+    "name": "Aspects of Chinese Linguistics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CL2292",
+      "CL2208"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CL3221",
+    "name": "Selected Readings in Chinese Verse",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CH3221"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CL3284",
+    "name": "Literary Translation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CL2280",
+      "CL2281"
+    ]
+  },
+  {
+    "code": "CL3285",
+    "name": "Computer-Assisted Translation Tools",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CL2280",
+      "CL2281"
+    ]
+  },
+  {
+    "code": "CLC2101",
+    "name": "Engaging and Building Communities",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UHB2213"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CLC2201",
+    "name": "Community Development Practicum",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM1111",
+    "name": "Inorganic Chemistry 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM1121",
+    "name": "Organic Chemistry 1",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM1501",
+      "CM1503",
+      "CM1401"
+    ],
+    "prerequisites": [
+      "CM1417",
+      "CM1417X"
+    ]
+  },
+  {
+    "code": "CM1131",
+    "name": "Physical Chemistry 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM1191",
+    "name": "Experiments in Chemistry 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM1401",
+    "name": "Chemistry for Life Sciences",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM1121",
+      "CM1402",
+      "CM1501"
+    ],
+    "prerequisites": [
+      "CM1417",
+      "CM1417X"
+    ]
+  },
+  {
+    "code": "CM1402",
+    "name": "General Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM1401"
+    ],
+    "prerequisites": [
+      "CM1417",
+      "CM1417X"
+    ]
+  },
+  {
+    "code": "CM1417",
+    "name": "Fundamentals of Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM1417X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CM1417X",
+    "name": "Fundamentals of Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM1417"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CM1501",
+    "name": "Organic Chemistry for Engineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM1121",
+      "CM1503",
+      "CM1401"
+    ],
+    "prerequisites": [
+      "CM1417",
+      "CM1417X"
+    ]
+  },
+  {
+    "code": "CM1502",
+    "name": "General and Physical Chemistry for Engineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM1502FC",
+      "CM1502X"
+    ],
+    "prerequisites": [
+      "CM1417",
+      "CM1417X"
+    ]
+  },
+  {
+    "code": "CM1502X",
+    "name": "General and Physical Chemistry for Engineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM1502",
+      "CM1502FC"
+    ],
+    "prerequisites": [
+      "CM1417",
+      "CM1417X"
+    ]
+  },
+  {
+    "code": "CM2101",
+    "name": "Physical Chemistry 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM1131"
+    ]
+  },
+  {
+    "code": "CM2111",
+    "name": "Inorganic Chemistry 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM1111"
+    ]
+  },
+  {
+    "code": "CM2121",
+    "name": "Organic Chemistry 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM1121"
+    ]
+  },
+  {
+    "code": "CM2191",
+    "name": "Experiments in Chemistry 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM1191"
+    ]
+  },
+  {
+    "code": "CM2192",
+    "name": "Experiments in Chemistry 3",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM2142"
+    ],
+    "prerequisites": [
+      "CM1191"
+    ]
+  },
+  {
+    "code": "CM2288",
+    "name": "Basic UROPS in Chemistry I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM1111",
+      "CM1121",
+      "CM1131"
+    ]
+  },
+  {
+    "code": "CM2289",
+    "name": "Basic UROPS In Chemistry II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM1111",
+      "CM1121",
+      "CM1131"
+    ]
+  },
+  {
+    "code": "CM3201",
+    "name": "Principles of Chemical Processes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CN1111",
+      "CM1161",
+      "CM2161"
+    ],
+    "prerequisites": [
+      "CM1131",
+      "CM2101",
+      "MA1421",
+      "MA1102R"
+    ]
+  },
+  {
+    "code": "CM3212",
+    "name": "Transition Metal Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2111"
+    ]
+  },
+  {
+    "code": "CM3221",
+    "name": "Organic Synthesis: The Disconnection Approach",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2121"
+    ]
+  },
+  {
+    "code": "CM3222",
+    "name": "Organic Reaction Mechanisms",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2121"
+    ]
+  },
+  {
+    "code": "CM3225",
+    "name": "Biomolecules",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2121"
+    ]
+  },
+  {
+    "code": "CM3231",
+    "name": "Quantum Chem & Molecular Thermodynamics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2101"
+    ]
+  },
+  {
+    "code": "CM3232",
+    "name": "Phy Chem of the Solid State & Interfaces",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2101"
+    ]
+  },
+  {
+    "code": "CM3242",
+    "name": "Instrumental Analysis II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2142",
+      "CM2192",
+      "LSM2191"
+    ]
+  },
+  {
+    "code": "CM3251",
+    "name": "Nanochemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SP2251"
+    ]
+  },
+  {
+    "code": "CM3252",
+    "name": "Polymer Chemistry 1",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM2264",
+      "CM3262",
+      "CM3265",
+      "CM3266"
+    ],
+    "prerequisites": [
+      "CM1131",
+      "CM2121"
+    ]
+  },
+  {
+    "code": "CM3253",
+    "name": "Materials Chemistry 1",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM2263",
+      "CM3262"
+    ],
+    "prerequisites": [
+      "CM1131",
+      "CM2111"
+    ]
+  },
+  {
+    "code": "CM3261",
+    "name": "Environmental Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2142",
+      "CM2192"
+    ]
+  },
+  {
+    "code": "CM3267",
+    "name": "Computational Thinking and Programming in Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2191",
+      "CM2192",
+      "FST2102B"
+    ]
+  },
+  {
+    "code": "CM3288",
+    "name": "Advanced UROPS in Chemistry I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM3289",
+    "name": "Advanced UROPS in Chemistry II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM3291",
+    "name": "Advanced Experiments In Organic & Inorganic Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2111",
+      "CM2121",
+      "CM2191"
+    ]
+  },
+  {
+    "code": "CM3292",
+    "name": "Advanced Experiments In Analytical & Physical Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2101",
+      "CM2142",
+      "CM2192"
+    ]
+  },
+  {
+    "code": "CM3295",
+    "name": "Selected Experiments in Analytical Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2142",
+      "CM2192"
+    ]
+  },
+  {
+    "code": "CM3296",
+    "name": "Molecular Modelling: Theory & Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2101"
+    ]
+  },
+  {
+    "code": "CM3301",
+    "name": "Advanced Forensic Science",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GEK1542"
+    ]
+  },
+  {
+    "code": "CM3302",
+    "name": "Overseas Exploratory Project (Europe)",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM3311",
+    "name": "Undergraduate Professional Internship Programme",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3311"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CM3312",
+    "name": "Enhanced Undergraduate Professional Internship Programme",
+    "creditCount": 12.0,
+    "preclusions": [
+      "XX3312"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CM4199A",
+    "name": "Honours Project in Chemistry",
+    "creditCount": 16.0,
+    "preclusions": [
+      "CM4299"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CM4211",
+    "name": "Advanced Coordination Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM3211",
+      "CM3212"
+    ]
+  },
+  {
+    "code": "CM4212",
+    "name": "Advanced Organometallic Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM3211",
+      "CM3212"
+    ]
+  },
+  {
+    "code": "CM4214",
+    "name": "Structural Methods in Inorganic Chem",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM3211",
+      "CM3212"
+    ]
+  },
+  {
+    "code": "CM4225",
+    "name": "Organic Spectroscopy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2121"
+    ]
+  },
+  {
+    "code": "CM4227",
+    "name": "Chemical Biology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM4233"
+    ],
+    "prerequisites": [
+      "CM1121",
+      "CM1401",
+      "LSM1101",
+      "LSM1401"
+    ]
+  },
+  {
+    "code": "CM4228",
+    "name": "Catalysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2121"
+    ]
+  },
+  {
+    "code": "CM4238",
+    "name": "Selected Topics in Physical Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM4236",
+      "CM4237"
+    ],
+    "prerequisites": [
+      "CM2101"
+    ]
+  },
+  {
+    "code": "CM4241",
+    "name": "Trace Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM3242"
+    ]
+  },
+  {
+    "code": "CM4242",
+    "name": "Advanced Analytical Techniques",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM3242"
+    ]
+  },
+  {
+    "code": "CM4251",
+    "name": "Characterization Techniques in Materials Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM3252",
+      "CM3253"
+    ]
+  },
+  {
+    "code": "CM4252",
+    "name": "Polymer Chemistry 2",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM4264",
+      "CM4265",
+      "CM4266",
+      "CM4268"
+    ],
+    "prerequisites": [
+      "CM3252"
+    ]
+  },
+  {
+    "code": "CM4253",
+    "name": "Materials Chemistry 2",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM4266"
+    ],
+    "prerequisites": [
+      "CM3253"
+    ]
+  },
+  {
+    "code": "CM4254",
+    "name": "Chemistry of Semiconductors",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM3263"
+    ],
+    "prerequisites": [
+      "CM3232"
+    ]
+  },
+  {
+    "code": "CM4258",
+    "name": "Advanced Polymer Science",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM4268"
+    ],
+    "prerequisites": [
+      "CM3252"
+    ]
+  },
+  {
+    "code": "CM4269",
+    "name": "Sustainable & Green Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM1121",
+      "CM1131",
+      "CM2121",
+      "CM2101"
+    ]
+  },
+  {
+    "code": "CM4271",
+    "name": "Medicinal Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM2121",
+      "CM3225"
+    ]
+  },
+  {
+    "code": "CM4274",
+    "name": "The Art and Methodology in Total Synthesis",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM4221"
+    ],
+    "prerequisites": [
+      "CM3221"
+    ]
+  },
+  {
+    "code": "CM4282",
+    "name": "Energy Resources",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM1131",
+      "CM1111"
+    ]
+  },
+  {
+    "code": "CM4299",
+    "name": "Applied Project in Chemistry",
+    "creditCount": 16.0,
+    "preclusions": [
+      "XX4199"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CM5100",
+    "name": "M.sc. Project",
+    "creditCount": 8.0,
+    "preclusions": [
+      "CM5100A"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CM5100A",
+    "name": "Advanced MSc Project",
+    "creditCount": 16.0,
+    "preclusions": [
+      "CM5100"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CM5101",
+    "name": "Advanced Analysis and Characterization Techniques",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM5201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CM5151",
+    "name": "Energy Storage and Conversion Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM5152",
+    "name": "Water Chemistry and Environment",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM5244"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CM5161",
+    "name": "Advanced Chemical Laboratory Safety",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM5198",
+    "name": "Graduate Seminar Module in Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM5199",
+    "name": "M.Sc. R&D project",
+    "creditCount": 16.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM5211",
+    "name": "Contemporary Organometallic Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM4212"
+    ]
+  },
+  {
+    "code": "CM5212",
+    "name": "Crystal Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM4214"
+    ]
+  },
+  {
+    "code": "CM5221",
+    "name": "Advanced Organic Synthesis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM4222"
+    ]
+  },
+  {
+    "code": "CM5224",
+    "name": "Emerging Concepts in Drug Discovery",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM5225",
+    "name": "Asymmetric Catalysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM4228"
+    ]
+  },
+  {
+    "code": "CM5237",
+    "name": "Advanced Optical Spectroscopy and Imaging",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM5241",
+    "name": "Modern Analytical Techniques",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM4242"
+    ]
+  },
+  {
+    "code": "CM5244",
+    "name": "Topics in Environmental Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM5245",
+    "name": "Bioanalyticalchemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM5262",
+    "name": "Contemporary Materials Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CM5268",
+    "name": "Advanced Organic Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CM3221",
+      "CM4268",
+      "CM3221"
+    ]
+  },
+  {
+    "code": "CN1101",
+    "name": "Chemical Engineering Principles and Practice I",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN1102",
+    "name": "Chemical Engineering Principles and Practice II",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN1111E",
+    "name": "Chemical Engineering Principles",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC1101",
+      "TCN1111"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CN2101",
+    "name": "Material and Energy Balances",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN2108",
+    "name": "Chemical Engineering Process Laboratory I",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN2121",
+      "CN2122",
+      "LSM1401"
+    ]
+  },
+  {
+    "code": "CN2116",
+    "name": "Chemical Kinetics & Reactor Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN1111",
+      "CN1111FC",
+      "CN1111X"
+    ]
+  },
+  {
+    "code": "CN2116E",
+    "name": "Chemical Kinetics And Reactor Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC2106",
+      "TCN2116"
+    ],
+    "prerequisites": [
+      "TC1101",
+      "CN1111E"
+    ]
+  },
+  {
+    "code": "CN2121",
+    "name": "Chemical Engineering Thermodynamics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN1111FC",
+      "CN1111",
+      "CN1111X",
+      "CM1502"
+    ]
+  },
+  {
+    "code": "CN2121E",
+    "name": "Chemical Engineering Thermodynamics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC2111",
+      "TCN2121"
+    ],
+    "prerequisites": [
+      "CN1111E"
+    ]
+  },
+  {
+    "code": "CN2122",
+    "name": "Fluid Mechanics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1511",
+      "MA1512",
+      "PC1221"
+    ]
+  },
+  {
+    "code": "CN2122E",
+    "name": "Fluid Mechanics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC2112",
+      "TCN2122"
+    ],
+    "prerequisites": [
+      "TC2411"
+    ]
+  },
+  {
+    "code": "CN2125",
+    "name": "Heat & Mass Transfer",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN2122"
+    ]
+  },
+  {
+    "code": "CN2125E",
+    "name": "Heat And Mass Transfer",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC2115",
+      "TCN2125"
+    ],
+    "prerequisites": [
+      "TC2112",
+      "CN2122E"
+    ]
+  },
+  {
+    "code": "CN3108",
+    "name": "Chemical Engineering Process Laboratory II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN2108",
+      "CN2116",
+      "CN2125",
+      "CN3124"
+    ]
+  },
+  {
+    "code": "CN3109",
+    "name": "Chemical Engineering Process Laboratory III",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN3121",
+      "CN3132"
+    ]
+  },
+  {
+    "code": "CN3121",
+    "name": "Process Dynamics & Control",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1505",
+      "MA1506"
+    ]
+  },
+  {
+    "code": "CN3121E",
+    "name": "Process Dynamics & Control",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC3111",
+      "TCN3121"
+    ],
+    "prerequisites": [
+      "TC2411"
+    ]
+  },
+  {
+    "code": "CN3124",
+    "name": "Fluid-Solid Systems",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN3124E",
+    "name": "Particle Technology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC3114",
+      "TCN3124"
+    ],
+    "prerequisites": [
+      "TC2112",
+      "CN2122E"
+    ]
+  },
+  {
+    "code": "CN3132",
+    "name": "Separation Processes",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN1111FC",
+      "CN1111",
+      "CN1111X",
+      "CN2125"
+    ]
+  },
+  {
+    "code": "CN3132E",
+    "name": "Separation Processes",
+    "creditCount": 5.0,
+    "preclusions": [
+      "TC2113",
+      "TCN3132"
+    ],
+    "prerequisites": [
+      "CN1111E",
+      "CN2121E",
+      "CN2125E"
+    ]
+  },
+  {
+    "code": "CN3135",
+    "name": "Process Safety, Health and Environment",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN2121",
+      "CN2122"
+    ]
+  },
+  {
+    "code": "CN3135E",
+    "name": "Process Safety, Health and Environment",
+    "creditCount": 3.0,
+    "preclusions": [
+      "TCN3135"
+    ],
+    "prerequisites": [
+      "CN2121E",
+      "CN2122E"
+    ]
+  },
+  {
+    "code": "CN3421",
+    "name": "Process Modeling And Numerical Simulation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1505",
+      "MA1506",
+      "CN1111",
+      "CN1111FC",
+      "CN1111X"
+    ]
+  },
+  {
+    "code": "CN3421E",
+    "name": "Process Modeling & Numerical Simulation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC3411",
+      "TCN3421"
+    ],
+    "prerequisites": [
+      "CN2116E",
+      "CN2121E",
+      "CN2125E"
+    ]
+  },
+  {
+    "code": "CN4118",
+    "name": "B.Eng. Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN3108",
+      "CN3121",
+      "CN3124",
+      "CN3132",
+      "CN3135",
+      "CN3421"
+    ]
+  },
+  {
+    "code": "CN4118E",
+    "name": "B.Tech. Dissertation",
+    "creditCount": 10.0,
+    "preclusions": [
+      "TC4118",
+      "CN4119E",
+      "TCN4119"
+    ],
+    "prerequisites": [
+      "TC1401",
+      "TC1422",
+      "CN1111E",
+      "TC1402",
+      "TC2401",
+      "TC2421",
+      "CN2121E",
+      "CN2122E",
+      "CN2116E",
+      "CN2125E",
+      "CN3124E",
+      "CN3421E",
+      "CN3121E",
+      "CN3132E",
+      "CN4111E",
+      "CN3135E"
+    ]
+  },
+  {
+    "code": "CN4118R",
+    "name": "B.Eng. Dissertation",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN3108",
+      "CN3121",
+      "CN3124",
+      "CN3132",
+      "CN3135",
+      "CN3421"
+    ]
+  },
+  {
+    "code": "CN4119E",
+    "name": "B.Tech. Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [
+      "TCN4119",
+      "CN4118E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CN4122",
+    "name": "Process Synthesis and Simulation",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN2116",
+      "CN2121",
+      "CN3124",
+      "CN3132"
+    ]
+  },
+  {
+    "code": "CN4122E",
+    "name": "Process Synthesis and Simulation",
+    "creditCount": 3.0,
+    "preclusions": [
+      "TCN4122"
+    ],
+    "prerequisites": [
+      "CN2116E",
+      "CN2121E",
+      "CN3124E",
+      "CN3132E"
+    ]
+  },
+  {
+    "code": "CN4123",
+    "name": "Design Project",
+    "creditCount": 7.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN3135",
+      "CN3421",
+      "CN4122",
+      "EG2401"
+    ]
+  },
+  {
+    "code": "CN4123E",
+    "name": "Design Project",
+    "creditCount": 7.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN3135E",
+      "CN3421E",
+      "CN4122E",
+      "TG2415"
+    ]
+  },
+  {
+    "code": "CN4123R",
+    "name": "Final Year Design Project",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN3135",
+      "CN3421",
+      "CN4122",
+      "EG2401"
+    ]
+  },
+  {
+    "code": "CN4201R",
+    "name": "Petroleum Refining",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN2116",
+      "CN3132"
+    ]
+  },
+  {
+    "code": "CN4203R",
+    "name": "Polymer Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN4205E",
+    "name": "Pinch Analysis and Process Integration",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCN4205"
+    ],
+    "prerequisites": [
+      "CN2125E",
+      "CN3421E"
+    ]
+  },
+  {
+    "code": "CN4205R",
+    "name": "Pinch Analysis and Process Integration",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN2125",
+      "CN3421"
+    ]
+  },
+  {
+    "code": "CN4208E",
+    "name": "Biochemical Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCN4208"
+    ],
+    "prerequisites": [
+      "TC2106",
+      "CN2116E",
+      "TC2112",
+      "CN2122E"
+    ]
+  },
+  {
+    "code": "CN4210E",
+    "name": "Membrane Science And Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC4210",
+      "TCN4210"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CN4211R",
+    "name": "Petrochemicals and Processing Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN2121",
+      "CN2116"
+    ]
+  },
+  {
+    "code": "CN4215E",
+    "name": "Food Technology And Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC4215",
+      "TCN4215"
+    ],
+    "prerequisites": [
+      "CN2122E",
+      "CN3132E"
+    ]
+  },
+  {
+    "code": "CN4215R",
+    "name": "Food Technology and Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN2125",
+      "CN3132"
+    ]
+  },
+  {
+    "code": "CN4216E",
+    "name": "Electronic Materials Science",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC4216",
+      "TCN4216"
+    ],
+    "prerequisites": [
+      "TC1422"
+    ]
+  },
+  {
+    "code": "CN4216R",
+    "name": "Electronic Materials Science",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE1101"
+    ]
+  },
+  {
+    "code": "CN4218",
+    "name": "Particle Technology Fundamentals and Applications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN4221R",
+    "name": "Control of Industrial Processes",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN3121",
+      "CN4122"
+    ]
+  },
+  {
+    "code": "CN4223R",
+    "name": "Microelectronic Thin Films",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE1101",
+      "EE2004",
+      "EE3431C"
+    ]
+  },
+  {
+    "code": "CN4227E",
+    "name": "Advanced Process Control",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC4227",
+      "TCN4227"
+    ],
+    "prerequisites": [
+      "TC3111",
+      "CN3121E"
+    ]
+  },
+  {
+    "code": "CN4227R",
+    "name": "Advanced Process Control",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN3121"
+    ]
+  },
+  {
+    "code": "CN4233E",
+    "name": "Good Manufacturing Practices in Pharmaceutical Industry",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CN4233R",
+      "PR2143",
+      "PR3145",
+      "PR4206",
+      "TCN4233"
+    ],
+    "prerequisites": [
+      "CN2122E",
+      "CN2125E"
+    ]
+  },
+  {
+    "code": "CN4233R",
+    "name": "Good Manufacturing Practices in Pharmaceutical Industry",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PR2143",
+      "PR3145",
+      "PR4206"
+    ],
+    "prerequisites": [
+      "LSM1401",
+      "CN2108"
+    ]
+  },
+  {
+    "code": "CN4238R",
+    "name": "Chemical & Biochemical Process Modeling",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN1111",
+      "CN1111FC",
+      "CN1111X"
+    ]
+  },
+  {
+    "code": "CN4240E",
+    "name": "Unit Operations and Processes for Effluent Treatment",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCN4240"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CN4240R",
+    "name": "Unit Operations and Processes for Effluent Treatment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1401",
+      "CN2116",
+      "CN3124"
+    ]
+  },
+  {
+    "code": "CN4242E",
+    "name": "Optimization of Chemical Processes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCN4242"
+    ],
+    "prerequisites": [
+      "TC2411",
+      "CN3421E"
+    ]
+  },
+  {
+    "code": "CN4246E",
+    "name": "Chemical And Bio-Catalysis",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCN4246"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CN4246R",
+    "name": "Chemical and Bio Catalysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN2116"
+    ]
+  },
+  {
+    "code": "CN4247R",
+    "name": "Enzyme Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN2116",
+      "LSM1401"
+    ]
+  },
+  {
+    "code": "CN4248",
+    "name": "Sustainable Process Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN2116",
+      "CN3132"
+    ]
+  },
+  {
+    "code": "CN4251",
+    "name": "Troubleshooting with Case Studies for Process Engineers",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN2116",
+      "CN2121",
+      "CN2125",
+      "CN3124",
+      "CN3132"
+    ]
+  },
+  {
+    "code": "CN5010",
+    "name": "Math & Computation Tools for Chemical Engineers",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5020",
+    "name": "Advanced Reaction Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5030",
+    "name": "Advanced Chemical Engineering Thermodynamics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5040",
+    "name": "Advanced Transport Phenomena",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5050",
+    "name": "Advanced Separation Processes",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5111",
+    "name": "Optimization Of Chemical Processes",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5111B",
+    "name": "Process Optimization with Industrial Applications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5161",
+    "name": "Polymer Processing Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CN4203"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5162",
+    "name": "Advanced Polymeric Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5172",
+    "name": "Biochemical Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CN4208"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5173",
+    "name": "Downstream Processing Of Biochemical & Pharmaceutical Products",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CN4231"
+    ],
+    "prerequisites": [
+      "CN3132"
+    ]
+  },
+  {
+    "code": "CN5191",
+    "name": "Project Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CN4225"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5193",
+    "name": "Instrumental Methods Of Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5251",
+    "name": "Membrane Science & Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5252",
+    "name": "Metabolic Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5555",
+    "name": "Chemical Engineering Project",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5666",
+    "name": "Industrial Attachment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN5999",
+    "name": "Graduate Seminars",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN6020",
+    "name": "Advanced Reaction Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CN6162",
+    "name": "Advanced Polymeric Materials",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CN5162"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CN6163",
+    "name": "Inorganic Nanomaterials for Sustainability",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CN5020",
+      "CN5030"
+    ]
+  },
+  {
+    "code": "CN6251",
+    "name": "Membrane Science & Technology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CN5251"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CN6999",
+    "name": "Doctoral Seminars",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "COS2000",
+    "name": "Computational Thinking for Scientists",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CP2106",
+    "name": "Independent Software Development Project (Orbital)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2103"
+    ],
+    "prerequisites": [
+      "CS1010"
+    ]
+  },
+  {
+    "code": "CP2201",
+    "name": "Journey of the Innovator",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CP3106",
+    "name": "Independent Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2102",
+      "CS2102S",
+      "CS2105",
+      "CS3214",
+      "CS3215",
+      "IS3102",
+      "IS4102",
+      "CS3201",
+      "CS3281",
+      "CS4201",
+      "CS4203"
+    ]
+  },
+  {
+    "code": "CP3201",
+    "name": "Industry Seminar",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CP3208",
+    "name": "Undergraduate Research in Computing I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS3208"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CP3209",
+    "name": "Undergraduate Research in Computing II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2309"
+    ]
+  },
+  {
+    "code": "CP3880",
+    "name": "Advanced Technology Attachment Programme",
+    "creditCount": 12.0,
+    "preclusions": [
+      "EG3601"
+    ],
+    "prerequisites": [
+      "IS2101",
+      "CS2101",
+      "CS2103",
+      "CS2103T",
+      "IS2103",
+      "IS2150",
+      "BT2101"
+    ]
+  },
+  {
+    "code": "CP4101",
+    "name": "B.Comp. Dissertation",
+    "creditCount": 12.0,
+    "preclusions": [
+      "CS4101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CP5010",
+    "name": "Graduate Research Paper",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CP5101",
+    "name": "MComp Dissertation",
+    "creditCount": 16.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CP5102",
+    "name": "MComp Information Security Project",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CP5103",
+    "name": "Master of Computing Project",
+    "creditCount": 8.0,
+    "preclusions": [
+      "CP5101",
+      "CP5102"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CP6010",
+    "name": "Doctoral Seminar",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CS1010",
+    "name": "Programming Methodology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CG1101",
+      "CS1010E",
+      "CS1010FC",
+      "CS1010S",
+      "CS1101",
+      "CS1101C",
+      "CS1101S"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CS1010E",
+    "name": "Programming Methodology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CG1101",
+      "CS1010",
+      "CS1010FC",
+      "CS1010S",
+      "CS1101",
+      "CS1101C",
+      "CS1101S"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CS1010J",
+    "name": "Programming Methodology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS1010"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CS1010S",
+    "name": "Programming Methodology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CG1101",
+      "CS1010",
+      "CS1010E",
+      "CS1010FC",
+      "CS1101",
+      "CS1101C",
+      "CS1101S"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CS1010X",
+    "name": "Programming Methodology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS1010",
+      "CS1010FC"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CS1020",
+    "name": "Data Structures and Algorithms I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS1020E",
+      "CS2020",
+      "CS2030",
+      "CS2040",
+      "CS2040C"
+    ],
+    "prerequisites": [
+      "CS1010"
+    ]
+  },
+  {
+    "code": "CS1020E",
+    "name": "Data Structures and Algorithms I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS1020",
+      "CS2020",
+      "CS2030",
+      "CS2040",
+      "CS2040C"
+    ],
+    "prerequisites": [
+      "CS1010E"
+    ]
+  },
+  {
+    "code": "CS1101S",
+    "name": "Programming Methodology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS1010"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CS1231",
+    "name": "Discrete Structures",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA1100"
+    ],
+    "prerequisites": [
+      "MA1301",
+      "MA1301FC",
+      "MA1301X"
+    ]
+  },
+  {
+    "code": "CS2010",
+    "name": "Data Structures and Algorithms II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2020",
+      "CS2030",
+      "CS2040",
+      "CS2040C"
+    ],
+    "prerequisites": [
+      "CS1020",
+      "CS1020E",
+      "CG1103"
+    ]
+  },
+  {
+    "code": "CS2030",
+    "name": "Programming Methodology II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS1020"
+    ],
+    "prerequisites": [
+      "CS1010"
+    ]
+  },
+  {
+    "code": "CS2040",
+    "name": "Data Structures and Algorithms",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS1020",
+      "CS1020E",
+      "CS2020",
+      "CS2010"
+    ],
+    "prerequisites": [
+      "CS1010"
+    ]
+  },
+  {
+    "code": "CS2040C",
+    "name": "Data Structures and Algorithms",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS1020",
+      "CS1020E",
+      "CS2020",
+      "CS2010",
+      "CS2040"
+    ],
+    "prerequisites": [
+      "CS1010"
+    ]
+  },
+  {
+    "code": "CS2100",
+    "name": "Computer Organisation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS1104"
+    ],
+    "prerequisites": [
+      "CS1010"
+    ]
+  },
+  {
+    "code": "CS2101",
+    "name": "Effective Communication for Computing Professionals",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2103",
+      "IS2101",
+      "ES2002",
+      "ES2007D",
+      "ES1601"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES1103"
+    ]
+  },
+  {
+    "code": "CS2102",
+    "name": "Database Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2102S",
+      "IT2002"
+    ],
+    "prerequisites": [
+      "CS1020",
+      "CS1020E",
+      "CS2020",
+      "CS2030",
+      "CS2040",
+      "CS2040C",
+      "CS1231",
+      "MA1100"
+    ]
+  },
+  {
+    "code": "CS2102R",
+    "name": "Database Systems",
+    "creditCount": 1.0,
+    "preclusions": [
+      "CS2102S",
+      "IT2002"
+    ],
+    "prerequisites": [
+      "CS1020",
+      "CS1231",
+      "MA1100"
+    ]
+  },
+  {
+    "code": "CS2103",
+    "name": "Software Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2103T",
+      "CS2113",
+      "CS2113T"
+    ],
+    "prerequisites": [
+      "CS1020",
+      "CS1020E",
+      "CS2020",
+      "CS2030",
+      "CS2040",
+      "CS2040C"
+    ]
+  },
+  {
+    "code": "CS2103R",
+    "name": "Software Engineering",
+    "creditCount": 1.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CS2103T",
+    "name": "Software Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2103",
+      "CS2113",
+      "CS2113T",
+      "IS2101"
+    ],
+    "prerequisites": [
+      "CS1020",
+      "CS1020E",
+      "CS2020",
+      "CS2030",
+      "CS2040",
+      "CS2040C"
+    ]
+  },
+  {
+    "code": "CS2104",
+    "name": "Programming Language Concepts",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1020",
+      "CS1020E",
+      "CS2020",
+      "CS2030",
+      "CS2113"
+    ]
+  },
+  {
+    "code": "CS2104R",
+    "name": "Programming Language Concepts",
+    "creditCount": 1.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CS2105",
+    "name": "Introduction to Computer Networks",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IT2001",
+      "EE3204",
+      "EE4210"
+    ],
+    "prerequisites": [
+      "CS1020",
+      "CS1020E",
+      "CS2020",
+      "CS2030",
+      "CS2040",
+      "CS2040C"
+    ]
+  },
+  {
+    "code": "CS2105R",
+    "name": "Introduction to Computer Networks",
+    "creditCount": 1.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CS2106",
+    "name": "Introduction to Operating Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CG2271",
+      "EE4214"
+    ],
+    "prerequisites": [
+      "CS2100",
+      "EE2007",
+      "EE2024"
+    ]
+  },
+  {
+    "code": "CS2106R",
+    "name": "Introduction to Operating Systems",
+    "creditCount": 1.0,
+    "preclusions": [
+      "CG2271",
+      "EE4214"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CS2107",
+    "name": "Introduction to Information Security",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1010"
+    ]
+  },
+  {
+    "code": "CS2108",
+    "name": "Introduction to Media Computing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS3246"
+    ],
+    "prerequisites": [
+      "CS1020",
+      "CS1020E",
+      "CS2020",
+      "CS2030",
+      "CS2113",
+      "CS2040",
+      "CS2040C"
+    ]
+  },
+  {
+    "code": "CS2113",
+    "name": "Software Engineering & Object-Oriented Programming",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2103",
+      "CS2103T",
+      "CS2113T",
+      "CS2113",
+      "CS2113",
+      "CS2113T"
+    ],
+    "prerequisites": [
+      "CS2040C",
+      "CS2030",
+      "CS2040"
+    ]
+  },
+  {
+    "code": "CS2113T",
+    "name": "Software Engineering & Object-Oriented Programming",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2103",
+      "CS2103T",
+      "CS2113T",
+      "CS2113",
+      "CS2113",
+      "CS2113T"
+    ],
+    "prerequisites": [
+      "CS2040C",
+      "CS2030",
+      "CS2040"
+    ]
+  },
+  {
+    "code": "CS2220",
+    "name": "Introduction to Computational Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1020",
+      "CS1020E",
+      "CS2020",
+      "CS2040",
+      "CS2040C"
+    ]
+  },
+  {
+    "code": "CS2309",
+    "name": "CS Research Methodology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2305S"
+    ],
+    "prerequisites": [
+      "CS2010",
+      "CS2020",
+      "CS2030",
+      "CS2113",
+      "CS2040C",
+      "CS2040",
+      "CS1231",
+      "MA1100"
+    ]
+  },
+  {
+    "code": "CS3103",
+    "name": "Computer Networks Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2105",
+      "EE3204",
+      "EE4204"
+    ]
+  },
+  {
+    "code": "CS3203",
+    "name": "Software Engineering Project",
+    "creditCount": 8.0,
+    "preclusions": [
+      "CS3201",
+      "CS3202"
+    ],
+    "prerequisites": [
+      "CS2103",
+      "CS2113",
+      "CS2101",
+      "IS2101"
+    ]
+  },
+  {
+    "code": "CS3210",
+    "name": "Parallel Computing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2100",
+      "CG2007",
+      "EE2024"
+    ]
+  },
+  {
+    "code": "CS3211",
+    "name": "Parallel and Concurrent Programming",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2106",
+      "CG2271"
+    ]
+  },
+  {
+    "code": "CS3216",
+    "name": "Software Product Engineering for Digital Markets",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2103"
+    ]
+  },
+  {
+    "code": "CS3217",
+    "name": "Software Engineering on Modern Application Platforms",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2103"
+    ]
+  },
+  {
+    "code": "CS3219",
+    "name": "Software Engineering Principles and Patterns",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS3213"
+    ],
+    "prerequisites": [
+      "CS2103"
+    ]
+  },
+  {
+    "code": "CS3223",
+    "name": "Database Systems Implementation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2010",
+      "CS2020",
+      "CS2040",
+      "CS2040C",
+      "CS2102"
+    ]
+  },
+  {
+    "code": "CS3230",
+    "name": "Design and Analysis of Algorithms",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2010",
+      "CS2020",
+      "CS2040",
+      "CS2040C",
+      "CS1231",
+      "MA1100"
+    ]
+  },
+  {
+    "code": "CS3230R",
+    "name": "Design and Analysis of Algorithms",
+    "creditCount": 1.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CS3233",
+    "name": "Competitive Programming",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2010",
+      "CS2020",
+      "CS2030",
+      "CS2040"
+    ]
+  },
+  {
+    "code": "CS3234",
+    "name": "Logic and Formal Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1231",
+      "MA1100"
+    ]
+  },
+  {
+    "code": "CS3235",
+    "name": "Computer Security",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2105",
+      "EE3204",
+      "EE4204",
+      "CS2106",
+      "CG2271",
+      "CS2107"
+    ]
+  },
+  {
+    "code": "CS3236",
+    "name": "Introduction to Information Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1231",
+      "MA1100",
+      "ST2334",
+      "ST2131"
+    ]
+  },
+  {
+    "code": "CS3236R",
+    "name": "Introduction to Information Theory",
+    "creditCount": 1.0,
+    "preclusions": [
+      "CS3236"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "CS3240",
+    "name": "Interaction Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1020",
+      "CS2020",
+      "CS2030",
+      "CS2113",
+      "NM3209",
+      "NM2207"
+    ]
+  },
+  {
+    "code": "CS3241",
+    "name": "Computer Graphics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2010",
+      "CS2020",
+      "CS2030",
+      "CS2113",
+      "CS2040",
+      "CS2040C"
+    ]
+  },
+  {
+    "code": "CS3241R",
+    "name": "Computer Graphics",
+    "creditCount": 1.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CS3242",
+    "name": "3D Modeling and Animation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS4342"
+    ],
+    "prerequisites": [
+      "CS3241",
+      "PC1221",
+      "PC1221X",
+      "MA1102R",
+      "MA1505",
+      "MA1511",
+      "MA1512",
+      "MA1521",
+      "MA1101R",
+      "MA1311",
+      "MA1506",
+      "MA1508E"
+    ]
+  },
+  {
+    "code": "CS3243",
+    "name": "Introduction to Artificial Intelligence",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2010",
+      "CS2020",
+      "CS2040",
+      "CS2040C",
+      "CS1231",
+      "MA1100"
+    ]
+  },
+  {
+    "code": "CS3244",
+    "name": "Machine Learning",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2010",
+      "CS2020",
+      "CS2040",
+      "CS2040C",
+      "ESP1107",
+      "ESP2107",
+      "ST1232",
+      "ST2131",
+      "ST2132",
+      "ST2334",
+      "MA1102R",
+      "MA1505",
+      "MA1511",
+      "MA1512",
+      "MA1521",
+      "MA1101R",
+      "MA1311",
+      "MA1506",
+      "MA1508E"
+    ]
+  },
+  {
+    "code": "CS3245",
+    "name": "Information Retrieval",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2010",
+      "CS2020",
+      "CS2030",
+      "CS2113",
+      "CS2040",
+      "CS2040C"
+    ]
+  },
+  {
+    "code": "CS3245R",
+    "name": "Information Retrieval",
+    "creditCount": 1.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CS3247",
+    "name": "Game Development",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS4213"
+    ],
+    "prerequisites": [
+      "CS3241",
+      "PC1221"
+    ]
+  },
+  {
+    "code": "CS3281",
+    "name": "Thematic Systems Project I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2103"
+    ]
+  },
+  {
+    "code": "CS3282",
+    "name": "Thematic Systems Project II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3281"
+    ]
+  },
+  {
+    "code": "CS4211",
+    "name": "Formal Methods for Software Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2103"
+    ]
+  },
+  {
+    "code": "CS4212",
+    "name": "Compiler Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2104"
+    ]
+  },
+  {
+    "code": "CS4215",
+    "name": "Programming Language Implementation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2010",
+      "CS2020",
+      "CS2040",
+      "CS2040C",
+      "CS2030",
+      "CS2113"
+    ]
+  },
+  {
+    "code": "CS4218",
+    "name": "Software Testing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3219"
+    ]
+  },
+  {
+    "code": "CS4220",
+    "name": "Knowledge Discovery Methods in Bioinformatics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2220",
+      "LSM2104"
+    ]
+  },
+  {
+    "code": "CS4221",
+    "name": "Database Applications Design and Tuning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS5421"
+    ],
+    "prerequisites": [
+      "CS3223"
+    ]
+  },
+  {
+    "code": "CS4222",
+    "name": "Wireless Networking",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS5422"
+    ],
+    "prerequisites": [
+      "CS2105",
+      "EE3204",
+      "EE4204",
+      "ST2334",
+      "ST2131"
+    ]
+  },
+  {
+    "code": "CS4223",
+    "name": "Multi-core Architectures",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2106",
+      "CG2271",
+      "CS3210",
+      "CS3220",
+      "CG3207"
+    ]
+  },
+  {
+    "code": "CS4224",
+    "name": "Distributed Databases",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3223"
+    ]
+  },
+  {
+    "code": "CS4225",
+    "name": "Big Data Systems for Data Science",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS5425"
+    ],
+    "prerequisites": [
+      "CS2102"
+    ]
+  },
+  {
+    "code": "CS4226",
+    "name": "Internet Architecture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2105",
+      "EE3204",
+      "EE4204",
+      "ST2334",
+      "ST2131"
+    ]
+  },
+  {
+    "code": "CS4231",
+    "name": "Parallel and Distributed Algorithms",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3230",
+      "CS3210"
+    ]
+  },
+  {
+    "code": "CS4232",
+    "name": "Theory of Computation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1231",
+      "CS1231S"
+    ]
+  },
+  {
+    "code": "CS4234",
+    "name": "Optimisation Algorithms",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1101R",
+      "MA1311",
+      "MA1506",
+      "MA1508E",
+      "CS3230"
+    ]
+  },
+  {
+    "code": "CS4236",
+    "name": "Cryptography Theory and Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1231",
+      "CS2107",
+      "CS2010",
+      "CS2020",
+      "CS2040",
+      "CS2040C"
+    ]
+  },
+  {
+    "code": "CS4238",
+    "name": "Computer Security Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3235"
+    ]
+  },
+  {
+    "code": "CS4239",
+    "name": "Software Security",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3235",
+      "CS2103"
+    ]
+  },
+  {
+    "code": "CS4240",
+    "name": "Interaction Design for Virtual and Augmented Reality",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3240",
+      "MA1301"
+    ]
+  },
+  {
+    "code": "CS4242",
+    "name": "Social Media Computing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2108",
+      "CS3245"
+    ]
+  },
+  {
+    "code": "CS4243",
+    "name": "Computer Vision and Pattern Recognition",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4212"
+    ],
+    "prerequisites": [
+      "CS1020",
+      "CS1020E",
+      "CS2020",
+      "CS2030",
+      "CS2113",
+      "CS2040",
+      "CS2040C",
+      "MA1101R",
+      "MA1311",
+      "MA1506",
+      "MA1508E",
+      "MA1102R",
+      "MA1505",
+      "MA1511",
+      "MA1512",
+      "MA1521",
+      "ST1232",
+      "ST2131",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "CS4244",
+    "name": "Knowledge-Based Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3243"
+    ]
+  },
+  {
+    "code": "CS4246",
+    "name": "AI Planning and Decision Making",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA2216",
+      "ST2131",
+      "ST2334",
+      "CS3243"
+    ]
+  },
+  {
+    "code": "CS4247",
+    "name": "Graphics Rendering Techniques",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3241"
+    ]
+  },
+  {
+    "code": "CS4248",
+    "name": "Natural Language Processing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3243",
+      "CS3245",
+      "ST1232",
+      "ST2131",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "CS4249",
+    "name": "Phenomena and Theories of Human-Computer Interaction",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3240",
+      "NM2213",
+      "NM2216"
+    ]
+  },
+  {
+    "code": "CS4257",
+    "name": "Algorithmic Foundations of Privacy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST1232",
+      "ST2131",
+      "ST2334",
+      "CS3230",
+      "CS2107"
+    ]
+  },
+  {
+    "code": "CS4261",
+    "name": "Algorithmic Mechanism Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ESP1107",
+      "ESP2107",
+      "ST1232",
+      "ST2132",
+      "ST2334",
+      "CS2010",
+      "CS2020",
+      "CS2040",
+      "BT2101",
+      "CS1231",
+      "MA1101R",
+      "MA1311",
+      "MA1506",
+      "MA1508E"
+    ]
+  },
+  {
+    "code": "CS4347",
+    "name": "Sound and Music Computing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1102R",
+      "MA1505",
+      "MA1511",
+      "MA1512",
+      "MA1521",
+      "MA1101R",
+      "MA1311",
+      "MA1506",
+      "MA1508E",
+      "CS2108"
+    ]
+  },
+  {
+    "code": "CS4350",
+    "name": "Game Development Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3247",
+      "NM3216"
+    ]
+  },
+  {
+    "code": "CS4351",
+    "name": "Real-Time Graphics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3241"
+    ]
+  },
+  {
+    "code": "CS5218",
+    "name": "Principles of Program Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS4212",
+      "CS4215"
+    ]
+  },
+  {
+    "code": "CS5219",
+    "name": "Automated Software Validation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2104"
+    ]
+  },
+  {
+    "code": "CS5222",
+    "name": "Advanced Computer Architecture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3220",
+      "CS4223"
+    ]
+  },
+  {
+    "code": "CS5223",
+    "name": "Distributed Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3211"
+    ]
+  },
+  {
+    "code": "CS5224",
+    "name": "Cloud Computing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CS5228",
+    "name": "Knowledge Discovery and Data Mining",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2102",
+      "ST1232",
+      "ST2131",
+      "ST2334",
+      "CS3243"
+    ]
+  },
+  {
+    "code": "CS5229",
+    "name": "Advanced Computer Networks",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS4226",
+      "EE4210"
+    ]
+  },
+  {
+    "code": "CS5230",
+    "name": "Computational Complexity",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS4230"
+    ],
+    "prerequisites": [
+      "CS4232"
+    ]
+  },
+  {
+    "code": "CS5231",
+    "name": "Systems Security",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3235"
+    ]
+  },
+  {
+    "code": "CS5232",
+    "name": "Formal Specification and Design Techniques",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1231",
+      "MA1100",
+      "CS2103"
+    ]
+  },
+  {
+    "code": "CS5233",
+    "name": "Simulation and Modelling Techniques",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST1232",
+      "ST2131",
+      "ST2334",
+      "CS4231"
+    ]
+  },
+  {
+    "code": "CS5234",
+    "name": "Combinatorial and Graph Algorithms",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS4234"
+    ],
+    "prerequisites": [
+      "CS3230"
+    ]
+  },
+  {
+    "code": "CS5236",
+    "name": "Advanced Automata Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS4232"
+    ]
+  },
+  {
+    "code": "CS5238",
+    "name": "Advanced Combinatorial Methods in Bioinformatics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3230"
+    ]
+  },
+  {
+    "code": "CS5239",
+    "name": "Computer System Performance Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1020",
+      "CS1020E",
+      "CS2020",
+      "CS2030",
+      "CS2113",
+      "ST1232",
+      "ST2131",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "CS5240",
+    "name": "Theoretical Foundations in MultiMedia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1020",
+      "CS1020E",
+      "CS2020",
+      "CS2040",
+      "CS2040C",
+      "MA1102R",
+      "MA1505",
+      "MA1511",
+      "MA1512",
+      "MA1521",
+      "MA1101R",
+      "MA1311",
+      "MA1506",
+      "MA1508E",
+      "ST1232",
+      "ST2131",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "CS5242",
+    "name": "Neural Networks and Deep Learning",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3244"
+    ]
+  },
+  {
+    "code": "CS5246",
+    "name": "Text Mining",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2103",
+      "MA1101R",
+      "MA1311",
+      "MA1506",
+      "MA1508E",
+      "ST1232",
+      "ST2131",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "CS5250",
+    "name": "Advanced Operating Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2106",
+      "CG2271"
+    ]
+  },
+  {
+    "code": "CS5272",
+    "name": "Embedded Software Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CG2271",
+      "CS2106",
+      "CS2103"
+    ]
+  },
+  {
+    "code": "CS5321",
+    "name": "Network Security",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3235"
+    ]
+  },
+  {
+    "code": "CS5322",
+    "name": "Database Security",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3223"
+    ]
+  },
+  {
+    "code": "CS5330",
+    "name": "Randomized Algorithms",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3230"
+    ]
+  },
+  {
+    "code": "CS5331",
+    "name": "Web Security",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3235"
+    ]
+  },
+  {
+    "code": "CS5332",
+    "name": "Biometric Authentication",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2040",
+      "MA1102R",
+      "MA1505",
+      "MA1505C",
+      "MA1521",
+      "MA1101R",
+      "MA1506",
+      "ST1232",
+      "ST2131",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "CS5339",
+    "name": "Theory and Algorithms for Machine Learning",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3244"
+    ]
+  },
+  {
+    "code": "CS5340",
+    "name": "Uncertainty Modelling in AI",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST1232",
+      "ST2131",
+      "ST2334",
+      "CS3243"
+    ]
+  },
+  {
+    "code": "CS5344",
+    "name": "Big-Data Analytics Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BT5110"
+    ]
+  },
+  {
+    "code": "CS5346",
+    "name": "Information Visualisation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2040",
+      "CS2102",
+      "CS3240",
+      "ST1232",
+      "ST2132",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "CS5421",
+    "name": "Database Applications Design and Tuning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS4221"
+    ],
+    "prerequisites": [
+      "CS3223"
+    ]
+  },
+  {
+    "code": "CS5422",
+    "name": "Wireless Networking",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS4222"
+    ],
+    "prerequisites": [
+      "CS2105",
+      "EE3204",
+      "EE4204",
+      "ST2334",
+      "ST2131"
+    ]
+  },
+  {
+    "code": "CS5424",
+    "name": "Distributed Databases",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS4224"
+    ],
+    "prerequisites": [
+      "CS3223"
+    ]
+  },
+  {
+    "code": "CS5425",
+    "name": "Big Data Systems for Data Science",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS4225"
+    ],
+    "prerequisites": [
+      "CS2102"
+    ]
+  },
+  {
+    "code": "CS5439",
+    "name": "Software Security",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS4239"
+    ],
+    "prerequisites": [
+      "CS3235",
+      "CS2103"
+    ]
+  },
+  {
+    "code": "CS6101",
+    "name": "Exploration of Computer Science Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CS6202",
+    "name": "Advanced Topics in Programming Languages",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3212",
+      "CS4212"
+    ]
+  },
+  {
+    "code": "CS6203",
+    "name": "Advanced Topics in Database Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3223"
+    ]
+  },
+  {
+    "code": "CS6208",
+    "name": "Advanced Topics in Artificial Intelligence",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3243"
+    ]
+  },
+  {
+    "code": "CS6210",
+    "name": "The Art of Computer Science Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3230"
+    ]
+  },
+  {
+    "code": "CS6211",
+    "name": "Analytical Performance Modelling for Computer Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2334",
+      "ST2131",
+      "CS2105",
+      "CS2106"
+    ]
+  },
+  {
+    "code": "CS6215",
+    "name": "Advanced Topics in Program Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3230",
+      "CS4212"
+    ]
+  },
+  {
+    "code": "CS6216",
+    "name": "Advanced Topics in Machine Learning",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3244"
+    ]
+  },
+  {
+    "code": "CS6220",
+    "name": "Advanced Topics in Data Mining",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS5228"
+    ]
+  },
+  {
+    "code": "CS6231",
+    "name": "Topics in System Security",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS4236",
+      "CS3235",
+      "CS5231"
+    ]
+  },
+  {
+    "code": "CS6234",
+    "name": "Advanced Algorithms",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS5234"
+    ]
+  },
+  {
+    "code": "CS6240",
+    "name": "Multimedia Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS4243",
+      "CS5240"
+    ]
+  },
+  {
+    "code": "CS6244",
+    "name": "Robot Motion Planning & Control",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3230",
+      "MA1101R",
+      "MA1311",
+      "MA1506",
+      "MA1508E",
+      "ST2131",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "CS6283",
+    "name": "Advanced Topics in Computer Science: Logic in AI",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3230",
+      "ST2334",
+      "ST2131"
+    ]
+  },
+  {
+    "code": "CS6285",
+    "name": "Topics in Computer Science VI: Pseudorandomness",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3230",
+      "ST2334",
+      "ST2131"
+    ]
+  },
+  {
+    "code": "CS6880",
+    "name": "Advanced Topics in Software Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2103"
+    ]
+  },
+  {
+    "code": "CSA6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "CSA6880",
+    "name": "Topics in Cultural Studies in Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DAO1704",
+    "name": "Decision Analytics using Spreadsheets",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC1007",
+      "DSC1007X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "DAO1704X",
+    "name": "Decision Analytics using Spreadsheets",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC1007",
+      "DSC1007X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "DAO1704Y",
+    "name": "Decision Analytics using Spreadsheets",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC1007",
+      "DSC1007X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "DAO2702",
+    "name": "Programming for Business Analytics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC1007"
+    ],
+    "prerequisites": [
+      "DAO1704",
+      "DAO1704X"
+    ]
+  },
+  {
+    "code": "DAO2703",
+    "name": "Operations and Technology Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DBA3711",
+    "name": "Stochastic Models in Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC3215"
+    ],
+    "prerequisites": [
+      "DAO2702"
+    ]
+  },
+  {
+    "code": "DBA3803",
+    "name": "Predictive Analytics in Business",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC3216"
+    ],
+    "prerequisites": [
+      "DAO2702"
+    ]
+  },
+  {
+    "code": "DE4201",
+    "name": "Seminars in Sustainable Cities",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DE5106",
+    "name": "Environmental Management And Assessment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DE5107",
+    "name": "Environmental Planning",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DE5108",
+    "name": "Study Report",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DE5109",
+    "name": "Dissertation",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DEP5101",
+    "name": "Urban Analysis Workshop",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DEP5101A",
+    "name": "Qualitative Methods for Urban Planning",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "DEP5101"
+    ]
+  },
+  {
+    "code": "DEP5102",
+    "name": "Urban Planning History & Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DEP5103",
+    "name": "Urban Planning Studio",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "UP5101",
+      "UD5622"
+    ]
+  },
+  {
+    "code": "DEP5103A",
+    "name": "Quantitative Methods for Urban Planning",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "DEP5103"
+    ]
+  },
+  {
+    "code": "DEP5104",
+    "name": "Urban and Regional Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DEP5105",
+    "name": "Urban Infrastructure and Mobility Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DEP5106",
+    "name": "Integrated Urban Planning Studio",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "UP5101",
+      "UD5622"
+    ]
+  },
+  {
+    "code": "DEP5107",
+    "name": "Professional Planning Report",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DEP5108",
+    "name": "MUP Internship Module",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DEP5109",
+    "name": "Integrated Planning Project",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": [
+      "DEP5101",
+      "DEP5103",
+      "UD5601",
+      "DEP5101A",
+      "DEP5103A",
+      "DEP5102",
+      "DEP5104",
+      "DEP5105",
+      "UD5521"
+    ]
+  },
+  {
+    "code": "DEP5110",
+    "name": "Urban Design and Regional Planning",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "DEP5101",
+      "DEP5103"
+    ]
+  },
+  {
+    "code": "DI5100",
+    "name": "Dental Implantology",
+    "creditCount": 1.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DOS3701",
+    "name": "Supply Chain Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC3201"
+    ],
+    "prerequisites": [
+      "DAO2703"
+    ]
+  },
+  {
+    "code": "DSA1101",
+    "name": "Introduction to Data Science",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DSA2101",
+    "name": "Essential Data Analytics Tools: Data Visualisation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "DSA1101",
+      "MA1101R",
+      "ST2131",
+      "MA2216"
+    ]
+  },
+  {
+    "code": "DSA2102",
+    "name": "Essential Data Analytics Tools: Numerical Computation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA2213"
+    ],
+    "prerequisites": [
+      "MA1101R",
+      "MA1102R"
+    ]
+  },
+  {
+    "code": "DSA3101",
+    "name": "Data Science in Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "DSA2101",
+      "ST2132"
+    ]
+  },
+  {
+    "code": "DSA3102",
+    "name": "Essential Data Analytics Tools: Convex Optimisation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1010",
+      "CS1010E",
+      "CS1010S",
+      "CS1010X",
+      "MA1101R",
+      "MA1104",
+      "MA2104",
+      "MA2311"
+    ]
+  },
+  {
+    "code": "DSA3312",
+    "name": "Enhanced Undergraduate Professional Internship Programme",
+    "creditCount": 12.0,
+    "preclusions": [
+      "XX3312"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "DSA4211",
+    "name": "High-Dimensional Statistical Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST3131"
+    ]
+  },
+  {
+    "code": "DSC1007",
+    "name": "Business Analytics - Models & Decisions",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC1007X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "DSC1007X",
+    "name": "Business Analytics - Models & Decisions",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC1007"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "DSC2006",
+    "name": "Operations Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH2006",
+      "BZ2003",
+      "BK2006",
+      "IE3120"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "DSC2008",
+    "name": "Business Analytics - Data & Decisions",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ST1131",
+      "ST1131A",
+      "ST1232",
+      "ST2334"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "DSC3201",
+    "name": "Supply Chain Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3201",
+      "BZ3402",
+      "BK3505",
+      "IE4220",
+      "CS5262"
+    ],
+    "prerequisites": [
+      "DSC2006",
+      "BH2006",
+      "BZ2003",
+      "BK2006"
+    ]
+  },
+  {
+    "code": "DSC3202",
+    "name": "Purchasing And Materials Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3202",
+      "BZ3414",
+      "BK3206"
+    ],
+    "prerequisites": [
+      "DSC2006",
+      "BH2006",
+      "BZ2003",
+      "BK2006"
+    ]
+  },
+  {
+    "code": "DSC3203",
+    "name": "Service Operations Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3203",
+      "BZ3404",
+      "BK3501"
+    ],
+    "prerequisites": [
+      "DSC2006",
+      "BH2006",
+      "BZ2003",
+      "BK2006"
+    ]
+  },
+  {
+    "code": "DSC3214",
+    "name": "Introduction To Optimisation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE2110"
+    ],
+    "prerequisites": [
+      "DSC1007",
+      "MA1101R",
+      "MA1311",
+      "MA1521",
+      "MA1102R"
+    ]
+  },
+  {
+    "code": "DSC3215",
+    "name": "Stochastic Models In Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "DSC1007",
+      "DSC1007X",
+      "ST2131",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "DSC3216",
+    "name": "Predictive Analytics in Business",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DSC3224",
+    "name": "Dynamic Pricing & Revenue Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "DSC1007",
+      "IE2110",
+      "DSC3214"
+    ]
+  },
+  {
+    "code": "DSC3229",
+    "name": "Independent Study in Ops & Supply Chain Mgt",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DSC3239",
+    "name": "Independent Study in Ops & Supply Chain Mgt",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DSC4211G",
+    "name": "SIOSCM: Service Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "DSC2006"
+    ]
+  },
+  {
+    "code": "DSC4213",
+    "name": "Analytical Tools for Consulting",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "DSC1007",
+      "IE2110",
+      "DSC3214"
+    ]
+  },
+  {
+    "code": "DSC4216",
+    "name": "Business-driven Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "DSC3201"
+    ]
+  },
+  {
+    "code": "DSC4219",
+    "name": "Advanced Independent Study in Ops & Supply Chain Mgt",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DSC5101",
+    "name": "Analytics in Managerial Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DSC5102",
+    "name": "Business Analytics Capstone Project",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DSC5103",
+    "name": "Statistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DSC5211A",
+    "name": "Supply Chain Coordination and Risk Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DTS5701",
+    "name": "Large Scale Systems Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DTS5702",
+    "name": "C3 Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DTS5703",
+    "name": "Operations Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DTS5711",
+    "name": "Integration Project",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DTS5712",
+    "name": "Thesis Project",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DTS5732",
+    "name": "Artificial Intelligence and Data Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DTS5733",
+    "name": "Sensors and Intelligence",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DTS5734",
+    "name": "Guided Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "DTS2701",
+      "DTS2703"
+    ]
+  },
+  {
+    "code": "DTS5735",
+    "name": "Introduction to Cybersecurity",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DTS5736",
+    "name": "Systems Design Project",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "DTS5731"
+    ]
+  },
+  {
+    "code": "DY5310",
+    "name": "Endodontics",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DY5320",
+    "name": "Oral & Maxillofacial Surgery",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DY5330",
+    "name": "Orthodontics",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DY5340",
+    "name": "Periodontology",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DY5350",
+    "name": "Prosthodontics",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "DY5360",
+    "name": "Paediatric Dentistry",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EB5102",
+    "name": "Data Analytics",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EB5001"
+    ]
+  },
+  {
+    "code": "EB5104",
+    "name": "Decision Making and Optimization",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EB5001"
+    ]
+  },
+  {
+    "code": "EB5105",
+    "name": "Enterprise Business Analytics Project",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EB5001",
+      "EB5002",
+      "EB5003"
+    ]
+  },
+  {
+    "code": "EB5202",
+    "name": "Web Analytics",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EB5001"
+    ]
+  },
+  {
+    "code": "EB5204",
+    "name": "New Media and Sentiment Mining",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EB5001"
+    ]
+  },
+  {
+    "code": "EB5206",
+    "name": "Supply Chain Analytics",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EB5001"
+    ]
+  },
+  {
+    "code": "EB5207",
+    "name": "Service Analytics",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EB5001"
+    ]
+  },
+  {
+    "code": "EC1101E",
+    "name": "Introduction to Economic Analysis",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC1301",
+      "BH1005",
+      "BSP1005",
+      "BSP1703",
+      "RE1704",
+      "USE2301",
+      "EC1101E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EC1301",
+    "name": "Principles of Economics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC1101E",
+      "BH1005",
+      "BSP1005",
+      "BSP1703",
+      "RE1704",
+      "USE2301",
+      "EC1301"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EC2101",
+    "name": "Microeconomic Analysis I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC1101E",
+      "EC1301",
+      "USE2301",
+      "BSP1005",
+      "BH1005"
+    ]
+  },
+  {
+    "code": "EC2102",
+    "name": "Macroeconomic Analysis I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BSP2001",
+      "BSE3701"
+    ],
+    "prerequisites": [
+      "EC1101E",
+      "EC1301",
+      "USE2301",
+      "BSP1005",
+      "BH2001"
+    ]
+  },
+  {
+    "code": "EC2104",
+    "name": "Quantitative Methods for Economic Analysis",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC3311",
+      "MA1301",
+      "MA1301FC",
+      "MA1301X",
+      "MA1311",
+      "MA1312",
+      "MA1421"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EC2204",
+    "name": "Financial Accounting for Economists",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ACC1002",
+      "ACC1002X",
+      "ACC1701"
+    ],
+    "prerequisites": [
+      "EC1101E",
+      "EC1301",
+      "GET1023"
+    ]
+  },
+  {
+    "code": "EC2205",
+    "name": "Economic Analysis of Business",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC2205"
+    ],
+    "prerequisites": [
+      "EC1101E",
+      "EC1301"
+    ]
+  },
+  {
+    "code": "EC2303",
+    "name": "Foundations for Econometrics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC1007",
+      "DSC1007X",
+      "MA2216"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EC2374",
+    "name": "Economy of Modern China I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC1101E",
+      "EC1301",
+      "BSP1005",
+      "USE2301"
+    ]
+  },
+  {
+    "code": "EC3101",
+    "name": "Microeconomic Analysis II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC2101",
+      "EC2104",
+      "MA1301",
+      "MA1301FC",
+      "MA1301X",
+      "MA1311",
+      "MA1312",
+      "MA1421"
+    ]
+  },
+  {
+    "code": "EC3102",
+    "name": "Macroeconomic Analysis II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC2102",
+      "EC2101",
+      "EC2104",
+      "MA1301",
+      "MA1301FC",
+      "MA1301X",
+      "MA1311",
+      "MA1312",
+      "MA1421"
+    ]
+  },
+  {
+    "code": "EC3303",
+    "name": "Econometrics I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ST3131"
+    ],
+    "prerequisites": [
+      "EC1101E",
+      "EC1301",
+      "BSP1005",
+      "EC2303",
+      "DSC1007",
+      "DSC1007X",
+      "MA2216"
+    ]
+  },
+  {
+    "code": "EC3304",
+    "name": "Econometrics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3303",
+      "ST3131",
+      "EC2104",
+      "MA1301",
+      "MA1301FC",
+      "MA1301X",
+      "MA1311",
+      "MA1312",
+      "MA1421"
+    ]
+  },
+  {
+    "code": "EC3305",
+    "name": "Programming Tools for Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC2303"
+    ]
+  },
+  {
+    "code": "EC3312",
+    "name": "Game Theory & Applications to Economics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA4264"
+    ],
+    "prerequisites": [
+      "EC2101",
+      "EC2104",
+      "MA1301",
+      "MA1301FC",
+      "MA1301X",
+      "MA1311",
+      "MA1312",
+      "MA1421"
+    ]
+  },
+  {
+    "code": "EC3314",
+    "name": "Mathematical Economics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC3311"
+    ],
+    "prerequisites": [
+      "EC2104",
+      "MA1101R",
+      "MA1102R",
+      "MA1505",
+      "MA1506",
+      "MA1507",
+      "MA1508",
+      "EC2101",
+      "EC2102"
+    ]
+  },
+  {
+    "code": "EC3322",
+    "name": "Industrial Organisation I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC2101",
+      "EC2104",
+      "MA1301",
+      "MA1301FC",
+      "MA1301X",
+      "MA1311",
+      "MA1312",
+      "MA1421"
+    ]
+  },
+  {
+    "code": "EC3332",
+    "name": "Money and Banking I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC2102",
+      "EC2104",
+      "MA1301",
+      "MA1301FC",
+      "MA1301X",
+      "MA1311",
+      "MA1312",
+      "MA1421"
+    ]
+  },
+  {
+    "code": "EC3333",
+    "name": "Financial Economics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC2101",
+      "EC2102",
+      "BSP2001",
+      "EC2104",
+      "MA1301",
+      "MA1301FC",
+      "MA1301X",
+      "MA1311",
+      "MA1312",
+      "MA1421"
+    ]
+  },
+  {
+    "code": "EC3342",
+    "name": "International Trade I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC3341"
+    ],
+    "prerequisites": [
+      "EC2101",
+      "EC2102"
+    ]
+  },
+  {
+    "code": "EC3343",
+    "name": "International Finance I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC3341"
+    ],
+    "prerequisites": [
+      "EC2101",
+      "EC2102"
+    ]
+  },
+  {
+    "code": "EC3351",
+    "name": "Public Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC2101",
+      "EC2104",
+      "MA1301",
+      "MA1301FC",
+      "MA1301X",
+      "MA1311",
+      "MA1312",
+      "MA1421"
+    ]
+  },
+  {
+    "code": "EC3361",
+    "name": "Labour Economics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC2101",
+      "EC2104",
+      "MA1301",
+      "MA1301FC",
+      "MA1301X",
+      "MA1311",
+      "MA1312",
+      "MA1421",
+      "EC3303"
+    ]
+  },
+  {
+    "code": "EC3371",
+    "name": "Development Economics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC2101",
+      "EC2104",
+      "MA1301",
+      "MA1301FC",
+      "MA1301X",
+      "MA1311",
+      "MA1312",
+      "MA1421",
+      "EC3303"
+    ]
+  },
+  {
+    "code": "EC3373",
+    "name": "Asean Economies",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC3375",
+      "EC3376",
+      "EU3214"
+    ],
+    "prerequisites": [
+      "EC2101"
+    ]
+  },
+  {
+    "code": "EC3381",
+    "name": "Urban Economics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE2102",
+      "RE2705"
+    ],
+    "prerequisites": [
+      "EC2101",
+      "EC2104",
+      "MA1301",
+      "MA1301FC",
+      "MA1301X",
+      "MA1311",
+      "MA1312",
+      "MA1421"
+    ]
+  },
+  {
+    "code": "EC3385",
+    "name": "Maritime and Shipping Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC2101"
+    ]
+  },
+  {
+    "code": "EC3394",
+    "name": "Economics and Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC2101",
+      "EC2102",
+      "EC3303"
+    ]
+  },
+  {
+    "code": "EC3396",
+    "name": "Economic Analysis of Law I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101"
+    ]
+  },
+  {
+    "code": "EC3551",
+    "name": "FASS Undergraduate Research Opportunity (UROP)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EC4301",
+    "name": "Microeconomic Analysis III",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EC4101"
+    ],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC4301",
+      "EC4101",
+      "EC4302",
+      "EC4102",
+      "EC3101",
+      "EC3102",
+      "EC3101",
+      "EC3102",
+      "EC4301",
+      "EC4101",
+      "EC4302",
+      "EC4102",
+      "EC3101",
+      "EC3102"
+    ]
+  },
+  {
+    "code": "EC4302",
+    "name": "Macroeconomic Analysis III",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EC4102"
+    ],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC4301",
+      "EC4101",
+      "EC4302",
+      "EC4102",
+      "EC3101",
+      "EC3102",
+      "EC3101",
+      "EC3102",
+      "EC4301",
+      "EC4101",
+      "EC4302",
+      "EC4102",
+      "EC3101",
+      "EC3102"
+    ]
+  },
+  {
+    "code": "EC4303",
+    "name": "Econometrics III",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC3304",
+      "EC3101",
+      "EC3102",
+      "EC3304"
+    ]
+  },
+  {
+    "code": "EC4304",
+    "name": "Economic and Financial Forecasting",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3303",
+      "EC3304",
+      "EC3303",
+      "EC3304"
+    ]
+  },
+  {
+    "code": "EC4305",
+    "name": "Applied Econometrics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3304",
+      "EC3304"
+    ]
+  },
+  {
+    "code": "EC4306",
+    "name": "Applied Microeconomic Analysis",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EC4101",
+      "EC4301"
+    ],
+    "prerequisites": [
+      "EC3101",
+      "EC3101"
+    ]
+  },
+  {
+    "code": "EC4307",
+    "name": "Issues in Macroeconomics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3102",
+      "EC3102"
+    ]
+  },
+  {
+    "code": "EC4313",
+    "name": "Search Theory and Applications",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC3101",
+      "EC3102"
+    ]
+  },
+  {
+    "code": "EC4324",
+    "name": "Economics of Competition Policy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC3312",
+      "EC3322",
+      "EC3101",
+      "EC3102",
+      "EC3312",
+      "EC3322"
+    ]
+  },
+  {
+    "code": "EC4332",
+    "name": "Money and Banking II",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC3303",
+      "EC3332",
+      "EC3101",
+      "EC3102",
+      "EC3303",
+      "EC3332"
+    ]
+  },
+  {
+    "code": "EC4333",
+    "name": "Financial Economics II",
+    "creditCount": 5.0,
+    "preclusions": [
+      "MA3245",
+      "MA4269"
+    ],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC3333",
+      "EC3101",
+      "EC3102",
+      "EC3333"
+    ]
+  },
+  {
+    "code": "EC4334",
+    "name": "Financial Market Microstructure",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3304",
+      "EC3333",
+      "EC3101",
+      "EC3304",
+      "EC3333"
+    ]
+  },
+  {
+    "code": "EC4343",
+    "name": "International Finance II",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC3303",
+      "EC3341",
+      "EC3101",
+      "EC3102",
+      "EC3303",
+      "EC3341",
+      "EC3343"
+    ]
+  },
+  {
+    "code": "EC4351",
+    "name": "Public Economics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC3303",
+      "EC3351",
+      "EC3101",
+      "EC3102",
+      "EC3303",
+      "EC3351"
+    ]
+  },
+  {
+    "code": "EC4353",
+    "name": "Health Economics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3304",
+      "EC3101",
+      "EC3304"
+    ]
+  },
+  {
+    "code": "EC4354",
+    "name": "Economics of Education",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC3303",
+      "EC3101",
+      "EC3102",
+      "EC3303"
+    ]
+  },
+  {
+    "code": "EC4361",
+    "name": "Labour Economics II",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC3303",
+      "EC3361",
+      "EC3101",
+      "EC3102",
+      "EC3303",
+      "EC3361"
+    ]
+  },
+  {
+    "code": "EC4362",
+    "name": "Immigration Economics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC3303",
+      "EC3351",
+      "EC3361",
+      "EC3371",
+      "EC3101",
+      "EC3102",
+      "EC3303",
+      "EC3351",
+      "EC3361",
+      "EC3371"
+    ]
+  },
+  {
+    "code": "EC4371",
+    "name": "Development Economics II",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC3303",
+      "EC3371",
+      "EC3101",
+      "EC3102",
+      "EC3303",
+      "EC3371"
+    ]
+  },
+  {
+    "code": "EC4372",
+    "name": "Technology and Innovation",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC3303",
+      "EC3101",
+      "EC3102",
+      "EC3303"
+    ]
+  },
+  {
+    "code": "EC4382",
+    "name": "Transport Economics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3304",
+      "EC3101",
+      "EC3304"
+    ]
+  },
+  {
+    "code": "EC4383",
+    "name": "Environmental Economics II",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC3304",
+      "EC3383",
+      "EC3101",
+      "EC3102",
+      "EC3304",
+      "EC3383"
+    ]
+  },
+  {
+    "code": "EC4387",
+    "name": "Housing Economics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3304",
+      "EC3101",
+      "EC3304"
+    ]
+  },
+  {
+    "code": "EC4394",
+    "name": "Behavioural Economics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101"
+    ]
+  },
+  {
+    "code": "EC4398",
+    "name": "Economics of Inequality",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC3304",
+      "EC3101",
+      "EC3102",
+      "EC3304"
+    ]
+  },
+  {
+    "code": "EC4399",
+    "name": "Behavioural Public Policy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3304",
+      "EC3394",
+      "EC4394"
+    ]
+  },
+  {
+    "code": "EC4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "EC4660"
+    ],
+    "prerequisites": [
+      "EC4301",
+      "EC4101",
+      "EC4302",
+      "EC4102"
+    ]
+  },
+  {
+    "code": "EC4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EC4401",
+      "EC4401S"
+    ],
+    "prerequisites": [
+      "EC4301",
+      "EC4101",
+      "EC4302",
+      "EC4102"
+    ]
+  },
+  {
+    "code": "EC4880",
+    "name": "Topics in Economics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3102",
+      "EC3101",
+      "EC3102"
+    ]
+  },
+  {
+    "code": "EC4880A",
+    "name": "Topics in Economics: Economics of Careers",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC3101",
+      "EC3303",
+      "EC3101",
+      "EC3303"
+    ]
+  },
+  {
+    "code": "EC5101",
+    "name": "Microeconomic Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EC5101R",
+    "name": "Microeconomic Theory",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EC5102",
+    "name": "Macroeconomic Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EC5102R",
+    "name": "Macroeconomic Theory",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EC5103",
+    "name": "Econometric Modelling And Applications I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC5154"
+    ],
+    "prerequisites": [
+      "EC5253",
+      "EC5304",
+      "ECA5103"
+    ]
+  },
+  {
+    "code": "EC5103R",
+    "name": "Econometric Modelling And Applications I",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EC5154"
+    ],
+    "prerequisites": [
+      "EC5253",
+      "EC5304",
+      "ECA5103"
+    ]
+  },
+  {
+    "code": "EC5104",
+    "name": "Mathematical Economics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC5210",
+      "EC5311"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EC5104R",
+    "name": "Mathematical Economics",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EC5210",
+      "EC5311"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EC5322",
+    "name": "Industrial Organisation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC5215",
+      "EC5268"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EC5322R",
+    "name": "Industrial Organisation",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EC5215",
+      "EC5268"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EC5332",
+    "name": "Money & Banking",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC5208"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EC5332R",
+    "name": "Money & Banking",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EC5208"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EC5352",
+    "name": "Public Economics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC5267",
+      "EC5209",
+      "EC5351",
+      "ECA5351"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EC5352R",
+    "name": "Public Economics",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EC5267",
+      "EC5209",
+      "EC5351",
+      "ECA5351"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EC5387",
+    "name": "Issues in Maritime and Shipping Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC2104",
+      "EC2303",
+      "EC3101"
+    ]
+  },
+  {
+    "code": "EC5387R",
+    "name": "Issues in Maritime and Shipping Economics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC2104",
+      "EC2303",
+      "EC3101"
+    ]
+  },
+  {
+    "code": "EC6101",
+    "name": "Advanced Microeconomic Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EC6102",
+    "name": "Advanced Macroeconomic Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EC6103",
+    "name": "Econometric Modelling And Applications Ii",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC6154"
+    ],
+    "prerequisites": [
+      "EC5154",
+      "EC5103"
+    ]
+  },
+  {
+    "code": "EC6104",
+    "name": "Advanced Mathematical Economics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC6210",
+      "EC6311"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EC6322",
+    "name": "Advanced Industrial Organisation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC6215",
+      "EC6268"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EC6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EC6884",
+    "name": "Behavioral and Experimental Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ECA5101",
+    "name": "Microeconomics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC5151",
+      "EC5101A"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ECA5102",
+    "name": "Macroeconomics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC5152",
+      "EC5102A"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ECA5103",
+    "name": "Quantitative & Computing Methods",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC5253",
+      "EC5304"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ECA5313",
+    "name": "Topics in Econometrics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ECA5253",
+      "ECA5304",
+      "ECA5103"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ECA5333",
+    "name": "Financial Markets & Portfolio Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC5274",
+      "EC5333",
+      "EC4209",
+      "EC4333",
+      "EC5274",
+      "ECA5333",
+      "EC5274",
+      "ECA5333"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ECA5334",
+    "name": "Corporate Finance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC5269",
+      "EC5334"
+    ],
+    "prerequisites": [
+      "EC5274",
+      "EC5333",
+      "ECA5333"
+    ]
+  },
+  {
+    "code": "ECA5335",
+    "name": "Derivative Securities",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC5260"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ECA5371",
+    "name": "Economic Growth And Development",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC5262",
+      "EC5263",
+      "IZ5201",
+      "EC5371"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ECA5373",
+    "name": "The Singapore Economy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC5205",
+      "EC5255",
+      "EC5373"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ECA5373R",
+    "name": "The Singapore Economy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EC5205",
+      "EC5255",
+      "EC5373"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ECA5375",
+    "name": "Economic Growth in East Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC5266",
+      "IZ5212"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ECA5880",
+    "name": "Topics in Applied Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ECA5881",
+    "name": "Topics in Economic Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE1111",
+    "name": "Engineering Principles and Practice I",
+    "creditCount": 6.0,
+    "preclusions": [
+      "EG1111"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE1112",
+    "name": "Engineering Principles and Practice II",
+    "creditCount": 6.0,
+    "preclusions": [
+      "EG1112",
+      "CG1111"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE2011E",
+    "name": "Engineering Electromagnetics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE2011"
+    ],
+    "prerequisites": [
+      "TE2002"
+    ]
+  },
+  {
+    "code": "EE2012",
+    "name": "Analytical Methods in Electrical and Computer Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ST2334"
+    ],
+    "prerequisites": [
+      "MA1505",
+      "MA1506",
+      "MA1511",
+      "MA1512"
+    ]
+  },
+  {
+    "code": "EE2023",
+    "name": "Signals and Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2023E",
+      "CG2023",
+      "TEE2023"
+    ],
+    "prerequisites": [
+      "MA1506",
+      "MA1512"
+    ]
+  },
+  {
+    "code": "EE2023E",
+    "name": "Signals and Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2009E",
+      "EE2010E",
+      "TEE2023"
+    ],
+    "prerequisites": [
+      "TG1401"
+    ]
+  },
+  {
+    "code": "EE2024",
+    "name": "Programming for Computer Interfaces",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE2020",
+      "CS1010E"
+    ]
+  },
+  {
+    "code": "EE2026",
+    "name": "Digital Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2020"
+    ],
+    "prerequisites": [
+      "EG1111"
+    ]
+  },
+  {
+    "code": "EE2027",
+    "name": "Electronic Circuits",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2021",
+      "CG2027"
+    ],
+    "prerequisites": [
+      "EG1112"
+    ]
+  },
+  {
+    "code": "EE2028",
+    "name": "Microcontroller Programming and Interfacing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2024",
+      "CG2028"
+    ],
+    "prerequisites": [
+      "IT1007",
+      "EE2026"
+    ]
+  },
+  {
+    "code": "EE2031",
+    "name": "Circuit and Systems Design Lab",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE2021"
+    ]
+  },
+  {
+    "code": "EE2032",
+    "name": "Signals & Communications Design Lab",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE2011",
+      "EE2023"
+    ]
+  },
+  {
+    "code": "EE2033",
+    "name": "Integrated System Lab",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2031",
+      "EE2032"
+    ],
+    "prerequisites": [
+      "EE2023",
+      "EE2027"
+    ]
+  },
+  {
+    "code": "EE3031",
+    "name": "Innovation & Enterprise I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TR3001",
+      "EE3001",
+      "MT4003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE3031E",
+    "name": "Innovation & Enterprise I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM4209",
+      "EE3001E",
+      "TEE3031"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE3104C",
+    "name": "Introduction to RF and Microwave Systems & Circuits",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3104E",
+      "TEE3104"
+    ],
+    "prerequisites": [
+      "PC2020",
+      "AY2017",
+      "EE2011",
+      "AY2016"
+    ]
+  },
+  {
+    "code": "EE3131C",
+    "name": "Communication Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3103"
+    ],
+    "prerequisites": [
+      "EE2023"
+    ]
+  },
+  {
+    "code": "EE3131E",
+    "name": "Communication Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3103E",
+      "TEE3131"
+    ],
+    "prerequisites": [
+      "EE2009E",
+      "EE2010E",
+      "EE2023E"
+    ]
+  },
+  {
+    "code": "EE3207E",
+    "name": "Computer Architecture",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE3207"
+    ],
+    "prerequisites": [
+      "EE2007E",
+      "EE2024E",
+      "TEE2028"
+    ]
+  },
+  {
+    "code": "EE3331C",
+    "name": "Feedback Control Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2010"
+    ],
+    "prerequisites": [
+      "EE2023"
+    ]
+  },
+  {
+    "code": "EE3331E",
+    "name": "Feedback Control Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2010E",
+      "TEE3331"
+    ],
+    "prerequisites": [
+      "EE2023E"
+    ]
+  },
+  {
+    "code": "EE3408C",
+    "name": "Integrated Analog Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3408E",
+      "TEE3408"
+    ],
+    "prerequisites": [
+      "CG2027",
+      "EE2027",
+      "AY2017",
+      "EE2021",
+      "AY2016"
+    ]
+  },
+  {
+    "code": "EE3408E",
+    "name": "Integrated Analog Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE3408"
+    ],
+    "prerequisites": [
+      "EE2021E",
+      "TEE2027"
+    ]
+  },
+  {
+    "code": "EE3431C",
+    "name": "Microelectronics Materials and Devices",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3406",
+      "EE2004",
+      "PC3235"
+    ],
+    "prerequisites": [
+      "EE2027",
+      "CG2027",
+      "EE2021"
+    ]
+  },
+  {
+    "code": "EE3431E",
+    "name": "Microelectronics Materials and Devices",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3406E",
+      "EE2004E",
+      "TEE3431"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE3501E",
+    "name": "Power Electronics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE3501"
+    ],
+    "prerequisites": [
+      "EE2005E",
+      "EE2021E",
+      "TEE2027"
+    ]
+  },
+  {
+    "code": "EE3506C",
+    "name": "Intro to Elect Energy Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3505C"
+    ],
+    "prerequisites": [
+      "EG1112",
+      "CG1111",
+      "AY2017",
+      "EE1002",
+      "EG1108",
+      "CG1108",
+      "AY2016"
+    ]
+  },
+  {
+    "code": "EE3731C",
+    "name": "Signal Processing Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE2012",
+      "ST2334",
+      "EE2023"
+    ]
+  },
+  {
+    "code": "EE4001",
+    "name": "B.Eng. Dissertation",
+    "creditCount": 12.0,
+    "preclusions": [
+      "CG4001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE4031",
+    "name": "Intellectual Property: Harnessing Innovation",
+    "creditCount": 2.0,
+    "preclusions": [
+      "MT5001",
+      "MT5010"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE4101",
+    "name": "RF Communications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE3104C"
+    ]
+  },
+  {
+    "code": "EE4101E",
+    "name": "Radio-Frequency (RF) Communications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE4101"
+    ],
+    "prerequisites": [
+      "EE2011E"
+    ]
+  },
+  {
+    "code": "EE4104",
+    "name": "Microwave Circuits & Devices",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE3104C"
+    ]
+  },
+  {
+    "code": "EE4112",
+    "name": "Radio Frequency Design and Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4112E",
+      "TEE4112"
+    ],
+    "prerequisites": [
+      "EE3104C"
+    ]
+  },
+  {
+    "code": "EE4112E",
+    "name": "Radio Frequency Design and Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE4112"
+    ],
+    "prerequisites": [
+      "EE2011E"
+    ]
+  },
+  {
+    "code": "EE4204",
+    "name": "Computer Networks",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3204",
+      "EE3204E",
+      "TEE3204",
+      "TEE4204"
+    ],
+    "prerequisites": [
+      "EE2012",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "EE4204E",
+    "name": "Computer Networks",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2105",
+      "CS3103",
+      "TEE3204",
+      "EE3204E",
+      "TEE4204"
+    ],
+    "prerequisites": [
+      "TE2003"
+    ]
+  },
+  {
+    "code": "EE4210",
+    "name": "Network Protocols and Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4210E",
+      "TEE4210"
+    ],
+    "prerequisites": [
+      "EE2012",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "EE4210E",
+    "name": "Network Protocols and Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE4210",
+      "TIC2501"
+    ],
+    "prerequisites": [
+      "TE2003"
+    ]
+  },
+  {
+    "code": "EE4211",
+    "name": "Data Science for the Internet of Things",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE2012",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "EE4212",
+    "name": "Computer Vision",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS4243"
+    ],
+    "prerequisites": [
+      "MA1508E",
+      "EE3731C",
+      "EE4704",
+      "AY2017",
+      "EE3206",
+      "EE3731C",
+      "AY2016"
+    ]
+  },
+  {
+    "code": "EE4214E",
+    "name": "Real-Time Embedded Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE4214",
+      "TIC2401"
+    ],
+    "prerequisites": [
+      "TE2101",
+      "EE2024E",
+      "TEE2028"
+    ]
+  },
+  {
+    "code": "EE4218",
+    "name": "Embedded Hardware System Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE2028",
+      "CG2028",
+      "AY2017",
+      "EE2024",
+      "AY2016"
+    ]
+  },
+  {
+    "code": "EE4302",
+    "name": "Advanced Control Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE3331C"
+    ]
+  },
+  {
+    "code": "EE4303",
+    "name": "Industrial Control Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3302",
+      "EE3302E",
+      "TEE3302",
+      "TEE4303"
+    ],
+    "prerequisites": [
+      "EE3331C"
+    ]
+  },
+  {
+    "code": "EE4303E",
+    "name": "Industrial Control Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE3302",
+      "EE3302E",
+      "TEE4303"
+    ],
+    "prerequisites": [
+      "EE2010E",
+      "EE3331E"
+    ]
+  },
+  {
+    "code": "EE4305",
+    "name": "Introduction To Fuzzy / Neural Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE2023"
+    ]
+  },
+  {
+    "code": "EE4305E",
+    "name": "Introduction To Fuzzy/Neural Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE4305"
+    ],
+    "prerequisites": [
+      "EE2010E",
+      "EE2023E"
+    ]
+  },
+  {
+    "code": "EE4307",
+    "name": "Control Systems Design And Simulation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE3331C"
+    ]
+  },
+  {
+    "code": "EE4308",
+    "name": "Advances in Intelligent Systems and Robotics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4306"
+    ],
+    "prerequisites": [
+      "EE3331C"
+    ]
+  },
+  {
+    "code": "EE4407E",
+    "name": "Analog Electronics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE3407",
+      "EE3407E",
+      "TEE4407"
+    ],
+    "prerequisites": [
+      "EE2021E",
+      "TEE2027"
+    ]
+  },
+  {
+    "code": "EE4409",
+    "name": "Microelectronic Applications for Modern Life",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3409"
+    ],
+    "prerequisites": [
+      "CG2027",
+      "EE2027",
+      "AY2017",
+      "EE2021",
+      "AY2016"
+    ]
+  },
+  {
+    "code": "EE4415",
+    "name": "Integrated Digital Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4415E",
+      "TEE4415"
+    ],
+    "prerequisites": [
+      "EE2026",
+      "AY2017",
+      "EE2020",
+      "AY2016"
+    ]
+  },
+  {
+    "code": "EE4415E",
+    "name": "Integrated Digital Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE4415"
+    ],
+    "prerequisites": [
+      "EE2006E",
+      "EE2020E",
+      "TEE2026"
+    ]
+  },
+  {
+    "code": "EE4434",
+    "name": "Integrated Circuit Technology, Design and Testing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE2026",
+      "CG2027",
+      "EE2027",
+      "AY2017",
+      "EE2020",
+      "EE2021",
+      "AY2016"
+    ]
+  },
+  {
+    "code": "EE4435",
+    "name": "Modern Transistors and Memory Devices",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE4435",
+      "EE4435E"
+    ],
+    "prerequisites": [
+      "CG2027",
+      "EE2027",
+      "EE3431C",
+      "AY2017",
+      "EE2021",
+      "EE3431C",
+      "AY2016"
+    ]
+  },
+  {
+    "code": "EE4435E",
+    "name": "Modern Transistors and Memory Devices",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4408E",
+      "EE4412E",
+      "TEE4435"
+    ],
+    "prerequisites": [
+      "EE2021E",
+      "TEE2027"
+    ]
+  },
+  {
+    "code": "EE4436",
+    "name": "Fabrication Process Technology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4411",
+      "EE4411E",
+      "EE4436E",
+      "TEE4436"
+    ],
+    "prerequisites": [
+      "CG2027",
+      "EE2027",
+      "AY2017",
+      "EE2021",
+      "AY2016"
+    ]
+  },
+  {
+    "code": "EE4436E",
+    "name": "Fabrication Process Technology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4411E",
+      "TEE4436"
+    ],
+    "prerequisites": [
+      "EE2021E",
+      "TEE2027"
+    ]
+  },
+  {
+    "code": "EE4437",
+    "name": "Photonics - Principles and Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4401"
+    ],
+    "prerequisites": [
+      "CG2027",
+      "EE2027",
+      "AY2017",
+      "EE2021",
+      "AY2016"
+    ]
+  },
+  {
+    "code": "EE4438",
+    "name": "Solar Cells and Modules",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4432"
+    ],
+    "prerequisites": [
+      "CG2027",
+      "EE2027",
+      "AY2017",
+      "EE2021",
+      "AY2016"
+    ]
+  },
+  {
+    "code": "EE4501",
+    "name": "Power System Management And Protection",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE3505C",
+      "AY2016",
+      "EE3506C",
+      "AY2017"
+    ]
+  },
+  {
+    "code": "EE4502",
+    "name": "Electric Drives & Control",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE2025",
+      "EE3505C",
+      "AY2016",
+      "EE3506C",
+      "AY2017"
+    ]
+  },
+  {
+    "code": "EE4503",
+    "name": "Advanced Power Electronics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2025",
+      "EE3501E",
+      "TEE3501"
+    ],
+    "prerequisites": [
+      "EE3505C",
+      "EE3506C"
+    ]
+  },
+  {
+    "code": "EE4505",
+    "name": "Power Semiconductor Devices & ICs",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AY2017",
+      "EE2021",
+      "AY2016"
+    ]
+  },
+  {
+    "code": "EE4511",
+    "name": "Renewable Generation and Smart Grid",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE3505C",
+      "AY2016",
+      "EE3506C",
+      "AY2017"
+    ]
+  },
+  {
+    "code": "EE4603",
+    "name": "Biomedical Imaging Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE2023",
+      "BN2401"
+    ]
+  },
+  {
+    "code": "EE4704",
+    "name": "Introduction to Computer Vision and Image Processing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS4243",
+      "EE3206",
+      "EE3206E",
+      "TEE3206",
+      "TEE4704"
+    ],
+    "prerequisites": [
+      "CG2023",
+      "EE2023"
+    ]
+  },
+  {
+    "code": "EE5001",
+    "name": "Independent Study Module I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5002",
+    "name": "Independent Study Module Ii",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5003",
+    "name": "Electrical Engineering Project",
+    "creditCount": 8.0,
+    "preclusions": [
+      "EE5001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5020",
+    "name": "Data Science for Internet of Things",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5021",
+    "name": "Cloud based Services for Internet of Things",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5022",
+    "name": "Cyber Security for Internet of Things",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5023",
+    "name": "Wireless Networks",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5024",
+    "name": "Sensor Networks",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5026",
+    "name": "Machine Learning for Data Analytics",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5027",
+    "name": "Statistical Pattern Recognition",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5060",
+    "name": "Sensors and Instrumentation for Automation",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5061",
+    "name": "Industrial Control and IEC Programming",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5063",
+    "name": "Modelling of Mechatronic Systems",
+    "creditCount": 2.0,
+    "preclusions": [
+      "EE5109"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5064",
+    "name": "Dynamics and Control of Robot Manipulators",
+    "creditCount": 2.0,
+    "preclusions": [
+      "ME5402",
+      "EE5106"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5101",
+    "name": "Linear Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MCH5201",
+      "ME5401",
+      "EE5101R"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5103",
+    "name": "Computer Control Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ME5403",
+      "EE5103R",
+      "MCH5103",
+      "TD5241"
+    ],
+    "prerequisites": [
+      "EE2010"
+    ]
+  },
+  {
+    "code": "EE5104",
+    "name": "Adaptive Control Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE6104"
+    ],
+    "prerequisites": [
+      "EE5101",
+      "EE5101R",
+      "ME5401"
+    ]
+  },
+  {
+    "code": "EE5106",
+    "name": "Advanced Robotics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MCH5209",
+      "ME5402",
+      "EE5106R"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5109",
+    "name": "Modelling and Applications of Mechatronic Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MCH5002",
+      "EE5063"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5110",
+    "name": "Special Topics in Automation and Control",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE6110"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5111",
+    "name": "Selected Topics in Industrial Control & Instrumentation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5060",
+      "EE5061"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5132",
+    "name": "Wireless and Sensor Networks",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5406",
+      "EE5913",
+      "EE5023",
+      "EE5024"
+    ],
+    "prerequisites": [
+      "EE3204",
+      "EE4210"
+    ]
+  },
+  {
+    "code": "EE5133",
+    "name": "Statistical Signal Processing Techniques",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE4131",
+      "EE5306",
+      "EE5137R"
+    ]
+  },
+  {
+    "code": "EE5134",
+    "name": "Optical Communications and Networks",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5912",
+      "EE6134"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5135",
+    "name": "Digital Communications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5305",
+      "EE6135"
+    ],
+    "prerequisites": [
+      "EE5137",
+      "EE5137R",
+      "EE5306"
+    ]
+  },
+  {
+    "code": "EE5137",
+    "name": "Stochastic Processes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5306",
+      "EE5137R"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5138",
+    "name": "Optimization for Communication Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5138R"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5303",
+    "name": "Microwave Electronics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5303R"
+    ],
+    "prerequisites": [
+      "EE4101",
+      "EE4104",
+      "EE4112"
+    ]
+  },
+  {
+    "code": "EE5308",
+    "name": "Antenna Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5308R"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5310",
+    "name": "Communication Networking Fundamentals",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE6310"
+    ],
+    "prerequisites": [
+      "EE2012",
+      "EE3204",
+      "EE4210"
+    ]
+  },
+  {
+    "code": "EE5431",
+    "name": "Fundamentals of Nanoelectronics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5431R"
+    ],
+    "prerequisites": [
+      "PC2232",
+      "EE3431C"
+    ]
+  },
+  {
+    "code": "EE5434",
+    "name": "Microelectronic Processes and Integration",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5515",
+      "EE5516",
+      "EE5432R"
+    ],
+    "prerequisites": [
+      "EE3431C"
+    ]
+  },
+  {
+    "code": "EE5439",
+    "name": "Micro/Nano Electromechanical Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE6439",
+      "EE5520"
+    ],
+    "prerequisites": [
+      "EE4411",
+      "CN4217"
+    ]
+  },
+  {
+    "code": "EE5440",
+    "name": "Magnetic Data Storage for Big Data",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4433"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5502",
+    "name": "Mos Devices",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5507",
+    "name": "Analog Integrated Circuits Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5507R"
+    ],
+    "prerequisites": [
+      "EE3408"
+    ]
+  },
+  {
+    "code": "EE5508",
+    "name": "Semiconductor Fundamentals",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE2004",
+      "EE3406",
+      "EE3431C"
+    ]
+  },
+  {
+    "code": "EE5517",
+    "name": "Optical Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE3431C"
+    ]
+  },
+  {
+    "code": "EE5518",
+    "name": "Vlsi Digital Circuit Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5518R"
+    ],
+    "prerequisites": [
+      "EE2020",
+      "EE4415"
+    ]
+  },
+  {
+    "code": "EE5666",
+    "name": "Industrial Attachment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5701",
+    "name": "High Voltage Testing And Switchgear",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5702",
+    "name": "Advanced Power System Analysis",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5702R"
+    ],
+    "prerequisites": [
+      "EE4501"
+    ]
+  },
+  {
+    "code": "EE5703",
+    "name": "Industrial Drives",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5703R",
+      "MCH5203"
+    ],
+    "prerequisites": [
+      "EE4502"
+    ]
+  },
+  {
+    "code": "EE5711",
+    "name": "Power Electronic Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5711R"
+    ],
+    "prerequisites": [
+      "EE3501C"
+    ]
+  },
+  {
+    "code": "EE5731",
+    "name": "Visual Computing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE6904",
+      "EE5731R"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5801",
+    "name": "Electromagnetic Compatibility",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5831",
+    "name": "Electromagnetic Wave Theory",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5831R"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5902",
+    "name": "Multiprocessor Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5902R",
+      "TD5180A"
+    ],
+    "prerequisites": [
+      "EE3204",
+      "EE3207"
+    ]
+  },
+  {
+    "code": "EE5903",
+    "name": "Real-Time Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4214",
+      "MCH5205",
+      "TD5103"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5904",
+    "name": "Neural Networks",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ME5404",
+      "EE5904R",
+      "MCH5202"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE5907",
+    "name": "Pattern Recognition",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5907R",
+      "EE5026",
+      "EE5027"
+    ],
+    "prerequisites": [
+      "EE2012",
+      "CS1101S"
+    ]
+  },
+  {
+    "code": "EE5934",
+    "name": "Deep Learning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE6934"
+    ],
+    "prerequisites": [
+      "EE2012",
+      "IT1007"
+    ]
+  },
+  {
+    "code": "EE5999",
+    "name": "Graduate Seminars",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE6104",
+    "name": "Adaptive Control Systems (Advanced)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5104"
+    ],
+    "prerequisites": [
+      "EE5101",
+      "EE5101R",
+      "ME5401"
+    ]
+  },
+  {
+    "code": "EE6110",
+    "name": "Special Topics in Automation and Control (Advanced)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5110"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EE6131",
+    "name": "Wireless Communications (Advanced)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE5137",
+      "EE5137R",
+      "EE5306"
+    ]
+  },
+  {
+    "code": "EE6135",
+    "name": "Digital Communications (Advanced)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5305",
+      "EE5135"
+    ],
+    "prerequisites": [
+      "EE5137",
+      "EE5137R",
+      "EE5306"
+    ]
+  },
+  {
+    "code": "EE6310",
+    "name": "Communication Networking Fundamentals (Advanced)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5310"
+    ],
+    "prerequisites": [
+      "EE2012",
+      "EE3204",
+      "EE4210"
+    ]
+  },
+  {
+    "code": "EE6435",
+    "name": "Advanced Concepts in Nanoelectronics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5209",
+      "EE5521"
+    ],
+    "prerequisites": [
+      "EE5431",
+      "EE5431R"
+    ]
+  },
+  {
+    "code": "EE6436",
+    "name": "Advanced Characterization of Materials and Devices",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE6503"
+    ],
+    "prerequisites": [
+      "EE5434",
+      "EE5432R"
+    ]
+  },
+  {
+    "code": "EE6437",
+    "name": "Advanced Semiconductor Devices",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE6505"
+    ],
+    "prerequisites": [
+      "EE5502",
+      "EE5433R"
+    ]
+  },
+  {
+    "code": "EE6438",
+    "name": "Magnetic materials and devices",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE5431",
+      "EE5431R",
+      "EE5433R"
+    ]
+  },
+  {
+    "code": "EE6439",
+    "name": "Micro/Nano Electromechanical Systems (Advanced)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5439",
+      "EE5520"
+    ],
+    "prerequisites": [
+      "EE4411",
+      "CN4217"
+    ]
+  },
+  {
+    "code": "EE6531",
+    "name": "Selected Topics in Smart Grid Technologies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE5711",
+      "EE5711R",
+      "EE5702",
+      "EE5702R"
+    ]
+  },
+  {
+    "code": "EE6733",
+    "name": "Advanced Topics on Vision and Machine Learning",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE5907",
+      "EE5907R",
+      "EE5731",
+      "EE5731R"
+    ]
+  },
+  {
+    "code": "EE6831",
+    "name": "Advanced Electromagnetic Theory and Applications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE5831",
+      "EE5831R"
+    ]
+  },
+  {
+    "code": "EE6832",
+    "name": "Advanced Multi-Antenna Communications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE5308",
+      "EE5308R"
+    ]
+  },
+  {
+    "code": "EE6833",
+    "name": "Selected Topics in Microwave and Antenna Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE5303",
+      "EE5303R",
+      "EE5308",
+      "EE5308R"
+    ]
+  },
+  {
+    "code": "EE6934",
+    "name": "Deep Learning (Advanced)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5934"
+    ],
+    "prerequisites": [
+      "EE2012",
+      "IT1007"
+    ]
+  },
+  {
+    "code": "EE6990",
+    "name": "Research Attachment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EE6999",
+    "name": "Doctoral Seminars",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EG1111",
+    "name": "Engineering Principles and Practice I",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EG1112",
+    "name": "Engineering Principles and Practice II",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EG1603",
+    "name": "TIP - Product & Business Plan Competition",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EG2201A",
+    "name": "Introduction to Design Thinking",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EG2301",
+    "name": "Case Studies in Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EG2311",
+    "name": "Introduction to Space Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EG2312",
+    "name": "Radar Theory and Techniques",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EG2401",
+    "name": "Engineering Professionalism",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ES1501A",
+      "ES1501B",
+      "ES1501C",
+      "EG1413",
+      "ES1531"
+    ]
+  },
+  {
+    "code": "EG2603",
+    "name": "TIP - Product & Business Plan Development",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EG2604",
+    "name": "Innovation Programme",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EG2605",
+    "name": "Undergraduate Research Opportunities Programme",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EG2606A",
+    "name": "Independent Work",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EG2606B",
+    "name": "Independent Work",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EG3301R",
+    "name": "DCP Project",
+    "creditCount": 12.0,
+    "preclusions": [
+      "ESP3902",
+      "ESP3903",
+      "BN2203",
+      "BN3101",
+      "CG3002",
+      "EE3001",
+      "EE3031",
+      "EE3032",
+      "IE3100M",
+      "ME3101",
+      "ME3102",
+      "ESE4501",
+      "MLE3103",
+      "MLE4102",
+      "EG3301"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EG3611",
+    "name": "Industrial Attachment",
+    "creditCount": 12.0,
+    "preclusions": [
+      "EG3601",
+      "EG3602",
+      "EG3612"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EG3612",
+    "name": "Vacation Internship Programme",
+    "creditCount": 6.0,
+    "preclusions": [
+      "EG3601",
+      "EG3602",
+      "EG3611"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EG4211",
+    "name": "Energy Storage Systems for Electric Grids",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EG4301",
+    "name": "DCP Dissertation",
+    "creditCount": 12.0,
+    "preclusions": [
+      "ESP4901",
+      "BN4101R",
+      "CN4118R",
+      "CG4001",
+      "EE4001",
+      "IE4100",
+      "ME4101",
+      "CE4104",
+      "ESE4502",
+      "MLE4101",
+      "BN4101",
+      "CG4003",
+      "CN4118",
+      "EE4002R",
+      "ESE4502R",
+      "IE4100R",
+      "ME4101A",
+      "MLE4101A"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EG4301A",
+    "name": "Ideas to Start-up",
+    "creditCount": 12.0,
+    "preclusions": [
+      "EG4301",
+      "BN4101",
+      "BN4101R",
+      "CE4104",
+      "CG4001",
+      "CG4003",
+      "CN4118",
+      "CN4118R",
+      "EE4001",
+      "EE4002R",
+      "ESP4901",
+      "ESE4502",
+      "ESE4502R",
+      "IE4100",
+      "IE4100R",
+      "ME4101",
+      "ME4101A",
+      "MLE4101",
+      "MLE4101A"
+    ],
+    "prerequisites": [
+      "EG3301R"
+    ]
+  },
+  {
+    "code": "EG5911",
+    "name": "Research Methodology & Ethics",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL1101E",
+    "name": "The Nature of Language",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1011"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EL2101",
+    "name": "Structure of Sentences and Meanings",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EL2201"
+    ],
+    "prerequisites": [
+      "EL1101E",
+      "GEK1011"
+    ]
+  },
+  {
+    "code": "EL2102",
+    "name": "Sound Patterns in Language",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EL2202"
+    ],
+    "prerequisites": [
+      "EL1101E",
+      "GEK1011"
+    ]
+  },
+  {
+    "code": "EL2111",
+    "name": "Historical Variation in English",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EL2211"
+    ],
+    "prerequisites": [
+      "EL1101E",
+      "GEK1011"
+    ]
+  },
+  {
+    "code": "EL2151",
+    "name": "Social Variation in English",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EL2251"
+    ],
+    "prerequisites": [
+      "EL1101E",
+      "GEK1011"
+    ]
+  },
+  {
+    "code": "EL3201",
+    "name": "Syntax",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EL2101",
+      "EL2201"
+    ]
+  },
+  {
+    "code": "EL3203",
+    "name": "Semantics and Pragmatics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EL1101E",
+      "GEK1011"
+    ]
+  },
+  {
+    "code": "EL3208",
+    "name": "Bilingualism",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EL1101E",
+      "GEK1011"
+    ]
+  },
+  {
+    "code": "EL3209",
+    "name": "Language, Culture, and Mind",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EL1101E",
+      "GEK1011"
+    ]
+  },
+  {
+    "code": "EL3210",
+    "name": "Topics in the Psychology of Language",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EL1101E",
+      "GEK1011"
+    ]
+  },
+  {
+    "code": "EL3211",
+    "name": "Language in Contact",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EL1101E",
+      "GEK1011"
+    ]
+  },
+  {
+    "code": "EL3213",
+    "name": "Language Typology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EL2101",
+      "EL2201"
+    ]
+  },
+  {
+    "code": "EL3214",
+    "name": "Language Documentation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EL1101E",
+      "GEK1011"
+    ]
+  },
+  {
+    "code": "EL3216",
+    "name": "Language and the Internet",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EL1101E",
+      "GEK1011"
+    ]
+  },
+  {
+    "code": "EL3222",
+    "name": "Cinematic Discourse and Language",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EL3880B"
+    ],
+    "prerequisites": [
+      "EL1101E",
+      "GEK1011"
+    ]
+  },
+  {
+    "code": "EL3231",
+    "name": "Phonetics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EL3202"
+    ],
+    "prerequisites": [
+      "EL2202",
+      "EL2102"
+    ]
+  },
+  {
+    "code": "EL3251",
+    "name": "Language, Society and Identity",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EL2151",
+      "EL2251"
+    ]
+  },
+  {
+    "code": "EL3551",
+    "name": "FASS Undergraduate Research Opportunity (UROP)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL4212",
+    "name": "Field Methods in Linguistics",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EL3212"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EL4216",
+    "name": "Lexicology and Lexicography",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL4222",
+    "name": "Stylistics and Drama",
+    "creditCount": 5.0,
+    "preclusions": [
+      "TS4213"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EL4251",
+    "name": "Social Thought in Language",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EL2251",
+      "EL2151"
+    ]
+  },
+  {
+    "code": "EL4252",
+    "name": "Interactional Discourse",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL4253",
+    "name": "Language, Gender, and Text",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL4254",
+    "name": "Language, Ideology and Power",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL4255",
+    "name": "English as a World Language",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "EL4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EL4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EL4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EL4880B",
+    "name": "Exploring Second Language Writing",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EL5880B",
+      "EL5880BR"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EL4880D",
+    "name": "Experimental Syntax",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EL3201"
+    ]
+  },
+  {
+    "code": "EL5101",
+    "name": "Grammatical Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5101R",
+    "name": "Grammatical Analysis",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5102",
+    "name": "Phonetics and Phonology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5102R",
+    "name": "Phonetics and Phonology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5103",
+    "name": "Language in Society",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EL5250"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5103R",
+    "name": "Language in Society",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EL5250"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5204",
+    "name": "Linguistic Typology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5204R",
+    "name": "Linguistic Typology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5216",
+    "name": "Corpus Linguistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5216R",
+    "name": "Corpus Linguistics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5251",
+    "name": "Approaches To Discourse",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5251R",
+    "name": "Approaches To Discourse",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5252",
+    "name": "Language Variation and Change",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5252R",
+    "name": "Language Variation and Change",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5253",
+    "name": "Textual Construction Of Knowledge",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5253R",
+    "name": "Textual Construction of Knowledge",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5255",
+    "name": "Second Language Writing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EL5880B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5255R",
+    "name": "Second Language Writing",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EL5880B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EL5660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL6660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL6880",
+    "name": "Topics in Grammatical Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL6882",
+    "name": "Topics In Language And Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EL6884",
+    "name": "Topics In Applied Linguistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EM1201",
+    "name": "English for Academic Purposes (Music) 1",
+    "creditCount": 0.0,
+    "preclusions": [
+      "AR1000",
+      "BE1000",
+      "ID1000",
+      "ET1000",
+      "NK1001",
+      "EA1101",
+      "EG1471",
+      "ES1301",
+      "ES1101",
+      "ES1102",
+      "ES1103",
+      "EM1101"
+    ],
+    "prerequisites": [
+      "AY2009"
+    ]
+  },
+  {
+    "code": "EM1202",
+    "name": "English for Academic Purposes (Music) 2",
+    "creditCount": 0.0,
+    "preclusions": [
+      "AR1000",
+      "BE1000",
+      "ID1000",
+      "ET1000",
+      "NK1001",
+      "EA1101",
+      "EG1471",
+      "ES1301",
+      "ES1101",
+      "ES1102",
+      "ES1103",
+      "EM1101"
+    ],
+    "prerequisites": [
+      "AY2009"
+    ]
+  },
+  {
+    "code": "EN1101E",
+    "name": "An Introduction to Literary Studies",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1000"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EN2201",
+    "name": "Backgrounds to Western Literature and Culture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EN1101E",
+      "GEK1000"
+    ]
+  },
+  {
+    "code": "EN2202",
+    "name": "Critical Reading",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EN3274"
+    ],
+    "prerequisites": [
+      "EN1101E",
+      "GEK1000"
+    ]
+  },
+  {
+    "code": "EN2203",
+    "name": "Introduction to Film Studies",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EN2113"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EN2207",
+    "name": "Gender and Sexuality in Literature",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EN1101E",
+      "GEK1000"
+    ]
+  },
+  {
+    "code": "EN2271",
+    "name": "Introduction to Playwriting",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EL1101E",
+      "EN1101E",
+      "TS1101E",
+      "GEK1011",
+      "GEK1000",
+      "GEM1003"
+    ]
+  },
+  {
+    "code": "EN2276",
+    "name": "Literature, Media and Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EN1101E",
+      "GEK1000"
+    ]
+  },
+  {
+    "code": "EN3221",
+    "name": "The English Renaissance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EN1101E",
+      "GEK1000",
+      "EN1101E",
+      "GEK1000",
+      "EN2201",
+      "EN2202",
+      "EN2203",
+      "EN2204",
+      "EN2205",
+      "EN2207"
+    ]
+  },
+  {
+    "code": "EN3222",
+    "name": "The Eighteenth Century",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EN1101E",
+      "GEK1000",
+      "EN1101E",
+      "GEK1000",
+      "EN2201",
+      "EN2202",
+      "EN2203",
+      "EN2204",
+      "EN2205",
+      "EN2207"
+    ]
+  },
+  {
+    "code": "EN3223",
+    "name": "Nineteenth Century Literature & Culture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EN1101E",
+      "GEK1000",
+      "EN1101E",
+      "GEK1000",
+      "EN2201",
+      "EN2202",
+      "EN2203",
+      "EN2204",
+      "EN2205",
+      "EN2207"
+    ]
+  },
+  {
+    "code": "EN3224",
+    "name": "The Twentieth Century",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EN1101E",
+      "GEK1000",
+      "EN1101E",
+      "GEK1000",
+      "EN2201",
+      "EN2202",
+      "EN2203",
+      "EN2204",
+      "EN2205",
+      "EN2207"
+    ]
+  },
+  {
+    "code": "EN3227",
+    "name": "Romanticism",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EN1101E",
+      "GEK1000",
+      "EN1101E",
+      "GEK1000",
+      "EN2201",
+      "EN2202",
+      "EN2203",
+      "EN2204",
+      "EN2205",
+      "EN2207"
+    ]
+  },
+  {
+    "code": "EN3231",
+    "name": "American Literature I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "AS3231"
+    ],
+    "prerequisites": [
+      "EN1101E",
+      "GEK1000",
+      "EN1101E",
+      "GEK1000",
+      "EN2201",
+      "EN2202",
+      "EN2203",
+      "EN2204",
+      "EN2205",
+      "EN2207"
+    ]
+  },
+  {
+    "code": "EN3241",
+    "name": "Literature and Psychoanalysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EN1101E",
+      "GEK1000",
+      "EN1101E",
+      "GEK1000",
+      "EN2201",
+      "EN2202",
+      "EN2203",
+      "EN2204",
+      "EN2205",
+      "EN2207"
+    ]
+  },
+  {
+    "code": "EN3243",
+    "name": "S/F: Science Fiction and Fantasy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EN1101E",
+      "GEK1000",
+      "EN1101E",
+      "GEK1000",
+      "EN2201",
+      "EN2202",
+      "EN2203",
+      "EN2204",
+      "EN2205",
+      "EN2207"
+    ]
+  },
+  {
+    "code": "EN3245",
+    "name": "Feminism: Text & Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EN1101E",
+      "GEK1000",
+      "EN1101E",
+      "GEK1000",
+      "EN2201",
+      "EN2202",
+      "EN2203",
+      "EN2204",
+      "EN2205",
+      "EN2207"
+    ]
+  },
+  {
+    "code": "EN3248",
+    "name": "Reading the Horror Film",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EN2204"
+    ],
+    "prerequisites": [
+      "EN2203"
+    ]
+  },
+  {
+    "code": "EN3263",
+    "name": "Singapore Literature in Context",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EN1101E",
+      "GEK1000",
+      "EN1101E",
+      "GEK1000",
+      "EN2201",
+      "EN2202",
+      "EN2203",
+      "EN2204",
+      "EN2205",
+      "EN2207"
+    ]
+  },
+  {
+    "code": "EN3271",
+    "name": "Advanced Playwriting",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TS4212"
+    ],
+    "prerequisites": [
+      "EN2271"
+    ]
+  },
+  {
+    "code": "EN3551",
+    "name": "FASS Undergraduate Research Opportunity (UROP)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN4234",
+    "name": "Pynchon and the Poetics of Information",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN4242",
+    "name": "Modern Critical Theory",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN4251",
+    "name": "Jonathan Swift",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN4261",
+    "name": "Metafictions and the Novel",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN4262",
+    "name": "Writing Global India: (Dis)Possessions of Capitalism",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN4264",
+    "name": "Modern Poetry",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN4265",
+    "name": "Approaches to World Literature: Critical Realism",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN4271",
+    "name": "Research Workshop",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EL4200"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EN4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "EN4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EN4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EN4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EN4880A",
+    "name": "Usurpation and Authority, 1558-1674",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN5238",
+    "name": "Twentieth-Century Literary Production",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN5238R",
+    "name": "Twentieth-Century Literary Production",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN5241",
+    "name": "Literature And New Worlds: 1590-1750",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN5241R",
+    "name": "Literature and New Worlds: 1590-1750",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN5242",
+    "name": "Women Novelists",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN5242R",
+    "name": "Women Novelists",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN5244",
+    "name": "Shakespeare And Literary Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN5244R",
+    "name": "Shakespeare And Literary Theory",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN5253",
+    "name": "Writing in the Aftermath",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN5253R",
+    "name": "Writing in the Aftermath",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN5254",
+    "name": "Rethinking Failure in the 21st Century",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN5254R",
+    "name": "Rethinking Failure in the 21st Century",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN5660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN5883",
+    "name": "Screen Culture In Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN5883R",
+    "name": "Screen Culture In Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN6102",
+    "name": "Advanced Critical Reading",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN6660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN6880",
+    "name": "Topics in the New Literatures",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN6881",
+    "name": "Topics In Literary History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EN6882",
+    "name": "Advanced Topics In Cultural Studies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ENV1101",
+    "name": "Environmental Studies: An Interdisciplinary Overview",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1903"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ENV1202",
+    "name": "Communications for Environmental Studies",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SP1202"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES1103"
+    ]
+  },
+  {
+    "code": "ENV2101",
+    "name": "Global Environmental Change",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM3272"
+    ],
+    "prerequisites": [
+      "ENV1101"
+    ]
+  },
+  {
+    "code": "ENV2102",
+    "name": "Environmental Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ENV2103",
+    "name": "The Environment and Public Health",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ENV3101",
+    "name": "Environmental Challenges: Asian Case Studies I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ENV2101"
+    ]
+  },
+  {
+    "code": "ENV3102",
+    "name": "Environmental Challenges: Asian Case Studies II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ENV3101"
+    ]
+  },
+  {
+    "code": "ENV3103",
+    "name": "Environmental Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EC1101E",
+      "EC1301"
+    ]
+  },
+  {
+    "code": "ENV3202",
+    "name": "Environmental Studies Internship Programme",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ENV4101",
+    "name": "Environmental Management in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ENV3101",
+      "ENV3102"
+    ]
+  },
+  {
+    "code": "ES1000",
+    "name": "Foundation Academic English",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ES1103",
+    "name": "English for Academic Purposes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ES1102"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "AY2016",
+      "ES1103"
+    ]
+  },
+  {
+    "code": "ES1531",
+    "name": "Critical Thinking And Writing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IEM1201",
+      "UTW1001",
+      "GEK1901",
+      "GET1021",
+      "ES1531",
+      "GEK1549"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES1102",
+      "ES1103",
+      "ES1531",
+      "GEK1549",
+      "AY2014",
+      "GEK1549"
+    ]
+  },
+  {
+    "code": "ES1541",
+    "name": "Exploring Science Communication through Popular Science",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SP1203",
+      "ENV1202",
+      "SP2171",
+      "SP1541",
+      "ES1601",
+      "ES1541"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES1102",
+      "ES1541"
+    ]
+  },
+  {
+    "code": "ES1601",
+    "name": "Professional and Academic Communication",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2101",
+      "IS2101",
+      "ES2331",
+      "ES2002",
+      "ES2007D",
+      "ES1541",
+      "SP1541",
+      "ES1501"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES1102",
+      "ES1103"
+    ]
+  },
+  {
+    "code": "ES2002",
+    "name": "Business Communication for Leaders (BBA)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MNO2706",
+      "IS2101",
+      "ES2007D",
+      "ES1601",
+      "UWC2101"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES2002"
+    ]
+  },
+  {
+    "code": "ES2007D",
+    "name": "Professional Communication",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2301",
+      "ES2002",
+      "IS2101",
+      "CS2101",
+      "CG1413",
+      "ES1601"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES1102",
+      "ES1103",
+      "ES2007D"
+    ]
+  },
+  {
+    "code": "ES2331",
+    "name": "Communicating Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ES1501",
+      "ES1601",
+      "AY2014"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES1103",
+      "ES2331"
+    ]
+  },
+  {
+    "code": "ES2660",
+    "name": "Communicating in the Information Age",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GET1006",
+      "GEK1901"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES1103",
+      "AY2016",
+      "ES2660"
+    ]
+  },
+  {
+    "code": "ES5000",
+    "name": "Graduate English Course (Basic Level)",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ES5001A",
+    "name": "Graduate English Course (Intermediate Level)",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ES5002",
+    "name": "Graduate English Course (Advanced Level)",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ES5101",
+    "name": "Technical Communication for Engineers",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE1001",
+    "name": "Environmental Engineering Fundamentals",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ESE1001FC",
+      "ESE1001X"
+    ],
+    "prerequisites": [
+      "MA1312"
+    ]
+  },
+  {
+    "code": "ESE1102",
+    "name": "Principles & Practice in Infrastructure and Environment",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE2001",
+    "name": "Environmental Processes",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE2401",
+    "name": "Water Science & Technology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE3001"
+    ],
+    "prerequisites": [
+      "ESE2001"
+    ]
+  },
+  {
+    "code": "ESE3001",
+    "name": "Water Quality Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ESE2401",
+      "ESE3401",
+      "TCE3001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE3101",
+    "name": "Solid And Hazardous Waste Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE3201",
+    "name": "Air Quality Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE3301",
+    "name": "Environmental Microbiological Principles",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE3401",
+    "name": "Water & Wastewater Engineering 1",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE3001"
+    ],
+    "prerequisites": [
+      "ESE2401"
+    ]
+  },
+  {
+    "code": "ESE4401",
+    "name": "Water & Wastewater Engineering 2",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE4401"
+    ],
+    "prerequisites": [
+      "ESE2401",
+      "ESE3401"
+    ]
+  },
+  {
+    "code": "ESE4404",
+    "name": "Bioenergy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE4408",
+    "name": "Environmental Impact Assessment",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE4408"
+    ],
+    "prerequisites": [
+      "ESE3101",
+      "ESE3201",
+      "ESE3301",
+      "ESE3401"
+    ]
+  },
+  {
+    "code": "ESE4501",
+    "name": "Design Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE4502",
+    "name": "B.Eng. Dissertation",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE4502R",
+    "name": "B. Eng. Dissertation B. Eng. Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5001",
+    "name": "Environmental Engineering Principles",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5002",
+    "name": "Physical and Process Principles",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5003",
+    "name": "Environmental Chemical Principles",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5004",
+    "name": "Research Project",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5202",
+    "name": "Air Pollution Control Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5202A",
+    "name": "Technologies for Air Quality Control",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5203",
+    "name": "Aerosol Science And Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE2134"
+    ]
+  },
+  {
+    "code": "ESE5204",
+    "name": "Toxic and Hazardous Waste Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5204B",
+    "name": "Physico-Chemical Treatment for Hazardous Chemicals",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5402B",
+    "name": "Biotechnologies for Industrial Wastewater Control",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5404",
+    "name": "Biological Treatment Processes",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5406",
+    "name": "Membrane Treatment Process Modelling",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5666",
+    "name": "Industrial Attachment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5880A",
+    "name": "Topics in Environmental Engineering: Chem. & Lab Safety",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5901",
+    "name": "Environmental Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5901B",
+    "name": "Technologies in Environmental Engineering",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE5999",
+    "name": "Graduate Seminars",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE6001",
+    "name": "Environmental Fate Of Organic Contaminant",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESE6999",
+    "name": "Doctoral Seminars",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESP1104A",
+    "name": "Sensor System Electronics",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESP2106",
+    "name": "Principles of Continua",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC1433"
+    ]
+  },
+  {
+    "code": "ESP2107",
+    "name": "Numerical Methods and Statistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1507",
+      "MA1508",
+      "MA1508E"
+    ]
+  },
+  {
+    "code": "ESP2110",
+    "name": "Design Project 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ESP1104",
+      "ESP1107"
+    ]
+  },
+  {
+    "code": "ESP3102",
+    "name": "From Making Nano to Probing Nano",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC2130B",
+      "PC2133"
+    ]
+  },
+  {
+    "code": "ESP3902",
+    "name": "Major Design Project I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ESP3901"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ESP3903",
+    "name": "Major Design Project 2",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ESP3901"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ESP4401",
+    "name": "Optimization of Energy Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME3122",
+      "PC2230",
+      "ME3221",
+      "ME4225"
+    ]
+  },
+  {
+    "code": "ESP4901",
+    "name": "Research Project",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ESP5402",
+    "name": "Transport Phenomena in Energy Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EU1101E",
+    "name": "Making of Modern Europe",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "EU2203",
+    "name": "Ancient Western Political Thought",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS2203",
+      "PS2231",
+      "EU2218",
+      "PS2201B",
+      "PS2218"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EU2204",
+    "name": "Modern Western Political Thought",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS2204",
+      "PS2231",
+      "EU2218",
+      "PS2201B",
+      "PS2218"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EU2213",
+    "name": "Upheaval in Europe: 1848-1918",
+    "creditCount": 4.0,
+    "preclusions": [
+      "HY2231"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EU2221",
+    "name": "Empires, Colonies and Imperialism",
+    "creditCount": 4.0,
+    "preclusions": [
+      "HY2245"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EU3212",
+    "name": "Europe of the Dictators",
+    "creditCount": 4.0,
+    "preclusions": [
+      "HY3227"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EU3224",
+    "name": "Social Thought & Social Theory",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SC3101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EU3231",
+    "name": "Modern Imperialism",
+    "creditCount": 4.0,
+    "preclusions": [
+      "HY3242"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EU4214",
+    "name": "Special Paper in Modern European History",
+    "creditCount": 5.0,
+    "preclusions": [
+      "HY4212"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EU4224",
+    "name": "Early Modern Europe and its World",
+    "creditCount": 5.0,
+    "preclusions": [
+      "HY4205"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EU4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "EU4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "EU4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EU4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "FAS1101",
+    "name": "Writing Academically: Arts and Social Sciences",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ES1531",
+      "GEK1549",
+      "GET1021",
+      "ES1501"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES1103"
+    ]
+  },
+  {
+    "code": "FAS1102",
+    "name": "Public Writing and Communication",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ES2002",
+      "CS2101",
+      "IS2101",
+      "GEK1901",
+      "GET1006",
+      "ES2660",
+      "ES2007D",
+      "ES1541",
+      "SP1541",
+      "ENV1202",
+      "ES1601"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES1103"
+    ]
+  },
+  {
+    "code": "FAS2551",
+    "name": "FASS Internship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FAS2552",
+    "name": "Extended Internship",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FAS2553",
+    "name": "Work Experience Internship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FAS2551"
+    ]
+  },
+  {
+    "code": "FDP2011",
+    "name": "Special Mathematics Class 1, 2",
+    "creditCount": 8.0,
+    "preclusions": [
+      "FDP2001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "FDP2021",
+    "name": "Special Physics Class 1, 2",
+    "creditCount": 8.0,
+    "preclusions": [
+      "FDP2002"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "FE5101",
+    "name": "Derivatives And Fixed Income",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FE5103",
+    "name": "Equity Products and Exotics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FE5105",
+    "name": "Corporate Financing And Risk",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FE5107",
+    "name": "Risk Analyses And Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FE5108",
+    "name": "Portfolio Theory And Investments",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FE5110",
+    "name": "Financial Engineering Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FE5112",
+    "name": "Stochastic Calculus and Quantitative Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FE5116",
+    "name": "Programming and Advanced Numerical Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FE5101",
+      "FE5101D",
+      "FE5112",
+      "FE5112D"
+    ]
+  },
+  {
+    "code": "FE5208",
+    "name": "Term Structure and Interest Rate Derivatives",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FE5101",
+      "FE5101D",
+      "FE5112",
+      "FE5112D"
+    ]
+  },
+  {
+    "code": "FE5209",
+    "name": "Financial Econometrics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FE5211",
+    "name": "Seminar In Financial Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FE5216",
+    "name": "Financial Technology Innovations Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FE5218",
+    "name": "Credit Risk",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FE5101"
+    ]
+  },
+  {
+    "code": "FE5221",
+    "name": "Trading Principles & Fundamentals",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FE5223",
+    "name": "Introduction to Electronic Financial Market",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FE5226",
+    "name": "C++ in Financial Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FIN2004",
+    "name": "Finance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2251",
+      "EC3209",
+      "EC3333",
+      "BK2004",
+      "BZ2004",
+      "BH2004",
+      "FNA2004",
+      "FIN2004",
+      "FIN2004"
+    ],
+    "prerequisites": [
+      "BK1003",
+      "BZ1002",
+      "BH1002",
+      "FNA1002",
+      "ACC1002",
+      "FNA1002X",
+      "ACC1002X",
+      "FNA1002E",
+      "BH1002E",
+      "EC3212",
+      "EG1422",
+      "FIN2004"
+    ]
+  },
+  {
+    "code": "FIN2004X",
+    "name": "Finance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2251",
+      "EC3209",
+      "EC3333",
+      "BK2004",
+      "BZ2004",
+      "BH2004",
+      "FNA2004",
+      "FIN2004",
+      "FIN2004"
+    ],
+    "prerequisites": [
+      "BK1003",
+      "BZ1002",
+      "BH1002",
+      "FNA1002",
+      "ACC1002",
+      "FNA1002X",
+      "ACC1002X",
+      "FNA1002E",
+      "BH1002E",
+      "EC3212",
+      "EG1422",
+      "FIN2004"
+    ]
+  },
+  {
+    "code": "FIN2704",
+    "name": "Finance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FIN2004"
+    ],
+    "prerequisites": [
+      "ACC1701",
+      "ACC1701X",
+      "EC2204"
+    ]
+  },
+  {
+    "code": "FIN2704X",
+    "name": "Finance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FIN2004"
+    ],
+    "prerequisites": [
+      "ACC1701",
+      "ACC1701X",
+      "EC2204"
+    ]
+  },
+  {
+    "code": "FIN3101",
+    "name": "Corporate Finance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3101",
+      "BZ3301",
+      "BK3100",
+      "FNA3101",
+      "FE5105",
+      "FIN3101A",
+      "FIN3101B",
+      "FIN3101C"
+    ],
+    "prerequisites": [
+      "FNA2004",
+      "FIN2004",
+      "BH2004",
+      "BZ2004",
+      "BK2004"
+    ]
+  },
+  {
+    "code": "FIN3101A",
+    "name": "Corporate Finance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3101",
+      "BZ3301",
+      "BK3100",
+      "FNA3101",
+      "FE5105",
+      "FIN3101",
+      "FIN3101B",
+      "FIN3101C"
+    ],
+    "prerequisites": [
+      "FNA2004",
+      "FIN2004",
+      "BH2004",
+      "BZ2004",
+      "BK2004"
+    ]
+  },
+  {
+    "code": "FIN3101B",
+    "name": "Corporate Finance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3101",
+      "BZ3301",
+      "BK3100",
+      "FNA3101",
+      "FE5105",
+      "FIN3101",
+      "FIN3101A",
+      "FIN3101C"
+    ],
+    "prerequisites": [
+      "FNA2004",
+      "FIN2004",
+      "BH2004",
+      "BZ2004",
+      "BK2004"
+    ]
+  },
+  {
+    "code": "FIN3102A",
+    "name": "Investment Analysis and Portfolio Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3102",
+      "BZ3302",
+      "BK3101",
+      "FNA3102",
+      "FNA3102B",
+      "FIN3102",
+      "FIN3102B",
+      "FE5108",
+      "EC3333",
+      "CF3101",
+      "QF3101"
+    ],
+    "prerequisites": [
+      "FNA2004",
+      "FIN2004",
+      "BH2004",
+      "BZ2004",
+      "BK2004"
+    ]
+  },
+  {
+    "code": "FIN3102B",
+    "name": "Investment Analysis and Portfolio Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3102",
+      "BZ3302",
+      "BK3101",
+      "FNA3102",
+      "FNA3102A",
+      "FIN3102",
+      "FIN3102A",
+      "FE5108",
+      "EC3333",
+      "CF3101",
+      "QF3101"
+    ],
+    "prerequisites": [
+      "FNA2004",
+      "FIN2004",
+      "BH2004",
+      "BZ2004",
+      "BK2004"
+    ]
+  },
+  {
+    "code": "FIN3102C",
+    "name": "Investment Analysis and Portfolio Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3102",
+      "BZ3302",
+      "BK3101",
+      "FNA3102",
+      "FNA3102A",
+      "FIN3102",
+      "FIN3102A",
+      "FE5108",
+      "EC3333",
+      "CF3101",
+      "QF3101"
+    ],
+    "prerequisites": [
+      "FNA2004",
+      "FIN2004",
+      "BH2004",
+      "BZ2004",
+      "BK2004"
+    ]
+  },
+  {
+    "code": "FIN3103A",
+    "name": "Financial Markets",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3103",
+      "BZ3303",
+      "BK3102",
+      "FNA3103",
+      "FIN3103",
+      "FIN3103B"
+    ],
+    "prerequisites": [
+      "FNA2004",
+      "FIN2004",
+      "BH2004",
+      "BZ2004",
+      "BK2004"
+    ]
+  },
+  {
+    "code": "FIN3103B",
+    "name": "Financial Markets",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3103",
+      "BZ3303",
+      "BK3102",
+      "FNA3103",
+      "FIN3103",
+      "FIN3103A"
+    ],
+    "prerequisites": [
+      "FNA2004",
+      "FIN2004",
+      "BH2004",
+      "BZ2004",
+      "BK2004"
+    ]
+  },
+  {
+    "code": "FIN3113",
+    "name": "Financial Statement Analysis",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3113",
+      "BZ3105",
+      "BK3105",
+      "FNA3113"
+    ],
+    "prerequisites": [
+      "FNA1002",
+      "FNA1002X",
+      "ACC1002",
+      "ACC1002X",
+      "BH1002",
+      "BZ1002",
+      "BK1003",
+      "FNA1002E",
+      "BH1002E"
+    ]
+  },
+  {
+    "code": "FIN3116",
+    "name": "Options and Futures",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3116",
+      "BZ3312",
+      "BK3109A",
+      "FNA3116",
+      "FIN3116A",
+      "FIN3116B"
+    ],
+    "prerequisites": [
+      "FNA3102",
+      "FNA3102A",
+      "FNA3102B",
+      "FNA3102C",
+      "FIN3102",
+      "FIN3102A",
+      "FIN3102B",
+      "FIN3102C"
+    ]
+  },
+  {
+    "code": "FIN3117",
+    "name": "Bank Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FNA3117",
+      "FIN3117",
+      "FE5105"
+    ],
+    "prerequisites": [
+      "FNA2004",
+      "FIN2004",
+      "FNA3102",
+      "FIN3102"
+    ]
+  },
+  {
+    "code": "FIN3118",
+    "name": "Financial Risk Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3118",
+      "BZ3305",
+      "FNA3118"
+    ],
+    "prerequisites": [
+      "FIN3102"
+    ]
+  },
+  {
+    "code": "FIN3119",
+    "name": "Risk and Insurance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3119",
+      "BZ3311",
+      "FNA3119"
+    ],
+    "prerequisites": [
+      "FNA2004",
+      "FIN2004",
+      "BH2004",
+      "BZ2004",
+      "BK2004"
+    ]
+  },
+  {
+    "code": "FIN3120B",
+    "name": "TIF: Transaction Banking",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FIN3101"
+    ]
+  },
+  {
+    "code": "FIN3129",
+    "name": "Independent Study in Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FIN3130",
+    "name": "Financial Modelling",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ACC1002",
+      "FIN2004",
+      "FIN3102"
+    ]
+  },
+  {
+    "code": "FIN3131",
+    "name": "Fixed Income Securities",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FNA3120A",
+      "CF3201",
+      "QF3201"
+    ],
+    "prerequisites": [
+      "FNA3102",
+      "FIN3102",
+      "FIN3102A",
+      "FIN3102B",
+      "FIN3102C"
+    ]
+  },
+  {
+    "code": "FIN3132",
+    "name": "Value Investing In Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ACC1002",
+      "FIN3101"
+    ]
+  },
+  {
+    "code": "FIN4112G",
+    "name": "SIF: Private Equity",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FIN4112F"
+    ],
+    "prerequisites": [
+      "FIN3101",
+      "FIN3102",
+      "FIN3103"
+    ]
+  },
+  {
+    "code": "FIN4112H",
+    "name": "SIF: Investment Banking",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FIN4112F"
+    ],
+    "prerequisites": [
+      "FIN3101",
+      "FIN3102",
+      "FIN3103"
+    ]
+  },
+  {
+    "code": "FIN4112K",
+    "name": "SIF: Applied Portfolio Management Techniques",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FIN3102"
+    ]
+  },
+  {
+    "code": "FIN4112L",
+    "name": "SIF: Family Business & Wealth Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FIN3101"
+    ]
+  },
+  {
+    "code": "FIN4113",
+    "name": "Personal Finance and Wealth Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FNA4112E"
+    ],
+    "prerequisites": [
+      "FIN3101",
+      "ST1131A"
+    ]
+  },
+  {
+    "code": "FIN4113Y",
+    "name": "Personal Finance and Wealth Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FNA4112E"
+    ],
+    "prerequisites": [
+      "FIN3101",
+      "ST1131A"
+    ]
+  },
+  {
+    "code": "FIN4115",
+    "name": "Advanced Portfolio Mgt: Security Analysis & Valuation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ACC1002",
+      "FIN3101",
+      "FIN3102"
+    ]
+  },
+  {
+    "code": "FIN4116",
+    "name": "Valuation and Mergers & Acquisitions",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FIN2004",
+      "FIN3101"
+    ]
+  },
+  {
+    "code": "FIN4119",
+    "name": "Advanced Independent Study in Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FIN4122",
+    "name": "Entrepreneurial Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FIN2004",
+      "FIN3101"
+    ]
+  },
+  {
+    "code": "FIN6001",
+    "name": "Corporate Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FIN6002",
+    "name": "Banking and Household Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMA1203C",
+    "name": "FS: Smart Cities",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMA1204C",
+    "name": "FS: Saving Face",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMA1206H",
+    "name": "FS: Travel and the Historian",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMS1203S",
+    "name": "FS: Randomness in Scientific Thinking",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMS1204S",
+    "name": "FS: Fraud, Deception and Data",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMS1205P",
+    "name": "FS: Nanoworld and Synchrotron Radiation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMS1206M",
+    "name": "FS: Is Mathematics Science?",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMS1206P",
+    "name": "Energy Storage Devices - State of the Art",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMS1210P",
+    "name": "Imaging our world",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMS1212P",
+    "name": "SYC: Simple Yet Complex",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMS1214B",
+    "name": "Mysteries of Water, Protein Aggregation and Diseases",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMS1214P",
+    "name": "Silk: Fibers that make a difference in our world",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMS1215B",
+    "name": "Plant Pathogens that cause plants to end up in a bucket",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMS1218B",
+    "name": "FS: How come aspirin can relieve my headache?",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMS1221B",
+    "name": "Science: The Good, the Bad, the Ugly and the Beautiful",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMS1223B",
+    "name": "The Native Seed Plants of Singapore",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FMS1225B",
+    "name": "Infectious Diseases and Host-Pathogen Interactions",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FSP4003",
+    "name": "Field Service Project",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FST1101",
+    "name": "Science and Technology of Foods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FST1103",
+    "name": "Fundamentals of Food Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM1161",
+      "CM2161"
+    ],
+    "prerequisites": [
+      "FST1101"
+    ]
+  },
+  {
+    "code": "FST2102B",
+    "name": "Chemistry of Food Components",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FST2102A"
+    ],
+    "prerequisites": [
+      "FST1101",
+      "CM1121",
+      "CM1501"
+    ]
+  },
+  {
+    "code": "FST2106",
+    "name": "Post Harvest Food Processing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FST1101",
+      "LSM1101",
+      "LSM1106"
+    ]
+  },
+  {
+    "code": "FST2107",
+    "name": "Food Analysis and Lab",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CM2192",
+      "CM2192A",
+      "FST2102A"
+    ],
+    "prerequisites": [
+      "FST1101",
+      "CM1191"
+    ]
+  },
+  {
+    "code": "FST2108",
+    "name": "Food Safety Assurance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FST3102"
+    ],
+    "prerequisites": [
+      "FST2102B",
+      "LSM1103",
+      "LSM2103",
+      "LSM1106"
+    ]
+  },
+  {
+    "code": "FST2201",
+    "name": "Introduction to Human Nutrition",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1101",
+      "LSM1106"
+    ]
+  },
+  {
+    "code": "FST2204",
+    "name": "Seafood Supply Chains in Japan and Singapore",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FST2288",
+    "name": "Basic UROPS in Food Science & Technology I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FST1101"
+    ]
+  },
+  {
+    "code": "FST2289",
+    "name": "Basic UROPS in Food Science & Technology II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FST1101"
+    ]
+  },
+  {
+    "code": "FST3101",
+    "name": "Food Microbiology & Fermentation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FST1101",
+      "FST2102B"
+    ]
+  },
+  {
+    "code": "FST3103",
+    "name": "Advanced Food Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FST1101",
+      "FST1103"
+    ]
+  },
+  {
+    "code": "FST3105",
+    "name": "Food Product Development and Packaging",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FST3104"
+    ],
+    "prerequisites": [
+      "FST2102B",
+      "FST2107",
+      "FST2108"
+    ]
+  },
+  {
+    "code": "FST3106",
+    "name": "Sensory and Flavour Science",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FST3104",
+      "FST4101"
+    ],
+    "prerequisites": [
+      "FST2102B"
+    ]
+  },
+  {
+    "code": "FST3181",
+    "name": "Professional Placement",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FST3201",
+    "name": "Independent Study (Food Science & Tech)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FST3202",
+    "name": "Nutrition and Disease Prevention",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FST2201"
+    ]
+  },
+  {
+    "code": "FST3288",
+    "name": "Advanced UROPS in Food Science & Technology I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FST3289",
+    "name": "Advanced UROPS in Food Science & Technology II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FST3288"
+    ]
+  },
+  {
+    "code": "FST3310",
+    "name": "Undergraduate Professional Internship Programme",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3310"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "FST3311",
+    "name": "Undergraduate Professional Internship Programme",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3311"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "FST4102",
+    "name": "Advanced Food Processing Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FST3103"
+    ]
+  },
+  {
+    "code": "FST4103",
+    "name": "Food Colloids and Components Science",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FST3105",
+      "FST3106"
+    ]
+  },
+  {
+    "code": "FST4199",
+    "name": "Honours Project in Food Science & Tech",
+    "creditCount": 16.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FST4202",
+    "name": "Nutritional Biochemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FST3202",
+      "LSM2101",
+      "LSM2211"
+    ]
+  },
+  {
+    "code": "FST4299",
+    "name": "Applied Project in FST",
+    "creditCount": 16.0,
+    "preclusions": [
+      "FST4199"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "FST5199",
+    "name": "MSc research project",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FST5202",
+    "name": "Advanced Food Fermentation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FST3101",
+      "LSM3232"
+    ]
+  },
+  {
+    "code": "FST5203",
+    "name": "Advanced Food Microbiology and Safety",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "FST3101",
+      "LSM3232"
+    ]
+  },
+  {
+    "code": "FST5205",
+    "name": "Frontier of Food Processing and Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FST5225",
+    "name": "Advanced Current Topics in Food Science I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FST5226",
+    "name": "Advanced Current Topics in Food Science II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FST5227",
+    "name": "Advanced Current Topics in Food Science III",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "FST5301",
+    "name": "Evidence Based Functional Foods",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FST5204"
+    ],
+    "prerequisites": [
+      "FST2102",
+      "CM2121"
+    ]
+  },
+  {
+    "code": "FST5302",
+    "name": "Food, Nutrition and Health",
+    "creditCount": 4.0,
+    "preclusions": [
+      "FST2201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "FST5303",
+    "name": "Modern Human Nutrition",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE1101E",
+    "name": "Geographical Journeys: Exploring World Environments",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GE2101",
+    "name": "Methods and Practices in Geography",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GE2225"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GE2202",
+    "name": "Economy & Space",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE2204",
+    "name": "Cities in Transition",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE2206",
+    "name": "Geographies of Life and Death",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE2215",
+    "name": "Introduction to GIS & Remote Sensing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IF2203"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GE2218",
+    "name": "Leisure, Recreation and Tourism",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE2220",
+    "name": "Terrestrial and Coastal Environments",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE2221",
+    "name": "Nature and Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE2222",
+    "name": "Politics and Space",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE2226",
+    "name": "Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE2227",
+    "name": "Cartography and Visualisation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE2228",
+    "name": "Weather and Climate",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GE2219"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GE2229",
+    "name": "Water and the Environment",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GE2219"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GE2230",
+    "name": "Energy Futures: Environment and Sustainability",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE2231",
+    "name": "Introduction to Social and Cultural Geographies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE3201",
+    "name": "The Service Economy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE3204",
+    "name": "Cities and Regions: Planning for Change",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE3206",
+    "name": "Gender, Space & Place",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE3219",
+    "name": "Globalisation and the Asian Cities",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE3226",
+    "name": "Tourism Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE3227",
+    "name": "Urban Climates",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GE2228"
+    ]
+  },
+  {
+    "code": "GE3230A",
+    "name": "Field Studies in Geography: SE Asia",
+    "creditCount": 8.0,
+    "preclusions": [
+      "GE3230"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GE3231",
+    "name": "Natural Hazards",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE3236",
+    "name": "Transport and Communications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE3237",
+    "name": "Geographies of Migration",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE3238",
+    "name": "GIS Design and Practices",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GE2215"
+    ]
+  },
+  {
+    "code": "GE3240",
+    "name": "Geographical Research: Developing Ideas",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE3241",
+    "name": "Geographies of Social Life",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GE2224"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GE3246",
+    "name": "Environmental Pollution",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE3550A",
+    "name": "GIS Internship Module",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GE3550B",
+      "XX3550"
+    ],
+    "prerequisites": [
+      "GE2215",
+      "GE2227",
+      "GE3238"
+    ]
+  },
+  {
+    "code": "GE3550B",
+    "name": "Geography Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GE3550A",
+      "XX3550"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GE3551",
+    "name": "FASS Undergraduate Research Opportunity (UROP)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE4204",
+    "name": "Urban Space:Critical Perspectives",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GE1101E",
+      "GE2204",
+      "GE3204",
+      "GE3219"
+    ]
+  },
+  {
+    "code": "GE4207",
+    "name": "Coastal Management",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GE1101E",
+      "GE2219",
+      "GE2220",
+      "GE2228",
+      "GE2229",
+      "GE3221",
+      "GE3227",
+      "GE1101E",
+      "GE2219",
+      "GE2220",
+      "GE2228",
+      "GE2229",
+      "GE3221",
+      "GE3227",
+      "GE1101E",
+      "GE2220",
+      "GE2228",
+      "GE2229",
+      "GE3221",
+      "GE3223",
+      "GE3231"
+    ]
+  },
+  {
+    "code": "GE4211",
+    "name": "Advanced Hydrology and Water Resources Management",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GE1101E",
+      "GE2219",
+      "GE2220",
+      "GE2228",
+      "GE2229",
+      "GE3221",
+      "GE3227",
+      "GE1101E",
+      "GE2219",
+      "GE2220",
+      "GE2228",
+      "GE2229",
+      "GE3221",
+      "GE3227",
+      "GE1101E",
+      "GE2220",
+      "GE2228",
+      "GE2229",
+      "GE3221",
+      "GE1101E",
+      "GE2219",
+      "GE2220",
+      "GE2228",
+      "GE2229",
+      "GE3221",
+      "GE3227"
+    ]
+  },
+  {
+    "code": "GE4212",
+    "name": "Environmental Modelling",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GE1101E",
+      "GE2219",
+      "GE2220",
+      "GE2228",
+      "GE2229",
+      "GE3221",
+      "GE3227",
+      "GE1101E",
+      "GE2219",
+      "GE2220",
+      "GE2228",
+      "GE2229",
+      "GE3221",
+      "GE3227",
+      "GE1101E",
+      "GE2219",
+      "GE2220",
+      "GE2228",
+      "GE2229",
+      "GE3221",
+      "GE3227",
+      "GE1101E",
+      "GE2220",
+      "GE2228",
+      "GE2229",
+      "GE3221",
+      "GE3223",
+      "GE3227"
+    ]
+  },
+  {
+    "code": "GE4213",
+    "name": "Cultural Geographies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GE1101E",
+      "GE2206",
+      "GE3206",
+      "GE3237"
+    ]
+  },
+  {
+    "code": "GE4214",
+    "name": "Remote Sensing of Environment",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GE2215",
+      "GE2215",
+      "GE2215"
+    ]
+  },
+  {
+    "code": "GE4217",
+    "name": "Political Geographies: Space and Power",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GE1101E",
+      "GE2222"
+    ]
+  },
+  {
+    "code": "GE4218",
+    "name": "Interpreting Tourism Spaces and Cultures",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE4219",
+    "name": "Development and Environment in Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GE1101E",
+      "GE2221",
+      "GE3210"
+    ]
+  },
+  {
+    "code": "GE4221",
+    "name": "Field Investigation in Human Geography",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE4223",
+    "name": "Development of Geographic Thought",
+    "creditCount": 5.0,
+    "preclusions": [
+      "GE4101A"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GE4225",
+    "name": "Young People and Children: Global Perspectives",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE4226",
+    "name": "Mobile Spaces: Making Social Worlds",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE4227",
+    "name": "Climate Change: Processes, Impact and Responses",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE4228",
+    "name": "Gender and the City",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GE3206",
+      "GE3206"
+    ]
+  },
+  {
+    "code": "GE4229",
+    "name": "Earth Systems Science",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE4230",
+    "name": "Greater China",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE4231",
+    "name": "Urban and Regional Economies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE4232",
+    "name": "Global Political Ecologies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE4233",
+    "name": "Geography in the Contemporary World",
+    "creditCount": 5.0,
+    "preclusions": [
+      "GE4102"
+    ],
+    "prerequisites": [
+      "GE1101E",
+      "GE2202",
+      "GE2206",
+      "GE2220",
+      "GE2228",
+      "GE2229",
+      "GE3201",
+      "GE3206",
+      "GE3221",
+      "GE3223",
+      "GE3227",
+      "GE3231",
+      "GE3237"
+    ]
+  },
+  {
+    "code": "GE4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "GE4660"
+    ],
+    "prerequisites": [
+      "GE3240",
+      "GE3240",
+      "GE3240",
+      "GE3240"
+    ]
+  },
+  {
+    "code": "GE4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "GE4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GE5211",
+    "name": "Dynamic Environments",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE5214",
+    "name": "Landscapes of Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SE5221"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GE5216",
+    "name": "Geography And Social Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE5219",
+    "name": "Spatial Programming",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GE5223"
+    ]
+  },
+  {
+    "code": "GE5223",
+    "name": "Introduction to Applied GIS",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE5225",
+    "name": "Thesis Planning and Implementation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE5226",
+    "name": "GIS Applications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE5227",
+    "name": "Internet GIS",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE5228",
+    "name": "Spatial Big Data and Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE5660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE6211",
+    "name": "Spatial Data Handling",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE6212",
+    "name": "Mapping Global Economic Change",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE6222",
+    "name": "Transnationalism and Society: Comparative Spaces",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE6223",
+    "name": "Navigating the Boundaries Between Science and Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE6225",
+    "name": "GIS Research Thesis",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GE5223",
+      "GE5219",
+      "GE6211",
+      "GE5225"
+    ]
+  },
+  {
+    "code": "GE6226",
+    "name": "GIS Research Project",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GE5223",
+      "GE5219",
+      "GE6211",
+      "GE5226"
+    ]
+  },
+  {
+    "code": "GE6660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GE6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1001",
+    "name": "Globalisation and New Media",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1036"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1002",
+    "name": "Economic Issues in Dev World",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1018K",
+      "GEK1018"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1004",
+    "name": "Chinese Heritage: Hist & Lit",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1007"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1005",
+    "name": "Crime Fiction in Eng & Chinese",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1021"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1006",
+    "name": "Chinese Music, Language and Literature (in English)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1053"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1008",
+    "name": "Nations & Nat'lisms in S Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1035"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1009",
+    "name": "Framing Bollywood: Unpacking The Magic",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1050"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1010",
+    "name": "Beasts, People and Wild Environments in South Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1913"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1013",
+    "name": "Pirates, Oceans and the Maritime World",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2049"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1014",
+    "name": "Samurai, Geisha, Yakuza as Self or Other",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2022"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1015",
+    "name": "Cultural Borrowing: Japan and China",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2042"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1018",
+    "name": "A Brief History of Science",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1539"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1019",
+    "name": "Food & Health",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1529",
+      "GEM1908"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1022",
+    "name": "Geopolitics:Geographies of War & Peace",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1022"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1023",
+    "name": "Exploring Chinese Cinema: Shanghai-Hong Kong-Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2047",
+      "CH2297"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1025",
+    "name": "Global Environmental Issues",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1522"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1025T",
+    "name": "Global Environmental Issues",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1522",
+      "GEK1522T",
+      "GEH1025"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1026",
+    "name": "Drugs and Society",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2506"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1027",
+    "name": "Einstein's Universe & Quantum Weirdness",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1508"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1028",
+    "name": "The Emerging Nanoworld",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1509"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1030",
+    "name": "Science of Music",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1519"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1032",
+    "name": "Modern Technology in Medicine and Health",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1540"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1033",
+    "name": "How the Ocean Works",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1548",
+      "GEK1548FC"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1034",
+    "name": "Clean Energy and Storage",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1535"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1035",
+    "name": "Phy'cal Qns from Everyday Life",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM2507"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1036",
+    "name": "Living with Mathematics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1505"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1040",
+    "name": "Exploration in Musical Production",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1065"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1041",
+    "name": "Engaging the natural environment in ASEAN",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1066"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1043",
+    "name": "Microbes which Changed Human History",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1534"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1044",
+    "name": "Understanding Globalisation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1041"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1047",
+    "name": "Social and Cultural Studies through Music",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1054"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1049",
+    "name": "Public Health in Action",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1900"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1050",
+    "name": "Plants and Society",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1538"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1051",
+    "name": "Narrative",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1049"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1053",
+    "name": "Film Art and Human Concerns",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2020"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1054",
+    "name": "Names as Markers of Socio-cultural Identity",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1031"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1055",
+    "name": "Religion and Film",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1033"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1056",
+    "name": "Understanding Contemporary Cultures",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1005"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1057",
+    "name": "Materials: The Enabling Substance of Civilization",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1058",
+    "name": "The Theatre Experience",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1055"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1060",
+    "name": "Social History of the Piano",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1061",
+    "name": "Representation and Media",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1062",
+    "name": "Ghosts and Spirits in Society and Culture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1063",
+    "name": "Understanding Body, Mind and Culture through Sport",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1065",
+    "name": "Art in Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1067",
+    "name": "Superhero Entertainments",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1068",
+    "name": "The Life Aquatic: Machines and the Making of the Ocean",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1069",
+    "name": "Art in Asia: Through Media, Style, Space and Time",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1070",
+    "name": "Traditional Chinese Knowledge of Health and Well-being",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1071",
+    "name": "Religion in Malay-Indonesian Literary Worlds",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1072",
+    "name": "Culture in Action",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1073",
+    "name": "The Art of Chinese Poetry: Past and Present",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1074",
+    "name": "Luck",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEH1075",
+    "name": "Life, Disrupted: The Sharing Revolution",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1000",
+    "name": "An Introduction to Literary Studies",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EN1101E",
+      "GEK1000"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1002",
+    "name": "Introduction to Japanese Studies",
+    "creditCount": 4.0,
+    "preclusions": [
+      "JS1101E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1003",
+    "name": "Introduction to Politics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS1101",
+      "GEM1003K",
+      "PS1101E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1005",
+    "name": "Understanding Contemporary Cultures",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1056"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1007",
+    "name": "Chinese Heritage: History and Literature",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1004"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1008",
+    "name": "Southeast Asia: A Changing Region",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SE1101E",
+      "SSA1202",
+      "SS1203SE",
+      "GEM1008K"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1010",
+    "name": "Property Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1011",
+    "name": "The Nature of Language",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EL1101E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1012",
+    "name": "Contemporary Social Issues in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GES1016"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1018",
+    "name": "Economic Issues in the Developing World",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1002"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1021",
+    "name": "Crime Fiction in English & Chinese",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1005"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1022",
+    "name": "Geopolitics:Geographies of War & Peace",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1022"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1035",
+    "name": "Nations & Nationalisms in South Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1008"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1041",
+    "name": "Understanding Globalisation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1044"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1048",
+    "name": "Gandhi's Life, Thought And Legacy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GET1009"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1049",
+    "name": "Narrative",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1051"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1053",
+    "name": "Chinese Music, Language and Literature (in English)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1006"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1054",
+    "name": "Social and Cultural Studies through Music",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1047"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1055",
+    "name": "The Theatre Experience",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1058"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1062",
+    "name": "Bridging East and West: Exploring Chinese Communication",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GET1002"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1064",
+    "name": "Psychology in Everyday Life",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PLB1201",
+      "PL1101E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1067",
+    "name": "Life, the Universe, and Everything",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PH1102E",
+      "GET1029"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1505",
+    "name": "Living with Mathematics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1036"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1508",
+    "name": "Einstein's Universe & Quantum Weirdness",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC1325",
+      "GEH1027"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1509",
+    "name": "The Emerging Nanoworld",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1028"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1520",
+    "name": "Understanding the Universe",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1031"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1522",
+    "name": "Global Environmental Issues",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1025"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1522T",
+    "name": "Global Environmental Issues",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1522",
+      "GEH1025",
+      "GEH1025T"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1529",
+    "name": "Food & Health",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1019",
+      "GEM1908"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1531",
+    "name": "Cyber Security",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GET1004"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1534",
+    "name": "Microbes which Changed Human History",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1043"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1539",
+    "name": "A Brief History of Science",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1018"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1540",
+    "name": "Modern Technology in Medicine and Health",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1032"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1544",
+    "name": "The Mathematics of Games",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GET1018"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1547",
+    "name": "The Art of Science, the Science of Art",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GET1014"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1548",
+    "name": "How the Ocean Works",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1033"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK1549",
+    "name": "Critical Thinking And Writing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IEM1201",
+      "UTW1001",
+      "GEK1901",
+      "GET1021",
+      "ES1531",
+      "GEK1549"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES1102",
+      "ES1103",
+      "ES1531",
+      "GEK1549",
+      "AY2014",
+      "GEK1549"
+    ]
+  },
+  {
+    "code": "GEK1900",
+    "name": "Public Health in Action",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1049"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2001",
+    "name": "Changing Landscapes of Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA2202",
+      "GES1003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2002",
+    "name": "Philosophy of Art",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2003",
+    "name": "Government and Politics of Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS1102",
+      "GEM2003K",
+      "SS2209PS",
+      "PS2101B",
+      "SSA2209",
+      "PS2101",
+      "PS2249"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2005",
+    "name": "Urban Planning in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GES1026"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2013",
+    "name": "Real Estate Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2020",
+    "name": "Film Art and Human Concerns",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1053"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2022",
+    "name": "Samurai, Geisha, Yakuza as Self or Other",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1014"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2025",
+    "name": "Politics of the Middle East",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS2255"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2028",
+    "name": "Founders of Modern Philosophy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PH2206"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2029",
+    "name": "Applied Ethics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PH2208"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2036",
+    "name": "Greek Philosophy (Socrates and Plato)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PH2222",
+      "PH3209"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2041",
+    "name": "Science Fiction and Philosophy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PH2225",
+      "GET1025"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2042",
+    "name": "Cultural Borrowing: Japan and China",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1015"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2044",
+    "name": "Reading Visual Images",
+    "creditCount": 4.0,
+    "preclusions": [
+      "AR2225"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2047",
+    "name": "Exploring Chinese Cinema: Shanghai-Hong Kong-Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CH2297",
+      "GEH1023"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2048",
+    "name": "Effective Reasoning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PH2111",
+      "GET1026"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2049",
+    "name": "Pirates, Oceans and the Maritime World",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1013"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK2050",
+    "name": "Digital Humanities in Arts Research",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GET1030"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEK3005",
+    "name": "Politics and the Visual",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS3260"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM1003",
+    "name": "Introduction to Theatre and Performance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TS1101E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM1004",
+    "name": "Reason and Persuasion",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GET1027"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM1029",
+    "name": "Patrons of the Arts",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MUL2102",
+      "GET1019"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM1031",
+    "name": "Names as Markers of Socio-cultural Identity",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1054"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM1033",
+    "name": "Religion and Film",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1055"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM1036",
+    "name": "Globalisation and New Media",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM1046",
+    "name": "Home",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GET1003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM1050",
+    "name": "Framing Bollywood: Unpacking The Magic",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1009"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM1051",
+    "name": "Ethnicity and Nation-Building: Singapore and Malaysia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GES1008"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM1052",
+    "name": "Understanding the Changing Global Economic Landscape",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GET1016"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM1052T",
+    "name": "Understanding The Changing Global Economic Landscape",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1052",
+      "GET1016",
+      "GET1016T"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM1535",
+    "name": "Clean Energy and Storage",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1034"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM1536",
+    "name": "Darwin and Evolution",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1902B",
+      "GET1020"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM1913",
+    "name": "Beasts, People and Wild Environments in South Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1010"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM2001",
+    "name": "Introduction to Asian Theatre",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TS2232"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM2006",
+    "name": "Logic",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PH2110",
+      "CS3234",
+      "MA4207",
+      "GET1028"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM2025",
+    "name": "Introduction to Philosophy Of Science",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PH2201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEM2027",
+    "name": "Public Speaking and Critical Reasoning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GET1008"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GEQ1000",
+    "name": "Asking Questions",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GEQ1917",
+    "name": "Understanding and Critiquing Sustainability",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1917"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GER1000",
+    "name": "Quantitative Reasoning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GER1000E",
+      "GER1000K",
+      "GER1000W",
+      "GER1000R",
+      "GER1000S",
+      "GER1000T",
+      "GER1000P",
+      "GER1000B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GER1000E",
+    "name": "Quantitative Reasoning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GER1000",
+      "GER1000K",
+      "GER1000W",
+      "GER1000R",
+      "GER1000S",
+      "GER1000T",
+      "GER1000P",
+      "GER1000B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GER1000K",
+    "name": "Quantitative Reasoning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GER1000",
+      "GER1000E",
+      "GER1000W",
+      "GER1000R",
+      "GER1000S",
+      "GER1000T",
+      "GER1000P",
+      "GER1000B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GER1000P",
+    "name": "Quantitative Reasoning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GER1000",
+      "GER1000E",
+      "GER1000K",
+      "GER1000W",
+      "GER1000R",
+      "GER1000S",
+      "GER1000T",
+      "GER1000B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GER1000R",
+    "name": "Quantitative Reasoning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GER1000",
+      "GER1000E",
+      "GER1000K",
+      "GER1000W",
+      "GER1000S",
+      "GER1000T",
+      "GER1000P",
+      "GER1000B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GER1000S",
+    "name": "Quantitative Reasoning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GER1000",
+      "GER1000E",
+      "GER1000K",
+      "GER1000W",
+      "GER1000R",
+      "GER1000T",
+      "GER1000P",
+      "GER1000B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GER1000T",
+    "name": "Quantitative Reasoning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GER1000",
+      "GER1000E",
+      "GER1000K",
+      "GER1000W",
+      "GER1000R",
+      "GER1000S",
+      "GER1000P",
+      "GER1000B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GER1000W",
+    "name": "Quantitative Reasoning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GER1000",
+      "GER1000E",
+      "GER1000K",
+      "GER1000R",
+      "GER1000S",
+      "GER1000T",
+      "GER1000P",
+      "GER1000B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1000T",
+    "name": "Labour Law In Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSB1204",
+      "SSB1204T",
+      "GES1000"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1002",
+    "name": "Global EC Dimensions of S'pore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA2220",
+      "SSA2220T",
+      "GES1002T"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1002T",
+    "name": "Global Economic Dimensions Of Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC2202",
+      "EC2373",
+      "GES1002",
+      "SSA2220",
+      "SSA2220T"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1003",
+    "name": "Changing Landscapes of Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2001",
+      "SSA2202"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1004",
+    "name": "The Biophysical Env of S'pore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA2215"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1005",
+    "name": "Everyday Life of Chinese Singaporeans: Past & Present (taught in English)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA1208"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1006",
+    "name": "Singapore and India: Emerging Relations",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA2214"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1007",
+    "name": "South Asia in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA2219"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1008",
+    "name": "Ethnicity and Nation-Building: Singapore and Malaysia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1051"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1009",
+    "name": "Singapore\u2019s Business History",
+    "creditCount": 4.0,
+    "preclusions": [
+      "HY2239",
+      "SSA2203"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1010",
+    "name": "Nation-Building in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "HY2229",
+      "USE2304",
+      "SSA2204"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1011",
+    "name": "The Evolution of a Global City-State",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA2211"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1012",
+    "name": "Popular Culture in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "HY2254",
+      "SSA2221"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1014",
+    "name": "Islam and Contemporary Malay Society",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA2206",
+      "MS2205"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1015",
+    "name": "Singapore and Japan: Historical and Contemporary Relationships",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA2205",
+      "JS2224"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1016",
+    "name": "Contemporary Social Issues in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1012"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1017",
+    "name": "Building a Dynamic Singapore - Role of Engineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSE1201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1019",
+    "name": "Managing Singapore's Built Environment",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSD2210"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1020",
+    "name": "Western Music within a Singaporean Context",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSY2223"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1021",
+    "name": "Natural Heritage of Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSS1207"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1023",
+    "name": "Representing Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA1206"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1024",
+    "name": "Real Estate Development & Investment Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSD1203"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1025",
+    "name": "Singapore Literature in English: Selected Texts",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA1207",
+      "SSA1207FC"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1026",
+    "name": "Urban Planning in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2005"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1028",
+    "name": "Singapore Society",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA1201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1029",
+    "name": "Singapore Film: Performance of Identity",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA2218",
+      "TS2238"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1031",
+    "name": "Culture and Communication in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1033",
+    "name": "Who moved my OB markers?",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1034",
+    "name": "We the Citizens - Understanding Singapore\u2019s Politics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1035",
+    "name": "Singapore: Imagining the Next 50 Years",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1039",
+    "name": "Cultural Performances and Practices in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GES1041",
+    "name": "Everyday Ethics in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1001",
+    "name": "Seeing the World Through Maps",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1037"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1002",
+    "name": "Bridging East and West: Exploring Chinese Communication",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1062"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1003",
+    "name": "Home",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1046"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1004",
+    "name": "Cyber Security",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1531"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1008",
+    "name": "Public Speaking and Critical Reasoning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM2027"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1009",
+    "name": "Gandhi's Life, Thought And Legacy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1048"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1011",
+    "name": "Towards an Understanding of the Complex World",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1912",
+      "GEM1912",
+      "GEM1915"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1013",
+    "name": "Physics in the Life Sciences",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1521"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1014",
+    "name": "The Art of Science, the Science of Art",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1547"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1016",
+    "name": "Understanding the Changing Global Economic Landscape",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1052"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1016T",
+    "name": "Understanding The Changing Global Economic Landscape",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1052",
+      "GET1016"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1018",
+    "name": "The Mathematics of Games",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1544"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1019",
+    "name": "Patrons of the Arts",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1029",
+      "MUL2102"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1020",
+    "name": "Darwin and Evolution",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1902B",
+      "GEM1536"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1021",
+    "name": "Critical Thinking And Writing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IEM1201",
+      "UTW1001",
+      "GET1006",
+      "ES1531",
+      "GEK1549",
+      "GET1021"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES1102",
+      "GET1021",
+      "AY2015",
+      "GET1021"
+    ]
+  },
+  {
+    "code": "GET1022",
+    "name": "Understanding Your Brain",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1023",
+    "name": "Thinking Like An Economist",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1024",
+    "name": "Radiation-Scientific Understanding and Public Perception",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1025",
+    "name": "Science Fiction and Philosophy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2041"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1026",
+    "name": "Effective Reasoning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2048"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1027",
+    "name": "Reason and Persuasion",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1004"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1028",
+    "name": "Logic",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PH2110",
+      "CS3234",
+      "MA4207",
+      "GEM2006"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1029",
+    "name": "Life, the Universe, and Everything",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PH1102E",
+      "GEK1067"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1030",
+    "name": "Digital Humanities in Arts Research",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2050"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1031A",
+    "name": "Computational Thinking",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1032",
+    "name": "Building Relationship : Theories and Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1033",
+    "name": "Exploring Computational Media Literacy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1034",
+    "name": "Communication and Critical Thinking for Community Leadership",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1035",
+    "name": "Critical Perspectives in Advertising",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1036",
+    "name": "The Logic of Language",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1037",
+    "name": "Big Picture History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1038",
+    "name": "Communication in Small Groups",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1042",
+    "name": "Sky and Telescopes",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1043",
+    "name": "Universe, Big Bang, and Unsolved Mysteries",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1046",
+    "name": "I Do Not Think Therefore I Am",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GET1048",
+    "name": "Science: From Thinking to Narratives",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GL1101E",
+    "name": "Global Issues",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GL2101",
+    "name": "Origins of the Modern World",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GL1101E"
+    ]
+  },
+  {
+    "code": "GL2102",
+    "name": "Global Political Economy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GL1101E"
+    ]
+  },
+  {
+    "code": "GL2103",
+    "name": "Global Governance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GL1101E"
+    ]
+  },
+  {
+    "code": "GL3201",
+    "name": "Global Studies and Humanities Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GL1101E",
+      "GL2101",
+      "GL2102",
+      "GL2103"
+    ]
+  },
+  {
+    "code": "GL3550",
+    "name": "Global Studies Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3550"
+    ],
+    "prerequisites": [
+      "GL1101E",
+      "GL2101",
+      "GL2102",
+      "GL2103"
+    ]
+  },
+  {
+    "code": "GL3551",
+    "name": "FASS Undergraduate Research Opportunity",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GL4101",
+    "name": "Research in Global Issues",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GL4102",
+    "name": "Task Force",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GL4101"
+    ]
+  },
+  {
+    "code": "GL4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "GL4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GL4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "GL4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "GL4881A",
+    "name": "Colonial, Anticolonial and Postcolonial Globalizations",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GL4882",
+    "name": "Topics in Global Economics and Development",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GL4882B",
+    "name": "Contested Globalisation: Resistance and Resilience",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GL4882C",
+    "name": "The Politics of Global Finance",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GL4883B",
+    "name": "Climate Justice",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GL4886A",
+    "name": "Citizenship and the Politics of Belonging",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GL4888A",
+    "name": "Justice and Emerging Technology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GL4889B",
+    "name": "Debates on Human Rights",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS5011",
+    "name": "Fundamentals of Pharmaceutical Regulation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS5012",
+    "name": "Chemistry, Manufacturing and Controls (CMC)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS5101",
+    "name": "Clinical Trial Design and Data Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS5103",
+    "name": "Regulation of Cell, Tissue and Gene Therapies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS5104",
+    "name": "Biotherapeutics and Biosimilars",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6800",
+    "name": "Integrated Biostatistics and Bioinformatics Journal Club",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6801",
+    "name": "Research Methods from Medicine to Population Health",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6802",
+    "name": "Analysis of Complex Biomedical Data",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6803",
+    "name": "Design and Analysis of Modern Clinical Studies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6804",
+    "name": "Biomedical Research Internship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6810",
+    "name": "Clinical and Translational Research Journal Club",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6811",
+    "name": "Principles of Clinical Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6812",
+    "name": "Foundations of Precision Medicine",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6820",
+    "name": "Core Concepts in Biostatistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6821",
+    "name": "R-Programming",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6850",
+    "name": "Core Concepts in Bioinformatics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GMS6901"
+    ]
+  },
+  {
+    "code": "GMS6900",
+    "name": "Student Research Seminars",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6901",
+    "name": "Molecules to Medicines",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6902",
+    "name": "Laboratory Rotation 1",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6903",
+    "name": "Laboratory Rotation 2",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6904",
+    "name": "Principles of Infectious Diseases",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GMS6901"
+    ]
+  },
+  {
+    "code": "GMS6906",
+    "name": "Laboratory Rotation 3",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6910",
+    "name": "Evolutionary Genetics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6920",
+    "name": "Metabolic Basis of Disease",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6921",
+    "name": "Cardiovascular Molecular Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GMS6901"
+    ]
+  },
+  {
+    "code": "GMS6950",
+    "name": "Health Services and Systems Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6991",
+    "name": "Thesis",
+    "creditCount": 40.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GMS6992",
+    "name": "Thesis (HSSR)",
+    "creditCount": 19.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GS5002",
+    "name": "Academic Professional Skills and Techniques",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GS5101",
+    "name": "Laboratory Rotation",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GS6001",
+    "name": "Research Ethics and Scientific Integrity",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GS6882A",
+    "name": "Biology of Disease",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GS6883A",
+    "name": "Interface Science and Engineering",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GS6889A",
+    "name": "Academic Professional Skills II",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GS6889B",
+    "name": "Academic Skills and Research Ethics",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GSN6501",
+    "name": "Neuronal Signalling",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GSN6504",
+    "name": "Behavioral & Cognitive Neuroscience",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "GSN6881",
+    "name": "Human Cognitive Neuroscience: A hands on approach",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HM5101",
+    "name": "Introduction to Psychiatry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HM5102",
+    "name": "Psychosis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HM5103",
+    "name": "Mood, Anxiety, & Grief",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HM5104",
+    "name": "Addiction/ Personality Disorders",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HM5105",
+    "name": "Child & Adolescent Mental Health including Learning Disabilities",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HM5106",
+    "name": "Psychogeriatrics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HR2002",
+    "name": "Human Capital in Organizations",
+    "creditCount": 3.0,
+    "preclusions": [
+      "HR2001",
+      "HR2101",
+      "HR3111",
+      "HR2002"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "HY1101E",
+    "name": "Asia and the Modern World",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY2206",
+    "name": "China's Imperial Past: History & Culture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY2210",
+    "name": "State & Society in Early-Modern Europe",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY2231",
+    "name": "Upheaval in Europe: 1848-1918",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EU2213"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "HY2232",
+    "name": "Modern Japan: Conflict in History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY2245",
+    "name": "Empires, Colonies and Imperialism",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EU2221"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "HY2249",
+    "name": "Art and History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY2250",
+    "name": "Introduction to Southeast Asian History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY2251",
+    "name": "From the Wheel to the Web",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY2253",
+    "name": "Christianity in World History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY2257",
+    "name": "Law, Crime, and Punishment in History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY2259",
+    "name": "The Craft of History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "HY1101E",
+      "EU1101E",
+      "HY1101E"
+    ]
+  },
+  {
+    "code": "HY2260",
+    "name": "History and Popular Culture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY3227",
+    "name": "Europe of the Dictators",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EU3212"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "HY3231",
+    "name": "History of the Malay World",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY3241",
+    "name": "Religion in the History of China & Japan",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY3242",
+    "name": "Modern Imperialism",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EU3231"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "HY3245",
+    "name": "Engendering History/Historicising Gender",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY3247",
+    "name": "From Monarchy to Military: History of Myanmar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY3256",
+    "name": "Brides of the Sea: Asia's Port Cities",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY3257",
+    "name": "The Philippines: A Social and Cultural History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY3258",
+    "name": "Cold War in the Global South",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY3260",
+    "name": "Chinese Migrations in World History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4205",
+    "name": "Early Modern Europe and its World",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EU4224"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4207",
+    "name": "Special Paper in Military History",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4212",
+    "name": "Special Paper in Modern European History",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EU4214"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4214",
+    "name": "Approaches to Chinese History",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4215",
+    "name": "The Classical Empires of Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4218",
+    "name": "Approaches to Modern Japanese History",
+    "creditCount": 5.0,
+    "preclusions": [
+      "JS4213"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4222",
+    "name": "Asian Business History: Case Studies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4225",
+    "name": "Ideological Origins of US Foreign Policy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4227",
+    "name": "Sources of Singaporean History",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4229",
+    "name": "Biography and History",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4230",
+    "name": "Historiography and Historical Method",
+    "creditCount": 5.0,
+    "preclusions": [
+      "HY4101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4231",
+    "name": "Family-State Relations in Chinese History",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4233",
+    "name": "Japanese Colonialism and Imperialism",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4234",
+    "name": "Grand Strategy in Peace and War",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4235",
+    "name": "A History of the 20th Century and Beyond",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4236",
+    "name": "Topics in Singaporean History",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "HY3250",
+      "HY3250"
+    ]
+  },
+  {
+    "code": "HY4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "HY4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "HY4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "HY4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "HY5210",
+    "name": "Approaches To Modern Se Asian History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY5305",
+    "name": "Approaches To World History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY5305R",
+    "name": "Approaches To World History",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY5402",
+    "name": "Reconsidering the Cold War",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY5660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY6101",
+    "name": "Historiography: Theory & Archive",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY6660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "HY6882",
+    "name": "Topics In Chinese History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID1105",
+    "name": "Design Fundamentals 1",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID1106",
+    "name": "Design Fundamentals 2",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID1113",
+    "name": "Modelling and Sketching for Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID1121",
+    "name": "Human-Centred Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID1223",
+    "name": "History & Theory Of Industrial Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID1322",
+    "name": "Materials and Manufacturing for Industrial Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID2041",
+    "name": "Design Internship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID2105",
+    "name": "Design for Context and Sustainability",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID2106",
+    "name": "Design Platforms 1",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID2111",
+    "name": "Computer Aided Industrial Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID2112",
+    "name": "Digital Design & Fabrication",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID2113",
+    "name": "Visual Communication Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID2114",
+    "name": "Form, Material and Making",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID2115",
+    "name": "Digital Sketching and Painting",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID2122",
+    "name": "Ecodesign And Sustainability",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID2323",
+    "name": "Technology for Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID3041",
+    "name": "Special Studies",
+    "creditCount": 14.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ID3041"
+    ]
+  },
+  {
+    "code": "ID3105",
+    "name": "Design Platforms 2",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID3106",
+    "name": "Design Platforms 3",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID3124",
+    "name": "Creative Communication & Design Argumentation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID3125",
+    "name": "Colours, Materials & Finishing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID4105",
+    "name": "Design Platforms 4",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID4106",
+    "name": "Design Thesis Project",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ID3103",
+      "ID3104",
+      "ID3105"
+    ]
+  },
+  {
+    "code": "ID4121",
+    "name": "Project Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID5021",
+    "name": "Design Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID5151",
+    "name": "Design Innovation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID5351",
+    "name": "Design Studies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID5770",
+    "name": "Graduate Seminar Module in Industrial Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID5951",
+    "name": "Topics in Industrial Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID5951A",
+    "name": "Topics in Industrial Design: Product Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID5951B",
+    "name": "Topics in Industrial Design: Interaction Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID5951C",
+    "name": "Topics in Industrial Design: Healthcare Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID5951D",
+    "name": "Topics in Industrial Design: Design Education",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID5951E",
+    "name": "Topics in Industrial Design: Sustainability",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ID6770",
+    "name": "Doctoral Seminar Module in Industrial Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE1111",
+    "name": "ISE Principles and Practice I",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE1112",
+    "name": "ISE Principles and Practice II",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IE1111"
+    ]
+  },
+  {
+    "code": "IE1113",
+    "name": "Introduction to Systems Analytics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE1111"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE1114",
+    "name": "Introduction to Systems Thinking and Dynamics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE1112",
+      "IE2101"
+    ],
+    "prerequisites": [
+      "IE1113"
+    ]
+  },
+  {
+    "code": "IE2010E",
+    "name": "Introduction to Industrial System",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3161",
+      "TIE2010"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE2100",
+    "name": "Probability Models With Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DBA3711"
+    ],
+    "prerequisites": [
+      "ST2334",
+      "EE2012",
+      "CE2407",
+      "BN2102"
+    ]
+  },
+  {
+    "code": "IE2100E",
+    "name": "Probability Models with Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC3215",
+      "TIE2100"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE2110",
+    "name": "Operations Research I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DBA3701",
+      "MA2215",
+      "MA3236"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE2110E",
+    "name": "Operations Research I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC3214",
+      "MA2215",
+      "MA3236",
+      "TIE2110"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE2120E",
+    "name": "Probability and Statistics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TIE2120",
+      "TMA2103"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE2130",
+    "name": "Quality Engineering I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2334",
+      "EE2012",
+      "CE2407",
+      "BN2102"
+    ]
+  },
+  {
+    "code": "IE2130E",
+    "name": "Quality Engineering I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM4271",
+      "TIE2130"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE2140",
+    "name": "Engineering Economy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE2140E",
+    "name": "Engineering Economy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TIE2140"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE2150",
+    "name": "Human Factors Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE2150E",
+    "name": "Human Factors Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TIE2150"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE3010E",
+    "name": "Systems Thinking and Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TIE3010"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE3100E",
+    "name": "Systems Design Project",
+    "creditCount": 8.0,
+    "preclusions": [
+      "TIE3100"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE3100M",
+    "name": "System Design Project",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IE2100",
+      "IE2110",
+      "IE1112"
+    ]
+  },
+  {
+    "code": "IE3101",
+    "name": "Statistics For Engineering Applications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2334",
+      "EE2012",
+      "CE2407",
+      "BN2102"
+    ]
+  },
+  {
+    "code": "IE3101E",
+    "name": "Statistics for Engineering Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TIE3101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE3105",
+    "name": "Fundamentals of Systems Engineering and Architecture",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE2101"
+    ],
+    "prerequisites": [
+      "IE1112"
+    ]
+  },
+  {
+    "code": "IE3110",
+    "name": "Simulation",
+    "creditCount": 5.0,
+    "preclusions": [
+      "DSC3221"
+    ],
+    "prerequisites": [
+      "IE2100",
+      "DSC3215"
+    ]
+  },
+  {
+    "code": "IE3110E",
+    "name": "Simulation",
+    "creditCount": 5.0,
+    "preclusions": [
+      "DSC3221",
+      "TIE3110"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE3120",
+    "name": "Manufacturing Logistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IE2100",
+      "DBA3711"
+    ]
+  },
+  {
+    "code": "IE4100E",
+    "name": "BTech Dissertation",
+    "creditCount": 12.0,
+    "preclusions": [
+      "IE4101E",
+      "TIE4101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE4100R",
+    "name": "B.Eng.Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [
+      "IE4102"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE4101E",
+    "name": "B.Tech. Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [
+      "TIE4101",
+      "IE4100E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE4102",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE4100R"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE4210",
+    "name": "Operations Research II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IE2110"
+    ]
+  },
+  {
+    "code": "IE4211",
+    "name": "Modelling & Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2334",
+      "EE2012",
+      "CE2407",
+      "BN2102"
+    ]
+  },
+  {
+    "code": "IE4220",
+    "name": "Supply Chain Modelling",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IE2100",
+      "IE2110"
+    ]
+  },
+  {
+    "code": "IE4220E",
+    "name": "Supply Chain Modelling",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TIE4220"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE4221",
+    "name": "Transportation Demand Modeling and Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IE2110"
+    ]
+  },
+  {
+    "code": "IE4230",
+    "name": "Quality Engineering II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IE2130",
+      "IE3101"
+    ]
+  },
+  {
+    "code": "IE4230E",
+    "name": "Quality Engineering II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TIE4230"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE4239E",
+    "name": "Selected Topics in Quality Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TIE4239"
+    ],
+    "prerequisites": [
+      "IE2100E",
+      "IE3101E"
+    ]
+  },
+  {
+    "code": "IE4240",
+    "name": "Project Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IE2140"
+    ]
+  },
+  {
+    "code": "IE4240E",
+    "name": "Project Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TIE4240"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE4242",
+    "name": "Cost Analysis And Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IE2140"
+    ]
+  },
+  {
+    "code": "IE4242E",
+    "name": "Cost Analysis And Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TIE4242"
+    ],
+    "prerequisites": [
+      "IE2140E"
+    ]
+  },
+  {
+    "code": "IE4243",
+    "name": "Decision Modeling & Risk Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IE2100"
+    ]
+  },
+  {
+    "code": "IE4249",
+    "name": "Selected Topics In Engineering Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IE2140"
+    ]
+  },
+  {
+    "code": "IE4259E",
+    "name": "Selected Topics in Systems Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TIE4259"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE4299",
+    "name": "Selected Topics In Industrial Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IE2100",
+      "IE2110"
+    ]
+  },
+  {
+    "code": "IE4299E",
+    "name": "Selected Topics in Industrial Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TIE4299"
+    ],
+    "prerequisites": [
+      "IE2010E"
+    ]
+  },
+  {
+    "code": "IE5001",
+    "name": "Operations Planning And Control I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BDC5101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5002",
+    "name": "Applied Engineering Statistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5003",
+    "name": "Cost Analysis And Engineering Economy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5004",
+    "name": "Engineering Probability And Simulation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5105",
+    "name": "Modelling for Supply Chain Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE5401",
+      "IE5405"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5107",
+    "name": "Material Flow Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5108",
+    "name": "Facility Layout And Location",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5121",
+    "name": "Quality Planning And Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5123",
+    "name": "Reliability Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5202",
+    "name": "Applied Forecasting Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5203",
+    "name": "Decision Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5205",
+    "name": "Healthcare System and Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5208",
+    "name": "Systems Approach To Project Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5211",
+    "name": "New Product Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MT5006"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5213",
+    "name": "Service Innovation And Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5301",
+    "name": "Human Factors In Engineering And Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5404",
+    "name": "Large Scale Systems Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5504",
+    "name": "Systems Modelling And Advanced Simulation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5666",
+    "name": "Industrial Attachment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5903",
+    "name": "Independent Study in PM",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5904A",
+    "name": "Research Project in Project Management I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5904B",
+    "name": "Research Project in Project Management II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IE5904A"
+    ]
+  },
+  {
+    "code": "IE5905",
+    "name": "Independent Study in Service Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5906A",
+    "name": "Research Project in Service Systems I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5906B",
+    "name": "Research Project in Service Systems II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IE5906A"
+    ]
+  },
+  {
+    "code": "IE5907",
+    "name": "Independent Study in Operations Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5908A",
+    "name": "Research Project in Operations Research I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE5908B",
+    "name": "Research Project in Operations Research II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IE5908A"
+    ]
+  },
+  {
+    "code": "IE5999",
+    "name": "Graduate Seminars",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE6002",
+    "name": "Advanced Engineering Statistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE6099",
+    "name": "Ise Research Methodology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IE6505",
+    "name": "Stochastic Processes II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BDC6306"
+    ],
+    "prerequisites": [
+      "BDC6112",
+      "IE6004"
+    ]
+  },
+  {
+    "code": "IE6509",
+    "name": "Theory and Algorithms for Dynamic Programming",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BDC6305"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE6511",
+    "name": "Surrogate and Metaheuristic Global Optimization",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE6499A"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IE6999",
+    "name": "Doctoral Seminars",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IFS4101",
+    "name": "Legal Aspects of Information Security",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2107"
+    ]
+  },
+  {
+    "code": "IFS4102",
+    "name": "Digital Forensics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3235"
+    ]
+  },
+  {
+    "code": "IFS4103",
+    "name": "Penetration Testing Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS3235"
+    ]
+  },
+  {
+    "code": "IFS4205",
+    "name": "Information Security Capstone Project.",
+    "creditCount": 8.0,
+    "preclusions": [
+      "CS3205",
+      "IFS4205"
+    ],
+    "prerequisites": [
+      "CS3235"
+    ]
+  },
+  {
+    "code": "IGL3550",
+    "name": "Extended Global Studies Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3550"
+    ],
+    "prerequisites": [
+      "GL1101E",
+      "GL2101",
+      "GL2102",
+      "GL2103"
+    ]
+  },
+  {
+    "code": "IL5101",
+    "name": "Strategic Alignment of Business and IT",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IL5102",
+    "name": "IT Innovation Leadership",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IL5104",
+    "name": "Process and Operational Excellence",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IL5105",
+    "name": "Fundamentals of IT Leadership Transformation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IL5107",
+    "name": "IT Leadership Capstone Project",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IL5105",
+      "IL5101"
+    ]
+  },
+  {
+    "code": "IL5202",
+    "name": "IT Governance and Risk Management",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IL5204",
+    "name": "Stakeholder Relationship Management in the IT Eco-System",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IPS3550",
+    "name": "Extended Political Science Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3550"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IS1103",
+    "name": "IS Innovations in Organisations and Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IS2101",
+    "name": "Business and Technical Communication",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ES2002",
+      "ES2007D",
+      "CS2101",
+      "CS2103T",
+      "ES1601"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES1102",
+      "ES1103",
+      "IS2101"
+    ]
+  },
+  {
+    "code": "IS2102",
+    "name": "Enterprise Systems Architecture and Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1020",
+      "CS2030"
+    ]
+  },
+  {
+    "code": "IS2103",
+    "name": "Enterprise Systems Server-side Design and Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1020",
+      "CS2030"
+    ]
+  },
+  {
+    "code": "IS3103",
+    "name": "Information Systems Leadership and Communication",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IS3101"
+    ],
+    "prerequisites": [
+      "IS1103",
+      "CS2101",
+      "IS2101"
+    ]
+  },
+  {
+    "code": "IS3106",
+    "name": "Enterprise Systems Interface Design and Development",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS3226"
+    ],
+    "prerequisites": [
+      "IS2103"
+    ]
+  },
+  {
+    "code": "IS3150",
+    "name": "Digital Media Marketing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS2101"
+    ]
+  },
+  {
+    "code": "IS3221",
+    "name": "Enterprise Resource Planning Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS1103",
+      "IS1103FC",
+      "IS1103X"
+    ]
+  },
+  {
+    "code": "IS3240",
+    "name": "Digital Platform Strategy and Architecture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS1103",
+      "IS2102",
+      "BT2102"
+    ]
+  },
+  {
+    "code": "IS3251",
+    "name": "Principles of Technology Entrepreneurship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS1103"
+    ]
+  },
+  {
+    "code": "IS3261",
+    "name": "Mobile Apps Development for Enterprise",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1020",
+      "CS2020",
+      "CS2030",
+      "CS2040"
+    ]
+  },
+  {
+    "code": "IS4010",
+    "name": "Industry Internship Programme",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS2101",
+      "CS2101",
+      "IS1105",
+      "IS3101",
+      "IS3103",
+      "IS2103",
+      "CS2107",
+      "BT2101",
+      "BT2102"
+    ]
+  },
+  {
+    "code": "IS4100",
+    "name": "IT Project Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IS5110",
+      "CS5212",
+      "IS5110"
+    ],
+    "prerequisites": [
+      "IS2102",
+      "IS2103",
+      "IS1103",
+      "EG2401"
+    ]
+  },
+  {
+    "code": "IS4103",
+    "name": "Information Systems Capstone Project",
+    "creditCount": 8.0,
+    "preclusions": [
+      "IS3102"
+    ],
+    "prerequisites": [
+      "IS2101",
+      "IS2102",
+      "IS2103",
+      "IS3106"
+    ]
+  },
+  {
+    "code": "IS4151",
+    "name": "Pervasive Technology Solutions and Development",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IS4150",
+      "IS5451",
+      "SMA5508",
+      "SG5233"
+    ],
+    "prerequisites": [
+      "IS2103",
+      "IS3106"
+    ]
+  },
+  {
+    "code": "IS4204",
+    "name": "IT Governance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS3101",
+      "IS3103"
+    ]
+  },
+  {
+    "code": "IS4228",
+    "name": "Information Technologies in Financial Services",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS3101",
+      "IS3103"
+    ]
+  },
+  {
+    "code": "IS4231",
+    "name": "Information Security Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS3254"
+    ],
+    "prerequisites": [
+      "CS2107"
+    ]
+  },
+  {
+    "code": "IS4233",
+    "name": "Legal Aspects of Information Technology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS4259"
+    ],
+    "prerequisites": [
+      "IS3101",
+      "IS3103"
+    ]
+  },
+  {
+    "code": "IS4234",
+    "name": "Quality Control and Audit of IS",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS4252"
+    ],
+    "prerequisites": [
+      "IS2102",
+      "IS2103",
+      "CS2103",
+      "CS2113"
+    ]
+  },
+  {
+    "code": "IS4241",
+    "name": "Social Media Network Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS1020",
+      "CS2030",
+      "CS2103",
+      "CS2113"
+    ]
+  },
+  {
+    "code": "IS4242",
+    "name": "Intelligent Systems and Techniques",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1312",
+      "MA1521",
+      "MA1505",
+      "MA1511",
+      "MA1512",
+      "ST2334",
+      "ST2131",
+      "ST2132",
+      "IS3106",
+      "BT3103"
+    ]
+  },
+  {
+    "code": "IS4243",
+    "name": "Information Systems Consulting",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS3101",
+      "IS3103"
+    ]
+  },
+  {
+    "code": "IS4250",
+    "name": "Healthcare IT and Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS1103",
+      "ST2131",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "IS4261",
+    "name": "Designing IT-enabled Business Innovations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS3103",
+      "IS3101"
+    ]
+  },
+  {
+    "code": "IS4301",
+    "name": "Agile IT with DevOps",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS4100"
+    ]
+  },
+  {
+    "code": "IS4302",
+    "name": "Blockchain and Distributed Ledger Technologies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CS2102",
+      "BT2102",
+      "CS1020",
+      "CS2030",
+      "CS2103",
+      "CS2113"
+    ]
+  },
+  {
+    "code": "IS4303",
+    "name": "IT-mediated financial solutions and platforms",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS2102"
+    ]
+  },
+  {
+    "code": "IS5002",
+    "name": "Digital Transformation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS2102"
+    ]
+  },
+  {
+    "code": "IS5003",
+    "name": "Platform Design and Economy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IS3240"
+    ],
+    "prerequisites": [
+      "IS2102"
+    ]
+  },
+  {
+    "code": "IS5004",
+    "name": "Enterprise Architecture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS2102"
+    ]
+  },
+  {
+    "code": "IS5005",
+    "name": "Digital Engagement",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS3150"
+    ]
+  },
+  {
+    "code": "IS5006",
+    "name": "Intelligent System Deployment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS4242",
+      "BT4014"
+    ]
+  },
+  {
+    "code": "IS5007",
+    "name": "Strategising for Global IT-enabled Business Success",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS4204"
+    ]
+  },
+  {
+    "code": "IS5110",
+    "name": "Software Project Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IS4100"
+    ],
+    "prerequisites": [
+      "IS3103"
+    ]
+  },
+  {
+    "code": "IS5111",
+    "name": "IT Strategy and Governance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IS4204"
+    ],
+    "prerequisites": [
+      "IS3103"
+    ]
+  },
+  {
+    "code": "IS5114",
+    "name": "Global IT Project and Vendor Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS3103"
+    ]
+  },
+  {
+    "code": "IS5116",
+    "name": "Digital Entrepreneurship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IS3251"
+    ],
+    "prerequisites": [
+      "IS3103"
+    ]
+  },
+  {
+    "code": "IS5117",
+    "name": "Digital Government",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS3103"
+    ]
+  },
+  {
+    "code": "IS5126",
+    "name": "Hands-on with Applied Analytics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BT5126"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IS5128",
+    "name": "Digital Innovation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "IS2102",
+      "IS3103"
+    ]
+  },
+  {
+    "code": "IS5151",
+    "name": "Information Security Policy and Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IS4231"
+    ],
+    "prerequisites": [
+      "CS2107"
+    ]
+  },
+  {
+    "code": "IS5152",
+    "name": "Data-Driven Decision Making",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2334",
+      "ST1131"
+    ]
+  },
+  {
+    "code": "IS5451",
+    "name": "Pervasive Technology Solutions and Development",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IS4151",
+      "IS4150",
+      "SMA5508",
+      "SG5233"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IS6000",
+    "name": "Qualifying Examination in IS",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IS6001",
+    "name": "Qualitative Methods for IS Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IS6002",
+    "name": "Quantitative Methods for IS Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IS6003",
+    "name": "Contemporary Theories for IS Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IS6004",
+    "name": "Econometrics for IS Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IS6005",
+    "name": "Seminars in Information Systems I",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "IS6103",
+    "name": "Design Science Research in Information Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ISD5101",
+    "name": "Integrated Studio Project 1",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ISD5102",
+    "name": "Integrated Studio Project 2",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ISD5103",
+    "name": "Green Buildings in the Tropics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ISD5104",
+    "name": "Energy and Ecology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ISD5105",
+    "name": "Principles of Sustainable Urbanism",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ISD5106",
+    "name": "Sustainability Models and Blueprints",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ISE3550",
+    "name": "Extended Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3550"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IT1001",
+    "name": "Introduction to Computing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS1010",
+      "CS1010E",
+      "CS1010FC",
+      "CS1010S",
+      "CS1101",
+      "CS1101C",
+      "CS1101S",
+      "GEK1511",
+      "AY2001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IT1007",
+    "name": "Introduction to Programming with Python and C",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS1010",
+      "IT1005"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "IT3010",
+    "name": "Data Management for Business Analytics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BT2102",
+      "CS2102"
+    ],
+    "prerequisites": [
+      "DAO2702",
+      "CS1010S"
+    ]
+  },
+  {
+    "code": "JS1101E",
+    "name": "Introduction to Japanese Studies",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1002"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "JS2101",
+    "name": "Approaches to Japanese Studies I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "JS1101E"
+    ]
+  },
+  {
+    "code": "JS2212",
+    "name": "Introduction to Japanese Literature",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS2213",
+    "name": "Popular Culture in Contemporary Japan",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS2225",
+    "name": "Marketing and Consumer Culture in Japan",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS2228",
+    "name": "Gender and Sexuality in Japan",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS2230",
+    "name": "Itadakimasu - Food In Japan",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS2880A",
+    "name": "Field Exposure Japan: Fashion Business",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS3101",
+    "name": "Approaches to Japanese Studies II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "JS2101",
+      "LAJ2202"
+    ]
+  },
+  {
+    "code": "JS3208",
+    "name": "Approaches to Japanese Linguistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAJ2202"
+    ]
+  },
+  {
+    "code": "JS3217",
+    "name": "Japanese Art and Aesthetics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS3222",
+    "name": "Japanese Business Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS3223",
+    "name": "Japan and the Asia-Pacific Region",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS3226",
+    "name": "Japan: The Green Nation?",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS4101",
+    "name": "Research and Writing in Japanese Studies",
+    "creditCount": 5.0,
+    "preclusions": [
+      "JS4221"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "JS4207",
+    "name": "Readings in Modern Japanese",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAJ3201",
+      "LAJ3203",
+      "LAJ3201",
+      "LAJ3203"
+    ]
+  },
+  {
+    "code": "JS4213",
+    "name": "Approaches to Modern Japanese History",
+    "creditCount": 5.0,
+    "preclusions": [
+      "HY4218"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "JS4214",
+    "name": "Ideas, Values and Identity in Japan",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS4216",
+    "name": "Tales and Performance in Premodern Japan",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS4217",
+    "name": "Selected Topics in Japanese Studies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS4225",
+    "name": "Social Dynamics in Modern Japan",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS4230",
+    "name": "Advanced Readings in Popular Culture",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "JS4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "JS4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "JS4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "JS5201",
+    "name": "Readings In Japanese Studies I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS5201R",
+    "name": "Readings In Japanese Studies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS5203",
+    "name": "Japanese Literary & Performance Studies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS5203R",
+    "name": "Japanese Literary & Performance Studies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS5204",
+    "name": "Contemporary Japanese Social Issues",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS5204R",
+    "name": "Contemporary Japanese Social Issues",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS5660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS5660R",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS6660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "JS6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "KE5105",
+    "name": "Knowledge Engineering Project",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "KE5106",
+    "name": "Data Warehousing for Business Analytics",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "KE5108",
+    "name": "Developing Intelligent Systems for Performing Business Analytics",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "KE4102",
+      "KE5107"
+    ]
+  },
+  {
+    "code": "KE5205",
+    "name": "Text Mining",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "KE5207",
+    "name": "Computational Intelligence II",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "KE5208",
+    "name": "Sense Making and Insight Discovery",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LA4202",
+    "name": "Planting Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LA4203",
+    "name": "History and Theory of Landscape Architecture",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LA3201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LA4212",
+    "name": "Topics in Tropical Forest Ecology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LA4301",
+    "name": "Material and Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LA4701",
+    "name": "MLA Studio: Quarter",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR3101",
+      "AR3102"
+    ]
+  },
+  {
+    "code": "LA4702",
+    "name": "MLA Studio: City",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AR3101",
+      "AR3102"
+    ]
+  },
+  {
+    "code": "LA5201",
+    "name": "Policy of Landscape",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LA5222",
+    "name": "Urban Ecology and Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LA5301",
+    "name": "Geo Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LA5302",
+    "name": "Detail Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LA5303",
+    "name": "Urban Greening: Technologies and Techniques",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LA5701",
+    "name": "MLA Studio: Country",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LA5702",
+    "name": "MLA Studio: Region",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LA5742",
+    "name": "Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LAB1201",
+    "name": "Bahasa Indonesia 1",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LAM1201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LAB2201",
+    "name": "Bahasa Indonesia 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAB1201"
+    ]
+  },
+  {
+    "code": "LAB3201",
+    "name": "Bahasa Indonesia 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAB2201"
+    ]
+  },
+  {
+    "code": "LAB3202",
+    "name": "Bahasa Indonesia 4",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAB3201"
+    ]
+  },
+  {
+    "code": "LAB4201",
+    "name": "Bahasa Indonesia 5",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAB3202"
+    ]
+  },
+  {
+    "code": "LAB4202",
+    "name": "Bahasa Indonesia 6",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAB4201"
+    ]
+  },
+  {
+    "code": "LAC1201",
+    "name": "Chinese 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LAC2201",
+    "name": "Chinese 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAC1201"
+    ]
+  },
+  {
+    "code": "LAC2202",
+    "name": "Chinese Characters Writing & Composition",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LAC3201",
+    "name": "Chinese 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAC2201"
+    ]
+  },
+  {
+    "code": "LAC3202",
+    "name": "Chinese 4",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAC3201"
+    ]
+  },
+  {
+    "code": "LAC3203",
+    "name": "Chinese for Science and Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LAC3204",
+    "name": "Chinese for Business & Social Sciences",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LAC4201",
+    "name": "Chinese 5",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAC3202"
+    ]
+  },
+  {
+    "code": "LAC4202",
+    "name": "Chinese 6",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAC4201"
+    ]
+  },
+  {
+    "code": "LAF1201",
+    "name": "French 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LAF2201",
+    "name": "French 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAF1201"
+    ]
+  },
+  {
+    "code": "LAF3201",
+    "name": "French 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAF2201"
+    ]
+  },
+  {
+    "code": "LAF3202",
+    "name": "French 4",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LAF3203"
+    ],
+    "prerequisites": [
+      "LAF3201"
+    ]
+  },
+  {
+    "code": "LAF4201",
+    "name": "French 5",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAF3202",
+      "LAF3203"
+    ]
+  },
+  {
+    "code": "LAF4202",
+    "name": "French 6",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAF4201"
+    ]
+  },
+  {
+    "code": "LAG1201",
+    "name": "German 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LAG2201",
+    "name": "German 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAG1201"
+    ]
+  },
+  {
+    "code": "LAG3201",
+    "name": "German 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAG2201"
+    ]
+  },
+  {
+    "code": "LAG3202",
+    "name": "German 4",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LAG3203"
+    ],
+    "prerequisites": [
+      "LAG3201"
+    ]
+  },
+  {
+    "code": "LAG4201",
+    "name": "German 5",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAG3202",
+      "LAG3203"
+    ]
+  },
+  {
+    "code": "LAG4202",
+    "name": "German 6",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAG4201"
+    ]
+  },
+  {
+    "code": "LAH1201",
+    "name": "Hindi 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LAH2201",
+    "name": "Hindi 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAH1201"
+    ]
+  },
+  {
+    "code": "LAH3201",
+    "name": "Hindi 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAH2201"
+    ]
+  },
+  {
+    "code": "LAH3202",
+    "name": "Hindi 4",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAH3201"
+    ]
+  },
+  {
+    "code": "LAH4201",
+    "name": "Hindi 5",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAH3202"
+    ]
+  },
+  {
+    "code": "LAH4202",
+    "name": "Hindi 6",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAH4201"
+    ]
+  },
+  {
+    "code": "LAJ1201",
+    "name": "Japanese 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LAJ2201",
+    "name": "Japanese 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAJ1201"
+    ]
+  },
+  {
+    "code": "LAJ2202",
+    "name": "Japanese 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAJ2201"
+    ]
+  },
+  {
+    "code": "LAJ2203",
+    "name": "Japanese 4",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAJ2202"
+    ]
+  },
+  {
+    "code": "LAJ3201",
+    "name": "Japanese 5",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LAJ3203"
+    ],
+    "prerequisites": [
+      "LAJ2203"
+    ]
+  },
+  {
+    "code": "LAJ3202",
+    "name": "Japanese 6",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAJ3201",
+      "LAJ3203"
+    ]
+  },
+  {
+    "code": "LAJ3204",
+    "name": "Business Japanese 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAJ3203",
+      "LAJ3201"
+    ]
+  },
+  {
+    "code": "LAJ4203",
+    "name": "Newspaper Reading",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAJ3201",
+      "LAJ3203"
+    ]
+  },
+  {
+    "code": "LAJ4205",
+    "name": "Expository Writing & Public Speaking",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAJ3202",
+      "LAJ3204"
+    ]
+  },
+  {
+    "code": "LAK1201",
+    "name": "Korean 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LAK2201",
+    "name": "Korean 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAK1201"
+    ]
+  },
+  {
+    "code": "LAK3201",
+    "name": "Korean 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAK2201"
+    ]
+  },
+  {
+    "code": "LAK3202",
+    "name": "Korean 4",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LAK3203"
+    ],
+    "prerequisites": [
+      "LAK3201"
+    ]
+  },
+  {
+    "code": "LAK4201",
+    "name": "Korean 5",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAK3202",
+      "LAK3203"
+    ]
+  },
+  {
+    "code": "LAK4202",
+    "name": "Korean 6",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAK4201"
+    ]
+  },
+  {
+    "code": "LAL1201",
+    "name": "Tamil 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LAL2201",
+    "name": "Tamil 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAL1201"
+    ]
+  },
+  {
+    "code": "LAM1201",
+    "name": "Malay 1",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LAB1201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LAM2201",
+    "name": "Malay 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAM1201"
+    ]
+  },
+  {
+    "code": "LAM3201",
+    "name": "Malay 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAM2201"
+    ]
+  },
+  {
+    "code": "LAM3202",
+    "name": "Malay 4",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAM3201"
+    ]
+  },
+  {
+    "code": "LAM4201",
+    "name": "Malay 5",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAM3202"
+    ]
+  },
+  {
+    "code": "LAM4202",
+    "name": "Malay 6",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAM4201"
+    ]
+  },
+  {
+    "code": "LAR1201",
+    "name": "Arabic 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LAR2201",
+    "name": "Arabic 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAR1201"
+    ]
+  },
+  {
+    "code": "LAR3201",
+    "name": "Arabic 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAR2201"
+    ]
+  },
+  {
+    "code": "LAR3202",
+    "name": "Arabic 4",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAR3201"
+    ]
+  },
+  {
+    "code": "LAR4201",
+    "name": "Arabic 5",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAR3202"
+    ]
+  },
+  {
+    "code": "LAR4202",
+    "name": "Arabic 6",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAR4201"
+    ]
+  },
+  {
+    "code": "LAS1201",
+    "name": "Spanish 1",
+    "creditCount": 4.0,
+    "preclusions": [
+      "YLS1201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LAS2201",
+    "name": "Spanish 2",
+    "creditCount": 4.0,
+    "preclusions": [
+      "YLS1202"
+    ],
+    "prerequisites": [
+      "LAS1201",
+      "YLS1201"
+    ]
+  },
+  {
+    "code": "LAS3201",
+    "name": "Spanish 3",
+    "creditCount": 4.0,
+    "preclusions": [
+      "YLS2201"
+    ],
+    "prerequisites": [
+      "LAS2201",
+      "YLS1202"
+    ]
+  },
+  {
+    "code": "LAS3202",
+    "name": "Spanish 4",
+    "creditCount": 4.0,
+    "preclusions": [
+      "YS2202"
+    ],
+    "prerequisites": [
+      "LAS3201",
+      "YLS2201"
+    ]
+  },
+  {
+    "code": "LAS4201",
+    "name": "Spanish 5",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YLS3201"
+    ],
+    "prerequisites": [
+      "LAS3202",
+      "YLS2202"
+    ]
+  },
+  {
+    "code": "LAS4202",
+    "name": "Spanish 6",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YLS3202"
+    ],
+    "prerequisites": [
+      "LAS4201",
+      "YLS3201"
+    ]
+  },
+  {
+    "code": "LAT1201",
+    "name": "Thai 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LAT2201",
+    "name": "Thai 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAT1201"
+    ]
+  },
+  {
+    "code": "LAT3201",
+    "name": "Thai 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAT2201"
+    ]
+  },
+  {
+    "code": "LAT3202",
+    "name": "Thai 4",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAT3201"
+    ]
+  },
+  {
+    "code": "LAT4201",
+    "name": "Thai 5",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAT3202"
+    ]
+  },
+  {
+    "code": "LAT4202",
+    "name": "Thai 6",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAT4201"
+    ]
+  },
+  {
+    "code": "LAV1201",
+    "name": "Vietnamese 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LAV2201",
+    "name": "Vietnamese 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAV1201"
+    ]
+  },
+  {
+    "code": "LAV3201",
+    "name": "Vietnamese 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAV2201"
+    ]
+  },
+  {
+    "code": "LAV3202",
+    "name": "Vietnamese 4",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAV3201"
+    ]
+  },
+  {
+    "code": "LAV4201",
+    "name": "Vietnamese 5",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAV3202"
+    ]
+  },
+  {
+    "code": "LAV4202",
+    "name": "Vietnamese 6",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAV4201"
+    ]
+  },
+  {
+    "code": "LC1001A",
+    "name": "Criminal Law (A)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1001B",
+    "name": "Criminal Law (B)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1001C",
+    "name": "Criminal Law (C)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1001D",
+    "name": "Criminal Law (D)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1001E",
+    "name": "Criminal Law (E)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1001F",
+    "name": "Criminal Law (F)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1002A",
+    "name": "Introduction To Legal Theory (A)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1002B",
+    "name": "Introduction To Legal Theory (B)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1002C",
+    "name": "Introduction to Legal Theory (C)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1002D",
+    "name": "Introduction to Legal Theory (D)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1002E",
+    "name": "Introduction to Legal Theory (E)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1002F",
+    "name": "Introduction to Legal Theory (F)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1002G",
+    "name": "Introduction to Legal Theory (G)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1003",
+    "name": "Law Of Contract",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1004",
+    "name": "Law Of Torts",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1015",
+    "name": "Singapore Law in Context",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1016",
+    "name": "Legal Analysis, Research & Communication",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC1025",
+    "name": "Singapore Law in Context",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2004",
+    "name": "Principles Of Property Law",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2006B",
+    "name": "Equity & Trusts (B)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2006C",
+    "name": "Equity & Trusts (C)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2006D",
+    "name": "Equity & Trusts (D)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2007",
+    "name": "Constitutional & Administrative Law",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2008A",
+    "name": "Company Law (A)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2008B",
+    "name": "Company Law (B)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2008C",
+    "name": "Company Law (C)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2008E",
+    "name": "Company Law (E)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2008F",
+    "name": "Company Law (F)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2008G",
+    "name": "Company Law (G)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2009",
+    "name": "Pro Bono Service",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2010A",
+    "name": "Legal Systems of Asia (A)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2010B",
+    "name": "Legal Systems of Asia (B)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2010C",
+    "name": "Legal Systems of Asia (C)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2010D",
+    "name": "Legal Systems of Asia (D)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2010E",
+    "name": "Legal Systems of Asia (E)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2010F",
+    "name": "Legal Systems of Asia (F)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2012",
+    "name": "Trial Advocacy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LC2002",
+      "LC2013",
+      "LC2003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LC2013",
+    "name": "Corporate Deals",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LC2002",
+      "LC2012",
+      "LC2003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LC3001A",
+    "name": "Evidence (A)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5009",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5010A",
+    "name": "Legal Systems of Asia (A)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5029",
+    "name": "International Commercial Arbitration",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5035",
+    "name": "Taxation Issues in Cross-Border Transactions",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4035",
+      "LL5035",
+      "LL6035",
+      "LL4035V",
+      "LL5035V",
+      "LL6035V",
+      "LL4342",
+      "LL5342",
+      "LL6342",
+      "LL4342V",
+      "LL5342V",
+      "LL6342V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5050V",
+    "name": "Public International Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LC5050"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5074",
+    "name": "Mergers & Acquisitions",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5089",
+    "name": "Chinese Corporate & Securities Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5093",
+    "name": "Chinese Intellectual Property Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5115",
+    "name": "International Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5118",
+    "name": "Foreign Direct Investment Law in Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5186",
+    "name": "International & Commercial Trusts Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5204AV",
+    "name": "Carriage of Goods By Sea",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5204BV",
+    "name": "Charterparties",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LC5204B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5225",
+    "name": "Carriage of Goods by Sea",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5230",
+    "name": "Elements of Company Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5262V",
+    "name": "International Commercial Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4029"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5264",
+    "name": "WTO and Regional Integration",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4060B",
+      "LL5060B",
+      "LL6060B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5265",
+    "name": "Chinese Business Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4089",
+      "LL5089",
+      "LL6089",
+      "LL4089V",
+      "LL5089V",
+      "LL6089V",
+      "LC5089"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5285V",
+    "name": "International Dispute Settlement",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4285",
+      "LL5285",
+      "LL6285",
+      "LC5285"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5336",
+    "name": "Topics in Int'l Arbitration & Dispute Resolution",
+    "creditCount": 1.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5337",
+    "name": "Singapore Common Law of Contract",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LC5337S"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LC5337S",
+    "name": "Singapore Common Law of Contract",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LC5337"
+    ],
+    "prerequisites": [
+      "LC5337"
+    ]
+  },
+  {
+    "code": "LC5405A",
+    "name": "Law Of Intellectual Property (A)",
+    "creditCount": 8.0,
+    "preclusions": [
+      "LL4405B",
+      "LL5405B",
+      "LL6405B",
+      "LL4070",
+      "LL5070",
+      "LC5070",
+      "LL6070"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LC6009",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LCD5204AV",
+    "name": "Carriage of Goods By Sea",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LCD5204BV",
+    "name": "Charterparties",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LCD5204B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LI5001",
+    "name": "Research Project",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LI5101",
+    "name": "Supply Chain Mgt Thinking & Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LI5201",
+    "name": "Special Topics in Logistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LI5202",
+    "name": "Supply Chain Management Strategies and Case Studies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LI5204",
+    "name": "Supply Chain Simulation and Optimization",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LI5101"
+    ]
+  },
+  {
+    "code": "LL4002V",
+    "name": "Admiralty Law & Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4002"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4003V",
+    "name": "China, India and International Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4004V",
+    "name": "Aviation Law & Policy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4004"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4006V",
+    "name": "Banking Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4006"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4008AV",
+    "name": "Carriage of Goods By Sea",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4008BV",
+    "name": "Charterparties",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4008B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4009V",
+    "name": "Chinese Legal Tradition And Legal Chinese",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4013V",
+    "name": "Comparative Environmental Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4013"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4014V",
+    "name": "Construction Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4014"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4019V",
+    "name": "Credit & Security",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4019"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4021V",
+    "name": "Environmental Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4022V",
+    "name": "Globalization And International Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4022"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4029V",
+    "name": "International Commercial Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4029"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4030V",
+    "name": "International Commercial Litigation",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4030"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4031V",
+    "name": "International Environmental Law & Policy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4031"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4032V",
+    "name": "International Investment Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4032"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4033V",
+    "name": "International Legal Process",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4033"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4034V",
+    "name": "International Regulation of Shipping",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4034"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4043",
+    "name": "Law Of Marine Insurance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4044V",
+    "name": "Mediation",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4045V",
+    "name": "Negotiation",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4049V",
+    "name": "Principles Of Conflict Of Laws",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4049"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4050V",
+    "name": "Public International Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4050"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4054V",
+    "name": "Domestic and International Sale of Goods",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4056BV",
+    "name": "Tax Planning And Policy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4056B"
+    ],
+    "prerequisites": [
+      "LC2008"
+    ]
+  },
+  {
+    "code": "LL4057V",
+    "name": "Theoretical Foundations Of Criminal Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4057"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4059V",
+    "name": "United Nations Law & Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4059"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4060B",
+    "name": "World Trade Law",
+    "creditCount": 8.0,
+    "preclusions": [
+      "LL4199A",
+      "LL4199B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4063V",
+    "name": "Business & Finance For Lawyers",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4063"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4067",
+    "name": "Comparative Criminal Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4069V",
+    "name": "European Union Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4070V",
+    "name": "Foundations Of Intellectual Property Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4070"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4076V",
+    "name": "IT Law I",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4076"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4077V",
+    "name": "IT Law II",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4077"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4089V",
+    "name": "Chinese Corporate & Securities Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4089"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4094AV",
+    "name": "Law & Practice - The Law Clinic",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4094BV",
+    "name": "Law & Practice - The Law Clinic",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4094CV",
+    "name": "Law & Practice - The Law Clinic",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4094V",
+    "name": "Law & Practice - The Law Clinic",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4099V",
+    "name": "Maritime Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4099"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4100",
+    "name": "Arbitration and Dispute Resolution in China",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4100V",
+      "LL5100V",
+      "LL6100V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4102",
+    "name": "Advanced Torts",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4104V",
+    "name": "Jurisprudence",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4104"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4109V",
+    "name": "International Law & Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4109"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4133V",
+    "name": "Human Rights in Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4133"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4134V",
+    "name": "Crossing Borders: Law, Migration & Citizenship",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4134"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4140V",
+    "name": "Ocean Law & Policy in Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4140"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4146V",
+    "name": "Law & Society",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4146"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4148",
+    "name": "Secured Transactions Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4019",
+      "LL5019",
+      "LL6019",
+      "LL4019V",
+      "LL5019V",
+      "LL6019V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4150V",
+    "name": "International Investment Law and Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4150",
+      "LL5150",
+      "LL6150"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4155",
+    "name": "Topics in Law and Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4158V",
+    "name": "Climate Change Law and Policy in Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4158",
+      "LL5158",
+      "LL6158",
+      "LL4221",
+      "LL5221",
+      "LL6221",
+      "LL4221V",
+      "LL5221V",
+      "LL6221V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4164V",
+    "name": "International Projects Law & Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4164"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4173V",
+    "name": "Comparative Corporate Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4173"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4178V",
+    "name": "International Legal Protection of Investment Flows",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4185V",
+    "name": "Government Regulations: Law, Policy & Practice",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4190",
+    "name": "Freedom of Speech: Critical & Comparative Perspectives",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4195V",
+    "name": "International Economic Law & Relations",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4195"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4197V",
+    "name": "Comparative State and Religion in Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4197"
+    ],
+    "prerequisites": [
+      "PS1101E"
+    ]
+  },
+  {
+    "code": "LL4202V",
+    "name": "ASEAN Economic Community Law and Policy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4202"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4203",
+    "name": "International Moots and Other Competitions",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4203A",
+    "name": "International Moots and Other Competitions",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4203B",
+    "name": "International Moots and Other Competitions",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4203C",
+    "name": "International Moots and Other Competitions",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4205V",
+    "name": "Maritime Conflict of Laws",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4205"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4208V",
+    "name": "Advanced Criminal Legal Process",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4208"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4209V",
+    "name": "Legal Argument & Narrative",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4209"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4214",
+    "name": "International and Comparative Oil and Gas Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4219",
+    "name": "The Trial of Jesus in Western Legal Thought",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4226",
+    "name": "Multimodal Transport Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4233V",
+    "name": "European Company Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4233"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4235V",
+    "name": "International Contract Law: Principles and Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4235",
+      "LL5235",
+      "LL6235"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4237V",
+    "name": "Law, Institutions, and Business in Greater China",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4242V",
+    "name": "Financial Regulation and Central Banking",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4241",
+      "LL5241",
+      "LL6241",
+      "LL4241V",
+      "LL5241V",
+      "LL6241V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4243V",
+    "name": "Regulation and Geography",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4243",
+      "LL5243",
+      "LL6243"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4244V",
+    "name": "Criminal Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4208",
+      "LL5208",
+      "LL6208",
+      "LL4208V",
+      "LL5208V",
+      "LL6208V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4251V",
+    "name": "International Humanitarian Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4258V",
+    "name": "Personal Property Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4047",
+      "LL5047",
+      "LL6047",
+      "LL4047V",
+      "LL5047V",
+      "LL6047V",
+      "LL4168",
+      "LL5168",
+      "LL6168",
+      "LL4168V",
+      "LL5168V",
+      "LL6168V",
+      "LL4411",
+      "LL5411",
+      "LL6411"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4259AV",
+    "name": "Alternative Investments",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4314",
+      "LL5314",
+      "LL6314",
+      "LL4314V",
+      "LL5314V",
+      "LL6314"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4259V",
+    "name": "Alternative Investments",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4314",
+      "LL5314",
+      "LL6314",
+      "LL4314V",
+      "LL5314V",
+      "LL6314"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4263V",
+    "name": "Intellectual Property Rights and Competition Policy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4075V",
+      "LL5075V",
+      "LL6075V",
+      "LL4075",
+      "LL5075",
+      "LL6075"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4276",
+    "name": "Advanced Contract Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4187",
+      "LL5187",
+      "LL6187",
+      "LL4187V",
+      "LL5187V",
+      "LL6187V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4277V",
+    "name": "Medical Law and Ethics",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4400",
+      "LL5400",
+      "LL6400"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4283V",
+    "name": "Artificial Intelligence, Information Science & Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LL4076",
+      "LL5076",
+      "LL6076",
+      "LL4076V",
+      "LL5076V",
+      "LL6076V",
+      "LL4077",
+      "LL5077",
+      "LL6077",
+      "LL4077V",
+      "LL5077V",
+      "LL6077V"
+    ]
+  },
+  {
+    "code": "LL4285V",
+    "name": "International Dispute Settlement",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4285",
+      "LL5285",
+      "LL6285",
+      "LC5285"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4286V",
+    "name": "Transnational Terrorism and International Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4287V",
+    "name": "ASEAN Law and Policy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4289V",
+    "name": "The Evolution of International Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4289",
+      "LL5289",
+      "LL6289"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4290V",
+    "name": "Legal Research: Method & Design",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4290",
+      "LL5290",
+      "LL6290"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4292V",
+    "name": "State Responsibility: Theory and Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4292",
+      "LL5292",
+      "LL6292"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4295",
+    "name": "Conflict of Laws in Int\u2019l Commercial Arbitration",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4295V",
+      "LL5295V",
+      "LL6295V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4299",
+    "name": "Advanced Issues in the Law & Practice of Int\u2019l Arbitration",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4299V",
+      "LL5299V",
+      "LL6299V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4308V",
+    "name": "Behavioural Economics, Law & Regulation",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4308",
+      "LL5308",
+      "LL6308"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4309",
+    "name": "Strategies for Asian Disputes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4309",
+      "LL5309",
+      "LL6309",
+      "LL4309V",
+      "LL5309V",
+      "LL6309V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4313V",
+    "name": "Mediation/Conciliation of Inter- & Investor-State Disputes",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4313",
+      "LL5313",
+      "LL6313"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4316V",
+    "name": "Restitution of Unjust Enrichment",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4316",
+      "LL5316",
+      "LL6316",
+      "LL4051",
+      "LL5051",
+      "LL6051",
+      "LL4051V",
+      "LL5051V",
+      "LL6051V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4317V",
+    "name": "International Arbitration in Asian Centres",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4317",
+      "LL5317",
+      "LL6317"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4318V",
+    "name": "Public Health Law and Regulation",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4318",
+      "LL5318",
+      "LL6318"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4319V",
+    "name": "Current Problems in International Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4319",
+      "LL5319",
+      "LL6319"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4320",
+    "name": "International Space Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4320V",
+      "LL5320V",
+      "LL6320V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4322",
+    "name": "Trade Finance Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4322V",
+      "LL5322V",
+      "LL6322V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4323V",
+    "name": "Law of Agency",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4323",
+      "LL5323",
+      "LL6323"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4325",
+    "name": "The Int'l Litigation & Procedure of State Disputes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4325V",
+      "LL5325V",
+      "LL6325V",
+      "LL4285V",
+      "LL5285V",
+      "LC5285V",
+      "LL6285V",
+      "LL4285",
+      "LL5285",
+      "LC5285",
+      "LL6285"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4327V",
+    "name": "Mergers and Acquisitions: A Practitioner\u2019s Perspective",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4327",
+      "LL5327",
+      "LL6327",
+      "LL4074",
+      "LL5074",
+      "LL6074",
+      "LL4074V",
+      "LL5074V",
+      "LL6074V",
+      "LL4223",
+      "LL5223",
+      "LL6223",
+      "LL4233V",
+      "LL5223V",
+      "LL6223V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4338V",
+    "name": "Advanced Practicum in International Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4338",
+      "LL5338",
+      "LL6338"
+    ],
+    "prerequisites": [
+      "LL4029",
+      "LL5029",
+      "LC5262",
+      "LL6029",
+      "LL4029V",
+      "LL5029V",
+      "LC5262V",
+      "LL6029V",
+      "LL4285",
+      "LL5285",
+      "LC5285",
+      "LL6285",
+      "LL4285V",
+      "LL5285V",
+      "LC5285V",
+      "LL6285V"
+    ]
+  },
+  {
+    "code": "LL4339",
+    "name": "Comparative Evidence in International Arbitration",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4339V",
+      "LL5339V",
+      "LL6339V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4340V",
+    "name": "International Refugee Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4340",
+      "LL5340",
+      "LL6340"
+    ],
+    "prerequisites": [
+      "LL4050",
+      "LL5050",
+      "LL6050",
+      "LC5050",
+      "LL5050V",
+      "LL6050V",
+      "LC5050V"
+    ]
+  },
+  {
+    "code": "LL4341V",
+    "name": "The Law and Politics of Forced Migration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4341",
+      "LL5341",
+      "LL6341"
+    ],
+    "prerequisites": [
+      "LL4050",
+      "LL5050",
+      "LL6050",
+      "LC5050",
+      "LL5050V",
+      "LL6050V",
+      "LC5050V"
+    ]
+  },
+  {
+    "code": "LL4342V",
+    "name": "Taxation of Cross-Border Commercial Transactions",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4035",
+      "LL5035",
+      "LL6035",
+      "LC5035",
+      "LC5035A",
+      "LC5035B",
+      "LL4035V",
+      "LL5035V",
+      "LL6035V",
+      "LL4342",
+      "LL5342",
+      "LL6342"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4343V",
+    "name": "International Regulation of the Global Commons",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4343",
+      "LL5343",
+      "LL6343"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4344",
+    "name": "Public and Private International Copyright Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4344V",
+      "LL5344V",
+      "LL6344V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4345",
+    "name": "The Fulfilled Life and the Life of the Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4345V",
+      "LL5345V",
+      "LL6345V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4346V",
+    "name": "Interim Measures in International Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4347",
+    "name": "Art & Cultural Heritage Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4347V",
+      "LL5347V",
+      "LL6347V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4348",
+    "name": "Monetary Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4348V",
+      "LL5348V",
+      "LL6348V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4349V",
+    "name": "Energy Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4349",
+      "LL5349",
+      "LL6349"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4350V",
+    "name": "Privacy & Data Protection Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4350",
+      "LL5350",
+      "LL6350"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4351",
+    "name": "Comparative Corporate Law in East Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4351V",
+      "LL5351V",
+      "LL6351V"
+    ],
+    "prerequisites": [
+      "LC2008"
+    ]
+  },
+  {
+    "code": "LL4352",
+    "name": "China and International Economic Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4352V",
+      "LL5352V",
+      "LL6352V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4353",
+    "name": "Character Evidence in the Common Law World",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4353V",
+      "LL5353V",
+      "LL6353V"
+    ],
+    "prerequisites": [
+      "LC3001A",
+      "LC3001B"
+    ]
+  },
+  {
+    "code": "LL4354",
+    "name": "Comparative Human Rights Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4354V",
+      "LL5354V",
+      "LL6353V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4355",
+    "name": "International Law and Development",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4355V",
+      "LL5355V",
+      "LL6355V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4356V",
+    "name": "International Investment Law Clinic",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4356",
+      "LL5356",
+      "LL6356"
+    ],
+    "prerequisites": [
+      "LL4032V",
+      "LL5032V",
+      "LL6032V",
+      "LL4032",
+      "LL5032",
+      "LL6032"
+    ]
+  },
+  {
+    "code": "LL4357V",
+    "name": "Regulation & Political Economy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4357",
+      "LL5357",
+      "LL6357"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4358Z",
+    "name": "ICC Arbitration",
+    "creditCount": 2.5,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4359Z",
+    "name": "SIAC and Institutional Arbitration",
+    "creditCount": 2.5,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4360Z",
+    "name": "Current Challenges to Investment Arbitration",
+    "creditCount": 2.5,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4361Z",
+    "name": "Complex Arbitrations: Multiparty \u2013 Multicontract",
+    "creditCount": 2.5,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4396",
+    "name": "University Research Opportunities Program",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4397",
+    "name": "University Research Opportunities Program",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4398",
+    "name": "University Research Opportunities Program",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4402",
+    "name": "Corporate Insolvency Law",
+    "creditCount": 8.0,
+    "preclusions": [
+      "LLA4038",
+      "LLA4039"
+    ],
+    "prerequisites": [
+      "LLB2008"
+    ]
+  },
+  {
+    "code": "LL4403",
+    "name": "Family Law",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4405A",
+    "name": "Law Of Intellectual Property (A)",
+    "creditCount": 8.0,
+    "preclusions": [
+      "LL4405B",
+      "LL5405B",
+      "LL6405B",
+      "LL4070",
+      "LL5070",
+      "LC5070",
+      "LL6070"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4407",
+    "name": "Law Of Insurance",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL4412",
+    "name": "Securities and Capital Markets Regulation",
+    "creditCount": 8.0,
+    "preclusions": [
+      "LL4409",
+      "LL5409",
+      "LLD5409",
+      "LL6409",
+      "LL4238",
+      "LL5238",
+      "LL6238",
+      "LL4238V",
+      "LL5238V",
+      "LL6238V",
+      "LL4182",
+      "LL5182",
+      "LL6182",
+      "LL4182V",
+      "LL5182V",
+      "LL6182V",
+      "LL5055",
+      "LL6055",
+      "LL4055V",
+      "LL5055V",
+      "LL6055V"
+    ],
+    "prerequisites": [
+      "LC2008",
+      "LLB2008"
+    ]
+  },
+  {
+    "code": "LL4413",
+    "name": "Civil Justice and Procedure",
+    "creditCount": 8.0,
+    "preclusions": [
+      "LL4011",
+      "LL5011",
+      "LL6011",
+      "LL4011V",
+      "LL5011V",
+      "LL6011V",
+      "LL4281",
+      "LL5281",
+      "LL6281",
+      "LL4281V",
+      "LL5281V",
+      "LL6281V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5002V",
+    "name": "Admiralty Law & Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5002"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5003V",
+    "name": "China, India and International Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5004V",
+    "name": "Aviation Law & Policy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5004"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5006V",
+    "name": "Banking Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5006"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5008AV",
+    "name": "Carriage of Goods By Sea",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5008BV",
+    "name": "Charterparties",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5008B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5009V",
+    "name": "Chinese Legal Tradition And Legal Chinese",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5013V",
+    "name": "Comparative Environmental Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5013"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5014V",
+    "name": "Construction Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5014"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5019V",
+    "name": "Credit & Security",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5019"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5021V",
+    "name": "Environmental Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5022V",
+    "name": "Globalization And International Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5022"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5029V",
+    "name": "International Commercial Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5029"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5030V",
+    "name": "International Commercial Litigation",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5030"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5031V",
+    "name": "International Environmental Law & Policy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5031"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5032V",
+    "name": "International Investment Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5032"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5033V",
+    "name": "International Legal Process",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5033"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5034V",
+    "name": "International Regulation of Shipping",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5034"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5043",
+    "name": "Law Of Marine Insurance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5044V",
+    "name": "Mediation",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5045V",
+    "name": "Negotiation",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5049V",
+    "name": "Principles Of Conflict Of Laws",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5049"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5050V",
+    "name": "Public International Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5050"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5054V",
+    "name": "Domestic and International Sale of Goods",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5056BV",
+    "name": "Tax Planning And Policy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LC2008"
+    ]
+  },
+  {
+    "code": "LL5057V",
+    "name": "Theoretical Foundations Of Criminal Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5057"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5059V",
+    "name": "United Nations Law & Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5059"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5060B",
+    "name": "World Trade Law",
+    "creditCount": 8.0,
+    "preclusions": [
+      "LL4199A",
+      "LL4199B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5063V",
+    "name": "Business & Finance For Lawyers",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5063"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5067",
+    "name": "Comparative Criminal Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5069V",
+    "name": "European Union Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5070V",
+    "name": "Foundations Of Intellectual Property Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5070"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5076V",
+    "name": "IT Law I",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5076"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5077V",
+    "name": "IT Law II",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5077"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5089V",
+    "name": "Chinese Corporate & Securities Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4089"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5094AV",
+    "name": "Law & Practice - The Law Clinic",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5094BV",
+    "name": "Law & Practice - The Law Clinic",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5094CV",
+    "name": "Law & Practice - The Law Clinic",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5094V",
+    "name": "Law & Practice - The Law Clinic",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5099V",
+    "name": "Maritime Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5099"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5100",
+    "name": "Arbitration and Dispute Resolution in China",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4100V",
+      "LL5100V",
+      "LL6100V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5102",
+    "name": "Advanced Torts",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5104V",
+    "name": "Jurisprudence",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5104"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5109V",
+    "name": "International Law & Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5109"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5133V",
+    "name": "Human Rights in Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5133"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5134V",
+    "name": "Crossing Borders: Law, Migration & Citizenship",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5134"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5140V",
+    "name": "Ocean Law & Policy in Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5140"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5148",
+    "name": "Secured Transactions Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4019",
+      "LL5019",
+      "LL6019",
+      "LL4019V",
+      "LL5019V",
+      "LL6019V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5150V",
+    "name": "International Investment Law and Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4150",
+      "LL5150",
+      "LL6150"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5155",
+    "name": "Topics in Law & Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5158V",
+    "name": "Climate Change Law and Policy in Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4158",
+      "LL5158",
+      "LL6158",
+      "LL4221",
+      "LL5221",
+      "LL6221",
+      "LL4221V",
+      "LL5221V",
+      "LL6221V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5164V",
+    "name": "International Projects Law & Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5164"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5173V",
+    "name": "Comparative Corporate Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5173"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5178V",
+    "name": "International Legal Protection of Investment Flows",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5185V",
+    "name": "Government Regulations: Law, Policy & Practice",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5190",
+    "name": "Freedom of Speech: Critical & Comparative Perspectives",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LC1005",
+      "LC2007"
+    ]
+  },
+  {
+    "code": "LL5195V",
+    "name": "International Economic Law & Relations",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5195"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5197V",
+    "name": "Comparative State and Religion in Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5197"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5202V",
+    "name": "ASEAN Economic Community Law and Policy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5202"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5203",
+    "name": "International Moots and Other Competitions",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5205V",
+    "name": "Maritime Conflict of Laws",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5205"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5208V",
+    "name": "Advanced Criminal Legal Process",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5208"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5209V",
+    "name": "Legal Argument & Narrative",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5209"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5214",
+    "name": "International and Comparative Oil and Gas Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5219",
+    "name": "The Trial of Jesus in Western Legal Thought",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5226",
+    "name": "Multimodal Transport Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5233V",
+    "name": "European Company Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL5233"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5235V",
+    "name": "International Contract Law: Principles and Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4235",
+      "LL5235",
+      "LL6235"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5237V",
+    "name": "Law, Institutions, and Business in Greater China",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5242S",
+    "name": "Financial Regulation and Central Banking",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4006",
+      "LL5006",
+      "LL6006",
+      "LL4006V",
+      "LL5006V",
+      "LL6006V",
+      "LL4242V",
+      "LL5242V",
+      "LL6242V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5242V",
+    "name": "Financial Regulation and Central Banking",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4241",
+      "LL5241",
+      "LL6241",
+      "LL4241V",
+      "LL5241V",
+      "LL6241V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5243V",
+    "name": "Regulation and Geography",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4243",
+      "LL5243",
+      "LL6243"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5244V",
+    "name": "Criminal Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4208",
+      "LL5208",
+      "LL6208",
+      "LL4208V",
+      "LL5208V",
+      "LL6208V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5251V",
+    "name": "International Humanitarian Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5258V",
+    "name": "Personal Property Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4047",
+      "LL5047",
+      "LL6047",
+      "LL4047V",
+      "LL5047V",
+      "LL6047V",
+      "LL4168",
+      "LL5168",
+      "LL6168",
+      "LL4168V",
+      "LL5168V",
+      "LL6168V",
+      "LL4411",
+      "LL5411",
+      "LL6411"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5259AV",
+    "name": "Alternative Investments",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4314",
+      "LL5314",
+      "LL6314",
+      "LL4314V",
+      "LL5314V",
+      "LL6314"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5259V",
+    "name": "Alternative Investments",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4314",
+      "LL5314",
+      "LL6314",
+      "LL4314V",
+      "LL5314V",
+      "LL6314"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5263V",
+    "name": "Intellectual Property Rights and Competition Policy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4075V",
+      "LL5075V",
+      "LL6075V",
+      "LL4075",
+      "LL5075",
+      "LL6075"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5276",
+    "name": "Advanced Contract Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4187",
+      "LL5187",
+      "LL6187",
+      "LL4187V",
+      "LL5187V",
+      "LL6187V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5277V",
+    "name": "Medical Law and Ethics",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4400",
+      "LL5400",
+      "LL6400"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5283V",
+    "name": "Artificial Intelligence, Information Science & Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LL4076",
+      "LL5076",
+      "LL6076",
+      "LL4076V",
+      "LL5076V",
+      "LL6076V",
+      "LL4077",
+      "LL5077",
+      "LL6077",
+      "LL4077V",
+      "LL5077V",
+      "LL6077V"
+    ]
+  },
+  {
+    "code": "LL5285V",
+    "name": "International Dispute Settlement",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4285",
+      "LL5285",
+      "LL6285",
+      "LC5285"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5286V",
+    "name": "Transnational Terrorism and International Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5287V",
+    "name": "ASEAN Law and Policy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5289V",
+    "name": "The Evolution of International Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4289",
+      "LL5289",
+      "LL6289"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5292V",
+    "name": "State Responsibility: Theory and Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4292",
+      "LL5292",
+      "LL6292"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5293S",
+    "name": "Business Torts",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5294S",
+    "name": "Security and Insolvency Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4019V",
+      "LL5019V",
+      "LL6019V"
+    ],
+    "prerequisites": [
+      "LC5230"
+    ]
+  },
+  {
+    "code": "LL5295",
+    "name": "Conflict of Laws in Int\u2019l Commercial Arbitration",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4295V",
+      "LL5295V",
+      "LL6295V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5299",
+    "name": "Advanced Issues in the Law & Practice of Int\u2019l Arbitration",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4299V",
+      "LL5299V",
+      "LL6299V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5308V",
+    "name": "Behavioural Economics, Law & Regulation",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4308",
+      "LL5308",
+      "LL6308"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5309",
+    "name": "Strategies for Asian Disputes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4309",
+      "LL5309",
+      "LL6309",
+      "LL4309V",
+      "LL5309V",
+      "LL6309V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5313V",
+    "name": "Mediation/Conciliation of Inter- & Investor-State Disputes",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4313",
+      "LL5313",
+      "LL6313"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5314S",
+    "name": "Private Equity and Venture Capital: Law and Practice",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4259V",
+      "LL5259V",
+      "LL6259V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5315S",
+    "name": "China's Tax Law and International Tax Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5316V",
+    "name": "Restitution of Unjust Enrichment",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4316",
+      "LL5316",
+      "LL6316",
+      "LL4051",
+      "LL5051",
+      "LL6051",
+      "LL4051V",
+      "LL5051V",
+      "LL6051V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5317V",
+    "name": "International Arbitration in Asian Centres",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4317",
+      "LL5317",
+      "LL6317"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5318V",
+    "name": "Public Health Law and Regulation",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4318",
+      "LL5318",
+      "LL6318"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5319V",
+    "name": "Current Problems in International Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4319",
+      "LL5319",
+      "LL6319"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5320",
+    "name": "International Space Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4320V",
+      "LL5320V",
+      "LL6320V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5322",
+    "name": "Trade Finance Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4322V",
+      "LL5322V",
+      "LL6322V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5323V",
+    "name": "Law of Agency",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4323",
+      "LL5323",
+      "LL6323"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5325",
+    "name": "The Int'l Litigation & Procedure of State Disputes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4325V",
+      "LL5325V",
+      "LL6325V",
+      "LL4285V",
+      "LL5285V",
+      "LC5285V",
+      "LL6285V",
+      "LL4285",
+      "LL5285",
+      "LC5285",
+      "LL6285"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5327V",
+    "name": "Mergers and Acquisitions: A Practitioner\u2019s Perspective",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4327",
+      "LL5327",
+      "LL6327",
+      "LL4074",
+      "LL5074",
+      "LL6074",
+      "LL4074V",
+      "LL5074V",
+      "LL6074V",
+      "LL4223",
+      "LL5223",
+      "LL6223",
+      "LL4233V",
+      "LL5223V",
+      "LL6223V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5338V",
+    "name": "Advanced Practicum in International Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4338",
+      "LL5338",
+      "LL6338"
+    ],
+    "prerequisites": [
+      "LL4029",
+      "LL5029",
+      "LC5262",
+      "LL6029",
+      "LL4029V",
+      "LL5029V",
+      "LC5262V",
+      "LL6029V",
+      "LL4285",
+      "LL5285",
+      "LC5285",
+      "LL6285",
+      "LL4285V",
+      "LL5285V",
+      "LC5285V",
+      "LL6285V"
+    ]
+  },
+  {
+    "code": "LL5339",
+    "name": "Comparative Evidence in International Arbitration",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4339V",
+      "LL5339V",
+      "LL6339V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5340V",
+    "name": "International Refugee Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4340",
+      "LL5340",
+      "LL6340"
+    ],
+    "prerequisites": [
+      "LL4050",
+      "LL5050",
+      "LL6050",
+      "LC5050",
+      "LL5050V",
+      "LL6050V",
+      "LC5050V"
+    ]
+  },
+  {
+    "code": "LL5341V",
+    "name": "The Law and Politics of Forced Migration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4341",
+      "LL5341",
+      "LL6341"
+    ],
+    "prerequisites": [
+      "LL4050",
+      "LL5050",
+      "LL6050",
+      "LC5050",
+      "LL5050V",
+      "LL6050V",
+      "LC5050V"
+    ]
+  },
+  {
+    "code": "LL5342V",
+    "name": "Taxation of Cross-Border Commercial Transactions",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4035",
+      "LL5035",
+      "LL6035",
+      "LC5035",
+      "LC5035A",
+      "LC5035B",
+      "LL4035V",
+      "LL5035V",
+      "LL6035V",
+      "LL4342",
+      "LL5342",
+      "LL6342"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5343V",
+    "name": "International Regulation of the Global Commons",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4343",
+      "LL5343",
+      "LL6343"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5344",
+    "name": "Public and Private International Copyright Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4344V",
+      "LL5344V",
+      "LL6344V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5345",
+    "name": "The Fulfilled Life and the Life of the Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4345V",
+      "LL5345V",
+      "LL6345V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5346V",
+    "name": "Interim Measures in International Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5347",
+    "name": "Art & Cultural Heritage Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4347V",
+      "LL5347V",
+      "LL6347V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5348",
+    "name": "Monetary Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4348V",
+      "LL5348V",
+      "LL6348V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5349V",
+    "name": "Energy Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4349",
+      "LL5349",
+      "LL6349"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5350V",
+    "name": "Privacy & Data Protection Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4350",
+      "LL5350",
+      "LL6350"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5351",
+    "name": "Comparative Corporate Law in East Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4351V",
+      "LL5351V",
+      "LL6351V"
+    ],
+    "prerequisites": [
+      "LC2008"
+    ]
+  },
+  {
+    "code": "LL5352",
+    "name": "China and International Economic Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4352V",
+      "LL5352V",
+      "LL6352V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5353",
+    "name": "Character Evidence in the Common Law World",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4353V",
+      "LL5353V",
+      "LL6353V"
+    ],
+    "prerequisites": [
+      "LC3001A",
+      "LC3001B"
+    ]
+  },
+  {
+    "code": "LL5354",
+    "name": "Comparative Human Rights Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4354V",
+      "LL5354V",
+      "LL6353V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5355",
+    "name": "International Law and Development",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4355V",
+      "LL5355V",
+      "LL6355V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5356V",
+    "name": "International Investment Law Clinic",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4356",
+      "LL5356",
+      "LL6356"
+    ],
+    "prerequisites": [
+      "LL4032V",
+      "LL5032V",
+      "LL6032V",
+      "LL4032",
+      "LL5032",
+      "LL6032"
+    ]
+  },
+  {
+    "code": "LL5357V",
+    "name": "Regulation & Political Economy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4357",
+      "LL5357",
+      "LL6357"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5358Z",
+    "name": "ICC Arbitration",
+    "creditCount": 2.5,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5359Z",
+    "name": "SIAC and Institutional Arbitration",
+    "creditCount": 2.5,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5360Z",
+    "name": "Current Challenges to Investment Arbitration",
+    "creditCount": 2.5,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5361Z",
+    "name": "Complex Arbitrations: Multiparty \u2013 Multicontract",
+    "creditCount": 2.5,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5396",
+    "name": "University Research Opportunities Programme",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5396V",
+    "name": "International Arbitration & Dispute Resolution Research",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5397",
+    "name": "University Research Opportunities Programme",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5397V",
+    "name": "International Arbitration & Dispute Resolution Research",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5398",
+    "name": "University Research Opportunities Programme",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5402",
+    "name": "Corporate Insolvency Law",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5403",
+    "name": "Family Law",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5405A",
+    "name": "Law Of Intellectual Property (A)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5407",
+    "name": "Law Of Insurance",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL5412",
+    "name": "Securities and Capital Markets Regulation",
+    "creditCount": 8.0,
+    "preclusions": [
+      "LL4409",
+      "LL5409",
+      "LLD5409",
+      "LL6409",
+      "LL4238",
+      "LL5238",
+      "LL6238",
+      "LL4238V",
+      "LL5238V",
+      "LL6238V",
+      "LL4182",
+      "LL5182",
+      "LL6182",
+      "LL4182V",
+      "LL5182V",
+      "LL6182V",
+      "LL5055",
+      "LL6055",
+      "LL4055V",
+      "LL5055V",
+      "LL6055V"
+    ],
+    "prerequisites": [
+      "LC2008",
+      "LLB2008"
+    ]
+  },
+  {
+    "code": "LL5413",
+    "name": "Civil Justice and Procedure",
+    "creditCount": 8.0,
+    "preclusions": [
+      "LL4011",
+      "LL5011",
+      "LL6011",
+      "LL4011V",
+      "LL5011V",
+      "LL6011V",
+      "LL4281",
+      "LL5281",
+      "LL6281",
+      "LL4281V",
+      "LL5281V",
+      "LL6281V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6002V",
+    "name": "Admiralty Law & Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6002"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6003V",
+    "name": "China, India and International Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6004V",
+    "name": "Aviation Law & Policy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6004"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6006V",
+    "name": "Banking Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6006"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6008AV",
+    "name": "Carriage of Goods By Sea",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6008BV",
+    "name": "Charterparties",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6008B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6009V",
+    "name": "Chinese Legal Tradition And Legal Chinese",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6013V",
+    "name": "Comparative Environmental Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6013"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6014V",
+    "name": "Construction Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6014"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6019V",
+    "name": "Credit & Security",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6019"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6021V",
+    "name": "Environmental Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6022V",
+    "name": "Globalization And International Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6022"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6029V",
+    "name": "International Commercial Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6029"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6030V",
+    "name": "International Commercial Litigation",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6030"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6031V",
+    "name": "International Environmental Law & Policy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6031"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6032V",
+    "name": "International Investment Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6032"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6033V",
+    "name": "International Legal Process",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6033"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6034V",
+    "name": "International Regulation of Shipping",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6034"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6043",
+    "name": "Law Of Marine Insurance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6044V",
+    "name": "Mediation",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6045V",
+    "name": "Negotiation",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6049V",
+    "name": "Principles Of Conflict Of Laws",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6049"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6050V",
+    "name": "Public International Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6050"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6054V",
+    "name": "Domestic and International Sale of Goods",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6056BV",
+    "name": "Tax Planning And Policy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LC2008"
+    ]
+  },
+  {
+    "code": "LL6057V",
+    "name": "Theoretical Foundations Of Criminal Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6057"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6059V",
+    "name": "United Nations Law & Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6059"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6060B",
+    "name": "World Trade Law",
+    "creditCount": 8.0,
+    "preclusions": [
+      "LL4199A",
+      "LL4199B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6063V",
+    "name": "Business & Finance For Lawyers",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6063"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6067",
+    "name": "Comparative Criminal Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6069V",
+    "name": "European Union Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6070V",
+    "name": "Foundations Of Intellectual Property Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6070"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6076V",
+    "name": "IT Law I",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6076"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6077V",
+    "name": "IT Law II",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6077"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6089V",
+    "name": "Chinese Corporate & Securities Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4089"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6094AV",
+    "name": "Law & Practice - The Law Clinic",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6094BV",
+    "name": "Law & Practice - The Law Clinic",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6094CV",
+    "name": "Law & Practice - The Law Clinic",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6094V",
+    "name": "Law & Practice - The Law Clinic",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6099V",
+    "name": "Maritime Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6099"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6100",
+    "name": "Arbitration and Dispute Resolution in China",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4100V",
+      "LL5100V",
+      "LL6100V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6102",
+    "name": "Advanced Torts",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6104V",
+    "name": "Jurisprudence",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6104"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6109V",
+    "name": "International Law & Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6109"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6133V",
+    "name": "Human Rights in Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6133"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6134V",
+    "name": "Crossing Borders: Law, Migration & Citizenship",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6134"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6140V",
+    "name": "Ocean Law & Policy in Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6140"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6148",
+    "name": "Secured Transactions Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4019",
+      "LL5019",
+      "LL6019",
+      "LL4019V",
+      "LL5019V",
+      "LL6019V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6150V",
+    "name": "International Investment Law and Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4150",
+      "LL5150",
+      "LL6150"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6155",
+    "name": "Topics in Law & Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6158V",
+    "name": "Climate Change Law and Policy in Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4158",
+      "LL5158",
+      "LL6158",
+      "LL4221",
+      "LL5221",
+      "LL6221",
+      "LL4221V",
+      "LL5221V",
+      "LL6221V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6164V",
+    "name": "International Projects Law & Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6164"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6173V",
+    "name": "Comparative Corporate Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6173"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6178V",
+    "name": "International Legal Protection of Investment Flows",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6185V",
+    "name": "Government Regulations: Law, Policy & Practice",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6190",
+    "name": "Freedom of Speech: Critical & Comparative Perspectives",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LC1005",
+      "LC2007"
+    ]
+  },
+  {
+    "code": "LL6195V",
+    "name": "International Economic Law & Relations",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6195"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6197V",
+    "name": "Comparative State and Religion in Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6197"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6202V",
+    "name": "ASEAN Economic Community Law and Policy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6202"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6203",
+    "name": "International Moots and Other Competitions",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6205V",
+    "name": "Maritime Conflict of Laws",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6205"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6208V",
+    "name": "Advanced Criminal Legal Process",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6208"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6209V",
+    "name": "Legal Argument & Narrative",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6209"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6214",
+    "name": "International and Comparative Oil and Gas Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6219",
+    "name": "The Trial of Jesus in Western Legal Thought",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6226",
+    "name": "Multimodal Transport Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6233V",
+    "name": "European Company Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL6233"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6235V",
+    "name": "International Contract Law: Principles and Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4235",
+      "LL5235",
+      "LL6235"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6237V",
+    "name": "Law, Institutions, and Business in Greater China",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6242V",
+    "name": "Financial Regulation and Central Banking",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4241",
+      "LL5241",
+      "LL6241",
+      "LL4241V",
+      "LL5241V",
+      "LL6241V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6243V",
+    "name": "Regulation and Geography",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4243",
+      "LL5243",
+      "LL6243"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6244V",
+    "name": "Criminal Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4208",
+      "LL5208",
+      "LL6208",
+      "LL4208V",
+      "LL5208V",
+      "LL6208V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6251V",
+    "name": "International Humanitarian Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6258V",
+    "name": "Personal Property Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4047",
+      "LL5047",
+      "LL6047",
+      "LL4047V",
+      "LL5047V",
+      "LL6047V",
+      "LL4168",
+      "LL5168",
+      "LL6168",
+      "LL4168V",
+      "LL5168V",
+      "LL6168V",
+      "LL4411",
+      "LL5411",
+      "LL6411"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6259AV",
+    "name": "Alternative Investments",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4314",
+      "LL5314",
+      "LL6314",
+      "LL4314V",
+      "LL5314V",
+      "LL6314"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6259V",
+    "name": "Alternative Investments",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4314",
+      "LL5314",
+      "LL6314",
+      "LL4314V",
+      "LL5314V",
+      "LL6314"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6263V",
+    "name": "Intellectual Property Rights and Competition Policy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4075V",
+      "LL5075V",
+      "LL6075V",
+      "LL4075",
+      "LL5075",
+      "LL6075"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6276",
+    "name": "Advanced Contract Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4187",
+      "LL5187",
+      "LL6187",
+      "LL4187V",
+      "LL5187V",
+      "LL6187V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6277V",
+    "name": "Medical Law and Ethics",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4400",
+      "LL5400",
+      "LL6400"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6283V",
+    "name": "Artificial Intelligence, Information Science & Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LL4076",
+      "LL5076",
+      "LL6076",
+      "LL4076V",
+      "LL5076V",
+      "LL6076V",
+      "LL4077",
+      "LL5077",
+      "LL6077",
+      "LL4077V",
+      "LL5077V",
+      "LL6077V"
+    ]
+  },
+  {
+    "code": "LL6285V",
+    "name": "International Dispute Settlement",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4285",
+      "LL5285",
+      "LL6285",
+      "LC5285"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6286V",
+    "name": "Transnational Terrorism and International Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6287V",
+    "name": "ASEAN Law and Policy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6289V",
+    "name": "The Evolution of International Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4289",
+      "LL5289",
+      "LL6289"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6292V",
+    "name": "State Responsibility: Theory and Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4292",
+      "LL5292",
+      "LL6292"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6295",
+    "name": "Conflict of Laws in Int\u2019l Commercial Arbitration",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4295V",
+      "LL5295V",
+      "LL6295V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6299",
+    "name": "Advanced Issues in the Law & Practice of Int\u2019l Arbitration",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4299V",
+      "LL5299V",
+      "LL6299V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6308V",
+    "name": "Behavioural Economics, Law & Regulation",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4308",
+      "LL5308",
+      "LL6308"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6309",
+    "name": "Strategies for Asian Disputes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4309",
+      "LL5309",
+      "LL6309",
+      "LL4309V",
+      "LL5309V",
+      "LL6309V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6313V",
+    "name": "Mediation/Conciliation of Inter- & Investor-State Disputes",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4313",
+      "LL5313",
+      "LL6313"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6316V",
+    "name": "Restitution of Unjust Enrichment",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4316",
+      "LL5316",
+      "LL6316",
+      "LL4051",
+      "LL5051",
+      "LL6051",
+      "LL4051V",
+      "LL5051V",
+      "LL6051V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6317V",
+    "name": "International Arbitration in Asian Centres",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4317",
+      "LL5317",
+      "LL6317"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6318V",
+    "name": "Public Health Law and Regulation",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4318",
+      "LL5318",
+      "LL6318"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6319V",
+    "name": "Current Problems in International Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4319",
+      "LL5319",
+      "LL6319"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6320",
+    "name": "International Space Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4320V",
+      "LL5320V",
+      "LL6320V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6322",
+    "name": "Trade Finance Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4322V",
+      "LL5322V",
+      "LL6322V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6323V",
+    "name": "Law of Agency",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4323",
+      "LL5323",
+      "LL6323"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6325",
+    "name": "The Int'l Litigation & Procedure of State Disputes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4325V",
+      "LL5325V",
+      "LL6325V",
+      "LL4285V",
+      "LL5285V",
+      "LC5285V",
+      "LL6285V",
+      "LL4285",
+      "LL5285",
+      "LC5285",
+      "LL6285"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6327V",
+    "name": "Mergers and Acquisitions: A Practitioner\u2019s Perspective",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4327",
+      "LL5327",
+      "LL6327",
+      "LL4074",
+      "LL5074",
+      "LL6074",
+      "LL4074V",
+      "LL5074V",
+      "LL6074V",
+      "LL4223",
+      "LL5223",
+      "LL6223",
+      "LL4233V",
+      "LL5223V",
+      "LL6223V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6338V",
+    "name": "Advanced Practicum in International Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4338",
+      "LL5338",
+      "LL6338"
+    ],
+    "prerequisites": [
+      "LL4029",
+      "LL5029",
+      "LC5262",
+      "LL6029",
+      "LL4029V",
+      "LL5029V",
+      "LC5262V",
+      "LL6029V",
+      "LL4285",
+      "LL5285",
+      "LC5285",
+      "LL6285",
+      "LL4285V",
+      "LL5285V",
+      "LC5285V",
+      "LL6285V"
+    ]
+  },
+  {
+    "code": "LL6339",
+    "name": "Comparative Evidence in International Arbitration",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4339V",
+      "LL5339V",
+      "LL6339V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6340V",
+    "name": "International Refugee Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4340",
+      "LL5340",
+      "LL6340"
+    ],
+    "prerequisites": [
+      "LL4050",
+      "LL5050",
+      "LL6050",
+      "LC5050",
+      "LL5050V",
+      "LL6050V",
+      "LC5050V"
+    ]
+  },
+  {
+    "code": "LL6341V",
+    "name": "The Law and Politics of Forced Migration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4341",
+      "LL5341",
+      "LL6341"
+    ],
+    "prerequisites": [
+      "LL4050",
+      "LL5050",
+      "LL6050",
+      "LC5050",
+      "LL5050V",
+      "LL6050V",
+      "LC5050V"
+    ]
+  },
+  {
+    "code": "LL6342V",
+    "name": "Taxation of Cross-Border Commercial Transactions",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4035",
+      "LL5035",
+      "LL6035",
+      "LC5035",
+      "LC5035A",
+      "LC5035B",
+      "LL4035V",
+      "LL5035V",
+      "LL6035V",
+      "LL4342",
+      "LL5342",
+      "LL6342"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6343V",
+    "name": "International Regulation of the Global Commons",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4343",
+      "LL5343",
+      "LL6343"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6344",
+    "name": "Public and Private International Copyright Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4344V",
+      "LL5344V",
+      "LL6344V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6345",
+    "name": "The Fulfilled Life and the Life of the Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4345V",
+      "LL5345V",
+      "LL6345V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6346V",
+    "name": "Interim Measures in International Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6347",
+    "name": "Art & Cultural Heritage Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4347V",
+      "LL5347V",
+      "LL6347V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6348",
+    "name": "Monetary Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4348V",
+      "LL5348V",
+      "LL6348V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6349V",
+    "name": "Energy Arbitration",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4349",
+      "LL5349",
+      "LL6349"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6350V",
+    "name": "Privacy & Data Protection Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4350",
+      "LL5350",
+      "LL6350"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6351",
+    "name": "Comparative Corporate Law in East Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4351V",
+      "LL5351V",
+      "LL6351V"
+    ],
+    "prerequisites": [
+      "LC2008"
+    ]
+  },
+  {
+    "code": "LL6352",
+    "name": "China and International Economic Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4352V",
+      "LL5352V",
+      "LL6352V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6353",
+    "name": "Character Evidence in the Common Law World",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4353V",
+      "LL5353V",
+      "LL6353V"
+    ],
+    "prerequisites": [
+      "LC3001A",
+      "LC3001B"
+    ]
+  },
+  {
+    "code": "LL6354",
+    "name": "Comparative Human Rights Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4354V",
+      "LL5354V",
+      "LL6353V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6355",
+    "name": "International Law and Development",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LL4355V",
+      "LL5355V",
+      "LL6355V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6356V",
+    "name": "International Investment Law Clinic\n(35 characters",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4356",
+      "LL5356",
+      "LL6356"
+    ],
+    "prerequisites": [
+      "LL4032V",
+      "LL5032V",
+      "LL6032V",
+      "LL4032",
+      "LL5032",
+      "LL6032"
+    ]
+  },
+  {
+    "code": "LL6357V",
+    "name": "Regulation & Political Economy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LL4357",
+      "LL5357",
+      "LL6357"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6358Z",
+    "name": "ICC Arbitration",
+    "creditCount": 2.5,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6359Z",
+    "name": "SIAC and Institutional Arbitration",
+    "creditCount": 2.5,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6360Z",
+    "name": "Current Challenges to Investment Arbitration",
+    "creditCount": 2.5,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6361Z",
+    "name": "Complex Arbitrations: Multiparty \u2013 Multicontract",
+    "creditCount": 2.5,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6396",
+    "name": "University Research Opportunities Programme",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6397",
+    "name": "University Research Opportunities Progra",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6402",
+    "name": "Corporate Insolvency Law",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6403",
+    "name": "Family Law",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6405A",
+    "name": "Law Of Intellectual Property (A)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6407",
+    "name": "Law Of Insurance",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LL6412",
+    "name": "Securities and Capital Markets Regulation",
+    "creditCount": 8.0,
+    "preclusions": [
+      "LL4409",
+      "LL5409",
+      "LLD5409",
+      "LL6409",
+      "LL4238",
+      "LL5238",
+      "LL6238",
+      "LL4238V",
+      "LL5238V",
+      "LL6238V",
+      "LL4182",
+      "LL5182",
+      "LL6182",
+      "LL4182V",
+      "LL5182V",
+      "LL6182V",
+      "LL5055",
+      "LL6055",
+      "LL4055V",
+      "LL5055V",
+      "LL6055V"
+    ],
+    "prerequisites": [
+      "LC2008",
+      "LLB2008"
+    ]
+  },
+  {
+    "code": "LL6413",
+    "name": "Civil Justice and Procedure",
+    "creditCount": 8.0,
+    "preclusions": [
+      "LL4011",
+      "LL5011",
+      "LL6011",
+      "LL4011V",
+      "LL5011V",
+      "LL6011V",
+      "LL4281",
+      "LL5281",
+      "LL6281",
+      "LL4281V",
+      "LL5281V",
+      "LL6281V"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LLD5002V",
+    "name": "Admiralty Law & Practice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LLD5002"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LLD5034V",
+    "name": "International Regulation of Shipping",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LLD5034"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LLD5043",
+    "name": "Law Of Marine Insurance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LLD5054V",
+    "name": "Domestic and International Sale of Goods",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LLD5099V",
+    "name": "Maritime Law",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LLD5099"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LLD5140V",
+    "name": "Ocean Law & Policy in Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LLD5140"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LLD5205V",
+    "name": "Maritime Conflict of Laws",
+    "creditCount": 5.0,
+    "preclusions": [
+      "LLD5205"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LLD5214",
+    "name": "International and Comparative Oil and Gas Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LLD5226",
+    "name": "Multimodal Transport Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LLD5396",
+    "name": "University Research Opportunities Programme",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LLD5397",
+    "name": "University Research Opportunities Programme",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LSM1102",
+    "name": "Molecular Genetics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1301",
+      "LSM1301X"
+    ]
+  },
+  {
+    "code": "LSM1105",
+    "name": "Evolutionary Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1301",
+      "LSM1301X"
+    ]
+  },
+  {
+    "code": "LSM1106",
+    "name": "Molecular Cell Biology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM1101"
+    ],
+    "prerequisites": [
+      "LSM1301",
+      "LSM1301X"
+    ]
+  },
+  {
+    "code": "LSM1301",
+    "name": "General Biology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM1301X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LSM1303",
+    "name": "Animal Behaviour",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LSM1306",
+    "name": "Forensic Science",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1542"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LSM1307",
+    "name": "Waste and Our Environment",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1515"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LSM1401",
+    "name": "Fundamentals of Biochemistry",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM1101"
+    ],
+    "prerequisites": [
+      "CM1417",
+      "CM1417X"
+    ]
+  },
+  {
+    "code": "LSM2191",
+    "name": "Laboratory Techniques in Life Sciences",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1102",
+      "LSM1106"
+    ]
+  },
+  {
+    "code": "LSM2211",
+    "name": "Metabolism and Regulation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM2101"
+    ],
+    "prerequisites": [
+      "LSM1106"
+    ]
+  },
+  {
+    "code": "LSM2212",
+    "name": "Human Anatomy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM1202"
+    ],
+    "prerequisites": [
+      "LSM1102",
+      "LSM1106"
+    ]
+  },
+  {
+    "code": "LSM2231",
+    "name": "General Physiology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM1104"
+    ],
+    "prerequisites": [
+      "LSM1301",
+      "LSM1301X"
+    ]
+  },
+  {
+    "code": "LSM2232",
+    "name": "Genes, Genomes and Biomedical Implications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM2102"
+    ],
+    "prerequisites": [
+      "LSM1102",
+      "LSM1106"
+    ]
+  },
+  {
+    "code": "LSM2233",
+    "name": "Cell Biology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM2103"
+    ],
+    "prerequisites": [
+      "LSM1106"
+    ]
+  },
+  {
+    "code": "LSM2234",
+    "name": "Physical Concepts in Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1301",
+      "LSM1301X"
+    ]
+  },
+  {
+    "code": "LSM2241",
+    "name": "Introductory Bioinformatics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1102",
+      "LSM1105",
+      "LSM1106",
+      "PR1111A"
+    ]
+  },
+  {
+    "code": "LSM2251",
+    "name": "Ecology and Environment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1301",
+      "LSM1301X"
+    ]
+  },
+  {
+    "code": "LSM2252",
+    "name": "Biodiversity",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM1103"
+    ],
+    "prerequisites": [
+      "LSM1301",
+      "LSM1301X"
+    ]
+  },
+  {
+    "code": "LSM2253",
+    "name": "Applied Data Analysis in Ecology and Evolution",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM3257"
+    ],
+    "prerequisites": [
+      "ST1232"
+    ]
+  },
+  {
+    "code": "LSM2254",
+    "name": "Fundamentals of Plant Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1102",
+      "LSM1106"
+    ]
+  },
+  {
+    "code": "LSM2288",
+    "name": "Basic UROPS in Life Sciences I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1102",
+      "LSM1105",
+      "LSM1106"
+    ]
+  },
+  {
+    "code": "LSM2289",
+    "name": "Basic UROPS in Life Sciences II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1102",
+      "LSM1105",
+      "LSM1106"
+    ]
+  },
+  {
+    "code": "LSM2291",
+    "name": "Fundamental Techniques in Microbiology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1102",
+      "LSM1106"
+    ]
+  },
+  {
+    "code": "LSM3201",
+    "name": "Research and Communication in Life Sciences",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LSM3211",
+    "name": "Fundamental Pharmacology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2501"
+    ],
+    "prerequisites": [
+      "LSM2211",
+      "LSM2233"
+    ]
+  },
+  {
+    "code": "LSM3212",
+    "name": "Human Physiology: Cardiopulmonary System",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2211"
+    ]
+  },
+  {
+    "code": "LSM3214",
+    "name": "Human Physiology - Hormones and Health",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2211",
+      "LSM3212"
+    ]
+  },
+  {
+    "code": "LSM3215",
+    "name": "Neuronal Signaling and Memory Mechanisms",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM3213"
+    ],
+    "prerequisites": [
+      "LSM2231",
+      "LSM2233"
+    ]
+  },
+  {
+    "code": "LSM3216",
+    "name": "Neuronal Development and Diseases",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM3213"
+    ],
+    "prerequisites": [
+      "LSM2232",
+      "LSM2233"
+    ]
+  },
+  {
+    "code": "LSM3217",
+    "name": "Human Ageing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2233"
+    ]
+  },
+  {
+    "code": "LSM3218",
+    "name": "Cardiopulmonary Pharmacology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM3221"
+    ],
+    "prerequisites": [
+      "LSM3211"
+    ]
+  },
+  {
+    "code": "LSM3219",
+    "name": "Neuropharmacology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM3221"
+    ],
+    "prerequisites": [
+      "LSM3211"
+    ]
+  },
+  {
+    "code": "LSM3222",
+    "name": "Human Neuroanatomy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1102",
+      "LSM1106"
+    ]
+  },
+  {
+    "code": "LSM3223",
+    "name": "Immunology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2233"
+    ]
+  },
+  {
+    "code": "LSM3224",
+    "name": "Molecular Basis of Human Diseases",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2211",
+      "LSM2233"
+    ]
+  },
+  {
+    "code": "LSM3225",
+    "name": "Molecular Microbiology in Human Diseases",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2211",
+      "LSM2232",
+      "LSM2233"
+    ]
+  },
+  {
+    "code": "LSM3226",
+    "name": "Medical Mycology and Drug Discovery",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2233",
+      "LSM2252",
+      "LSM2291"
+    ]
+  },
+  {
+    "code": "LSM3231",
+    "name": "Protein Structure and Function",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2211",
+      "LSM2241"
+    ]
+  },
+  {
+    "code": "LSM3232",
+    "name": "Microbiology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2211",
+      "LSM2232",
+      "LSM2233"
+    ]
+  },
+  {
+    "code": "LSM3233",
+    "name": "Developmental Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2233"
+    ]
+  },
+  {
+    "code": "LSM3234",
+    "name": "Biological Imaging of Growth and Form",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2233"
+    ]
+  },
+  {
+    "code": "LSM3235",
+    "name": "Epigenetics in Human Health and Diseases",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2232"
+    ]
+  },
+  {
+    "code": "LSM3241",
+    "name": "Genomic Data Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2232",
+      "LSM2241"
+    ]
+  },
+  {
+    "code": "LSM3242",
+    "name": "Translational Microbiology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2232",
+      "LSM2211",
+      "LSM3232"
+    ]
+  },
+  {
+    "code": "LSM3243",
+    "name": "Molecular Biophysics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1106"
+    ]
+  },
+  {
+    "code": "LSM3244",
+    "name": "Molecular Biotechnology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2233"
+    ]
+  },
+  {
+    "code": "LSM3245",
+    "name": "RNA Biology and Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2232"
+    ]
+  },
+  {
+    "code": "LSM3246",
+    "name": "Synthetic Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2211",
+      "LSM2232",
+      "LSM2233"
+    ]
+  },
+  {
+    "code": "LSM3247",
+    "name": "Practical Synthetic Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2191"
+    ]
+  },
+  {
+    "code": "LSM3252",
+    "name": "Evolution and Comparative Genomics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1105"
+    ]
+  },
+  {
+    "code": "LSM3254",
+    "name": "Ecology of Aquatic Environments",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2251"
+    ]
+  },
+  {
+    "code": "LSM3255",
+    "name": "Ecology of Terrestrial Environments",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM3271"
+    ],
+    "prerequisites": [
+      "LSM2251"
+    ]
+  },
+  {
+    "code": "LSM3256",
+    "name": "Tropical Horticulture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2231",
+      "LSM2252"
+    ]
+  },
+  {
+    "code": "LSM3258",
+    "name": "Comparative Botany",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM3261"
+    ],
+    "prerequisites": [
+      "LSM2231",
+      "LSM2252"
+    ]
+  },
+  {
+    "code": "LSM3259",
+    "name": "Fungal Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2252"
+    ]
+  },
+  {
+    "code": "LSM3262",
+    "name": "Environmental Animal Physiology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2231"
+    ]
+  },
+  {
+    "code": "LSM3265",
+    "name": "Entomology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2251"
+    ]
+  },
+  {
+    "code": "LSM3266",
+    "name": "Avian Biology and Evolution",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2252"
+    ]
+  },
+  {
+    "code": "LSM3267",
+    "name": "Behavioural Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2251"
+    ]
+  },
+  {
+    "code": "LSM3272",
+    "name": "Global Change Biology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ENV2101"
+    ],
+    "prerequisites": [
+      "LSM2252"
+    ]
+  },
+  {
+    "code": "LSM3288",
+    "name": "Advanced UROPS in Life Sciences I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LSM3289",
+    "name": "Advanced UROPS in Life Sciences II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "LSM3311",
+    "name": "Undergraduate Professional Internship Programme",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3311"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LSM3312",
+    "name": "Enhanced Undergraduate Professional Internship Programme",
+    "creditCount": 12.0,
+    "preclusions": [
+      "XX3312"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LSM4199",
+    "name": "Honours Project in Life Sciences",
+    "creditCount": 16.0,
+    "preclusions": [
+      "LSM4299"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LSM4211",
+    "name": "Toxicology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3211"
+    ]
+  },
+  {
+    "code": "LSM4213",
+    "name": "System Neurobiology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3215",
+      "LSM3216"
+    ]
+  },
+  {
+    "code": "LSM4214",
+    "name": "Cancer Pharmacology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3211"
+    ]
+  },
+  {
+    "code": "LSM4215",
+    "name": "Extreme Physiology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3212",
+      "LSM3214"
+    ]
+  },
+  {
+    "code": "LSM4216",
+    "name": "Molecular Nutrition and Metabolic Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2101",
+      "LSM2102"
+    ]
+  },
+  {
+    "code": "LSM4217",
+    "name": "Functional Ageing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3217"
+    ]
+  },
+  {
+    "code": "LSM4221",
+    "name": "Drug Discovery and Clinical Trials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3211"
+    ]
+  },
+  {
+    "code": "LSM4222",
+    "name": "Advanced Immunology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3223"
+    ]
+  },
+  {
+    "code": "LSM4223",
+    "name": "Advances in Antimicrobial Strategies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3232",
+      "LSM3225"
+    ]
+  },
+  {
+    "code": "LSM4225",
+    "name": "Genetic Medicine in the Post-Genomic Era",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2102"
+    ]
+  },
+  {
+    "code": "LSM4226",
+    "name": "Infection and Immunity",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3223",
+      "LSM3225",
+      "LSM3232"
+    ]
+  },
+  {
+    "code": "LSM4227",
+    "name": "Stem Cell Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2102",
+      "LSM2103"
+    ]
+  },
+  {
+    "code": "LSM4228",
+    "name": "Experimental Models for Human Disease and Therapy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2103"
+    ]
+  },
+  {
+    "code": "LSM4229",
+    "name": "Therapeutic and diagnostic agents from animal toxins",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3211",
+      "LSM3231"
+    ]
+  },
+  {
+    "code": "LSM4231",
+    "name": "Structural Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2103"
+    ]
+  },
+  {
+    "code": "LSM4232",
+    "name": "Advanced Cell Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2103"
+    ]
+  },
+  {
+    "code": "LSM4234",
+    "name": "Mechanobiology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2102",
+      "LSM2103"
+    ]
+  },
+  {
+    "code": "LSM4235",
+    "name": "Nuclear Mechanics and Genome Regulation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2102"
+    ]
+  },
+  {
+    "code": "LSM4241",
+    "name": "Functional Genomics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3231",
+      "LSM3241"
+    ]
+  },
+  {
+    "code": "LSM4242",
+    "name": "Protein Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2232",
+      "LSM3231"
+    ]
+  },
+  {
+    "code": "LSM4243",
+    "name": "Tumour Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2103"
+    ]
+  },
+  {
+    "code": "LSM4244",
+    "name": "Oncogenes and Signal Transduction",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2103"
+    ]
+  },
+  {
+    "code": "LSM4245",
+    "name": "Advanced Epigenetics and Chromatin Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3235"
+    ]
+  },
+  {
+    "code": "LSM4251",
+    "name": "Plant Growth and Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3233",
+      "LSM3258"
+    ]
+  },
+  {
+    "code": "LSM4252",
+    "name": "Reproductive Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3233"
+    ]
+  },
+  {
+    "code": "LSM4254",
+    "name": "Principles of Taxonomy and Systematics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3241",
+      "LSM3252"
+    ]
+  },
+  {
+    "code": "LSM4255",
+    "name": "Methods in Mathematical Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1301",
+      "MA1301X"
+    ]
+  },
+  {
+    "code": "LSM4256",
+    "name": "Evolution of Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3233",
+      "LSM3252"
+    ]
+  },
+  {
+    "code": "LSM4257",
+    "name": "Aquatic Vertebrate Diversity",
+    "creditCount": 4.0,
+    "preclusions": [
+      "LSM4266"
+    ],
+    "prerequisites": [
+      "LSM2252"
+    ]
+  },
+  {
+    "code": "LSM4261",
+    "name": "Marine Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3254"
+    ]
+  },
+  {
+    "code": "LSM4262",
+    "name": "Tropical Conservation Biology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ULS2204"
+    ],
+    "prerequisites": [
+      "LSM3272",
+      "ENV2101"
+    ]
+  },
+  {
+    "code": "LSM4264",
+    "name": "Freshwater Biology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3254"
+    ]
+  },
+  {
+    "code": "LSM4265",
+    "name": "Urban Ecology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2251",
+      "LSM3255"
+    ]
+  },
+  {
+    "code": "LSM4267",
+    "name": "Animal Communications & Sensory Ecology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM3267"
+    ]
+  },
+  {
+    "code": "LSM4299",
+    "name": "Applied Project in Life Sciences",
+    "creditCount": 16.0,
+    "preclusions": [
+      "XX4199"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "LX5103",
+    "name": "Environmental Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MA1100",
+    "name": "Fundamental Concepts of Mathematics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA1100S",
+      "GM1308",
+      "CS1231",
+      "CS1231S",
+      "CS1301"
+    ],
+    "prerequisites": [
+      "GM1101",
+      "GM1102",
+      "MA1301",
+      "MA1301FC",
+      "MA1301X"
+    ]
+  },
+  {
+    "code": "MA1101R",
+    "name": "Linear Algebra I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EG1401",
+      "EG1402",
+      "MA1101",
+      "MA1311",
+      "MA1506",
+      "MA1508"
+    ],
+    "prerequisites": [
+      "MA1301",
+      "MA1301FC",
+      "MA1301X"
+    ]
+  },
+  {
+    "code": "MA1102R",
+    "name": "Calculus",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE1401",
+      "EE1461",
+      "EG1401",
+      "EG1402",
+      "CE1402",
+      "MA1102",
+      "MA1312",
+      "MA1505",
+      "MA1505C",
+      "MA1507",
+      "MA1521"
+    ],
+    "prerequisites": [
+      "MA1301",
+      "MA1301FC",
+      "MA1301X"
+    ]
+  },
+  {
+    "code": "MA1301",
+    "name": "Introductory Mathematics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA1101R",
+      "MA1102R",
+      "MA1301FC",
+      "MA1301X",
+      "MA1505",
+      "MA1506",
+      "MA1507",
+      "MA1508",
+      "MA1521",
+      "MA1311",
+      "MA1312",
+      "MA1421"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MA1301X",
+    "name": "Introductory Mathematics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MA1312",
+    "name": "Calculus with Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA1102R",
+      "MA1505",
+      "MA1505C",
+      "MA1521",
+      "MA1511"
+    ],
+    "prerequisites": [
+      "MA1301",
+      "MA1301FC",
+      "MA1301X"
+    ]
+  },
+  {
+    "code": "MA1421",
+    "name": "Basic Applied Mathematics for Sciences",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA1102R",
+      "MA1312",
+      "MA1505",
+      "MA1506",
+      "MA1507",
+      "MA1521"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MA1505",
+    "name": "Mathematics I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA1102R",
+      "MA1312",
+      "MA1507",
+      "MA1511",
+      "MA1521",
+      "MA2311",
+      "MA2501",
+      "EE1461",
+      "PC2174"
+    ],
+    "prerequisites": [
+      "MA1301",
+      "MA1301FC",
+      "MA1301X"
+    ]
+  },
+  {
+    "code": "MA1507",
+    "name": "Advanced Calculus",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA1102R",
+      "MA1104",
+      "MA1505",
+      "MA1511",
+      "MA1512",
+      "MA1521",
+      "MA2104",
+      "MA2311"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MA1508E",
+    "name": "Linear Algebra for Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA1101R",
+      "MA1311",
+      "MA1506",
+      "MA1508",
+      "MA1513"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MA1511",
+    "name": "Engineering Calculus",
+    "creditCount": 2.0,
+    "preclusions": [
+      "MA1102R",
+      "MA1312",
+      "MA1505",
+      "MA1506",
+      "MA1507",
+      "MA1521",
+      "MA2311",
+      "MA2501",
+      "EE1461",
+      "PC2174"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MA1512",
+    "name": "Differential Equations for Engineering",
+    "creditCount": 2.0,
+    "preclusions": [
+      "MA1506",
+      "MA1507",
+      "EE1461",
+      "PC2174"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MA1513",
+    "name": "Linear Algebra with Differential Equations",
+    "creditCount": 2.0,
+    "preclusions": [
+      "MA1101R",
+      "MA1311",
+      "MA1506",
+      "MA1508",
+      "MA1508E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MA1521",
+    "name": "Calculus for Computing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA1102R",
+      "MA1312",
+      "MA1505",
+      "MA1507",
+      "MA2501",
+      "MA1511"
+    ],
+    "prerequisites": [
+      "MA1301",
+      "MA1301FC",
+      "MA1301X"
+    ]
+  },
+  {
+    "code": "MA2101",
+    "name": "Linear Algebra II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA2101S",
+      "MA2101H",
+      "MA2201",
+      "MA2203",
+      "MQ2201",
+      "MQ2101",
+      "MQ2203"
+    ],
+    "prerequisites": [
+      "MA1101R",
+      "MA1506",
+      "MA1508",
+      "MA1508E",
+      "MA1513"
+    ]
+  },
+  {
+    "code": "MA2101S",
+    "name": "Linear Algebra II (S)",
+    "creditCount": 5.0,
+    "preclusions": [
+      "MA2101",
+      "MA2101H",
+      "MA2201",
+      "MA2203",
+      "MQ2201",
+      "MQ2101",
+      "MQ2203"
+    ],
+    "prerequisites": [
+      "MA1101R",
+      "MA1506",
+      "MA1508",
+      "MA1508E",
+      "MA1513"
+    ]
+  },
+  {
+    "code": "MA2104",
+    "name": "Multivariable Calculus",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA1104",
+      "MA2311",
+      "MA1507"
+    ],
+    "prerequisites": [
+      "MA1102R",
+      "MA1505",
+      "MA1511",
+      "MA1521"
+    ]
+  },
+  {
+    "code": "MA2108",
+    "name": "Mathematical Analysis I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA2108S",
+      "MA2206",
+      "MA2208",
+      "MA2221",
+      "MA2311",
+      "MQ2202",
+      "MQ2102",
+      "MQ2203",
+      "CN2401",
+      "EE2401",
+      "ME2492"
+    ],
+    "prerequisites": [
+      "MA1102R",
+      "MA1505",
+      "MA1511",
+      "MA1505C",
+      "MA1507",
+      "MA1521"
+    ]
+  },
+  {
+    "code": "MA2108S",
+    "name": "Mathematical Analysis I (S)",
+    "creditCount": 5.0,
+    "preclusions": [
+      "MA2108",
+      "MA2206",
+      "MA2208",
+      "MA2221",
+      "MA2311",
+      "MQ2202",
+      "MQ2102",
+      "MQ2203",
+      "CN2401",
+      "EE2401",
+      "ME2492"
+    ],
+    "prerequisites": [
+      "MA1102R",
+      "MA1505",
+      "MA1511",
+      "MA1505C",
+      "MA1507",
+      "MA1521"
+    ]
+  },
+  {
+    "code": "MA2202",
+    "name": "Algebra I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA2202S",
+      "MA3250",
+      "MQ3201"
+    ],
+    "prerequisites": [
+      "MA1100",
+      "MA1100S",
+      "CS1231",
+      "CS1231S"
+    ]
+  },
+  {
+    "code": "MA2202S",
+    "name": "Algebra I (S)",
+    "creditCount": 5.0,
+    "preclusions": [
+      "MA2202",
+      "MA3250",
+      "MQ3201"
+    ],
+    "prerequisites": [
+      "MA1100",
+      "MA1100S",
+      "CS1231",
+      "CS1231S"
+    ]
+  },
+  {
+    "code": "MA2213",
+    "name": "Numerical Analysis I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE2407",
+      "ME3291",
+      "CN3421",
+      "CN3411",
+      "DSA2102"
+    ],
+    "prerequisites": [
+      "MA1102R",
+      "MA1312",
+      "MA1507",
+      "MA1505",
+      "MA1521",
+      "MA1511",
+      "EG1402",
+      "EE1401",
+      "EE1461",
+      "MA1101R",
+      "MA1311",
+      "MA1508",
+      "MA1506",
+      "MA1508E",
+      "MA1513"
+    ]
+  },
+  {
+    "code": "MA2214",
+    "name": "Combinatorics and Graphs I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1100",
+      "MA1101R",
+      "MA1311",
+      "MA1506",
+      "MA1508",
+      "MA1508E",
+      "MA1513",
+      "CS1231",
+      "CS1231S"
+    ]
+  },
+  {
+    "code": "MA2216",
+    "name": "Probability",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ST2131",
+      "ST2334",
+      "CE2407"
+    ],
+    "prerequisites": [
+      "MA1102R",
+      "MA1312",
+      "MA1507",
+      "MA1505",
+      "MA1505C",
+      "MA1511",
+      "MA1521"
+    ]
+  },
+  {
+    "code": "MA2219",
+    "name": "Introduction to Geometry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1100",
+      "MA1101R",
+      "MA1506",
+      "MA1508",
+      "MA1508E",
+      "MA1513",
+      "MA1102R",
+      "MA1505",
+      "MA1507",
+      "MA1511",
+      "CS1231"
+    ]
+  },
+  {
+    "code": "MA2288",
+    "name": "Basic UROPS in Mathematics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1101R"
+    ]
+  },
+  {
+    "code": "MA2289",
+    "name": "Basic UROPS in Mathematics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1101R"
+    ]
+  },
+  {
+    "code": "MA2311",
+    "name": "Techniques in Advanced Calculus",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA1104",
+      "MA2104",
+      "MA1505",
+      "MA1507",
+      "MA1511",
+      "MA2108",
+      "MA2108S"
+    ],
+    "prerequisites": [
+      "MA1102R",
+      "MA1312",
+      "MA1421",
+      "MA1521"
+    ]
+  },
+  {
+    "code": "MA2501",
+    "name": "Differential Equations and Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA1505",
+      "MA1505C",
+      "MA1506",
+      "MA1512",
+      "MA1521",
+      "MA2210",
+      "MA2312",
+      "MA1511"
+    ],
+    "prerequisites": [
+      "MA1507",
+      "MA1508",
+      "MA1508E"
+    ]
+  },
+  {
+    "code": "MA3110",
+    "name": "Mathematical Analysis II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA2118",
+      "MA2118H",
+      "MA2205",
+      "MQ3202",
+      "MA3110S",
+      "ST2236"
+    ],
+    "prerequisites": [
+      "MA2108",
+      "MA2108S"
+    ]
+  },
+  {
+    "code": "MA3110S",
+    "name": "Mathematical Analysis II (S)",
+    "creditCount": 5.0,
+    "preclusions": [
+      "MA2118",
+      "MA2118H",
+      "MA2205",
+      "MQ3202",
+      "MA3110"
+    ],
+    "prerequisites": [
+      "MA2108",
+      "MA2108S"
+    ]
+  },
+  {
+    "code": "MA3111",
+    "name": "Complex Analysis I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA3111S",
+      "EE3002"
+    ],
+    "prerequisites": [
+      "MA1104",
+      "MA2104",
+      "MA1507",
+      "MA3110",
+      "MA3110S"
+    ]
+  },
+  {
+    "code": "MA3111S",
+    "name": "Complex Analysis I (S)",
+    "creditCount": 5.0,
+    "preclusions": [
+      "MA3111",
+      "EE3002"
+    ],
+    "prerequisites": [
+      "MA1104",
+      "MA2104",
+      "MA1507",
+      "MA3110",
+      "MA3110S"
+    ]
+  },
+  {
+    "code": "MA3201",
+    "name": "Algebra II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA2202",
+      "MA2202S",
+      "MA2101",
+      "MA2101S"
+    ]
+  },
+  {
+    "code": "MA3205",
+    "name": "Set Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1100",
+      "MA1100S",
+      "CS1231",
+      "CS1231S"
+    ]
+  },
+  {
+    "code": "MA3209",
+    "name": "Mathematical Analysis III",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA3213",
+      "MA3251"
+    ],
+    "prerequisites": [
+      "MA3110",
+      "MA3110S",
+      "MA1104",
+      "MA2104",
+      "MA1507"
+    ]
+  },
+  {
+    "code": "MA3218",
+    "name": "Applied Algebra",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA2202",
+      "MA2202S",
+      "EE4103"
+    ],
+    "prerequisites": [
+      "MA2101",
+      "MA2101S"
+    ]
+  },
+  {
+    "code": "MA3220",
+    "name": "Ordinary Differential Equations",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA2312",
+      "PC2174"
+    ],
+    "prerequisites": [
+      "MA1104",
+      "MA2104",
+      "MA1505",
+      "MA1507",
+      "MA1511",
+      "MA1521",
+      "MA1101R",
+      "MA1311",
+      "MA1506",
+      "MA1508",
+      "MA1508E",
+      "MA1513",
+      "MA2108",
+      "MA2108S"
+    ]
+  },
+  {
+    "code": "MA3227",
+    "name": "Numerical Analysis II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ME3291"
+    ],
+    "prerequisites": [
+      "MA2213",
+      "MA1104",
+      "MA2104",
+      "MA1506",
+      "MA1507",
+      "MA1505",
+      "MA1511",
+      "MA2311",
+      "MA2101",
+      "MA2101S",
+      "MA2216",
+      "ST2131",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "MA3233",
+    "name": "Combinatorics and Graphs II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA2214"
+    ]
+  },
+  {
+    "code": "MA3236",
+    "name": "Non-Linear Programming",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC3214",
+      "DSN3701"
+    ],
+    "prerequisites": [
+      "MA1104",
+      "MA2104",
+      "MA1506",
+      "MA1507",
+      "MA1505",
+      "MA1511",
+      "MA2311"
+    ]
+  },
+  {
+    "code": "MA3238",
+    "name": "Stochastic Processes I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ST3236"
+    ],
+    "prerequisites": [
+      "MA1101",
+      "MA1101R",
+      "MA1311",
+      "MA1508",
+      "GM1302",
+      "MA2216",
+      "ST2131"
+    ]
+  },
+  {
+    "code": "MA3252",
+    "name": "Linear and Network Optimisation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MQ2204",
+      "CS3252",
+      "IC2231",
+      "DSC3214",
+      "DSN3701",
+      "MA3235",
+      "BH3214"
+    ],
+    "prerequisites": [
+      "MA1101R",
+      "MA1306",
+      "MA1311",
+      "MA1508",
+      "MA1506",
+      "MA1508E",
+      "MA1513"
+    ]
+  },
+  {
+    "code": "MA3259",
+    "name": "Mathematical Methods in Genomics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA2216",
+      "MA3233",
+      "MA3501",
+      "ST2131",
+      "ST2334",
+      "LSM2241"
+    ]
+  },
+  {
+    "code": "MA3264",
+    "name": "Mathematical Modelling",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1104",
+      "MA2104",
+      "MA1104S",
+      "MA1506",
+      "MA2108",
+      "MA2108S",
+      "MA2221",
+      "MA1505",
+      "MA1511",
+      "MA2311"
+    ]
+  },
+  {
+    "code": "MA3265",
+    "name": "Introduction to Number Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA2108",
+      "MA2108S",
+      "MA2202",
+      "MA2202S"
+    ]
+  },
+  {
+    "code": "MA3269",
+    "name": "Mathematical Finance I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "QF2101"
+    ],
+    "prerequisites": [
+      "CS1010",
+      "CS1010E",
+      "CS1010S",
+      "CS1010FC",
+      "IT1006",
+      "CS1101",
+      "CS1101C",
+      "CS1101S",
+      "IT1002",
+      "ST2131",
+      "ST2334",
+      "MA2216"
+    ]
+  },
+  {
+    "code": "MA3288",
+    "name": "Advanced UROPS in Mathematics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MA3289",
+    "name": "Advanced UROPS in Mathematics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MA3310",
+    "name": "Undergraduate Professional Internship Programme",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3310"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MA3311",
+    "name": "Undergraduate Professional Internship Programme",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3311"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MA3312",
+    "name": "Enhanced Undergraduate Professional Internship Programme",
+    "creditCount": 12.0,
+    "preclusions": [
+      "XX3312"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MA4199",
+    "name": "Honours Project in Mathematics",
+    "creditCount": 12.0,
+    "preclusions": [
+      "XFS4199M"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MA4203",
+    "name": "Galois Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA3201"
+    ]
+  },
+  {
+    "code": "MA4207",
+    "name": "Mathematical Logic",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA3110",
+      "MA3110S",
+      "MA3205",
+      "MA3219"
+    ]
+  },
+  {
+    "code": "MA4211",
+    "name": "Functional Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA3207H",
+      "MA3209"
+    ]
+  },
+  {
+    "code": "MA4221",
+    "name": "Partial Differential Equations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA3220"
+    ]
+  },
+  {
+    "code": "MA4229",
+    "name": "Approximation Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA2101",
+      "MA2101S",
+      "MA3110",
+      "MA3110S"
+    ]
+  },
+  {
+    "code": "MA4230",
+    "name": "Matrix Computation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA2101",
+      "MA2101S",
+      "MA2213",
+      "DSA2102"
+    ]
+  },
+  {
+    "code": "MA4235",
+    "name": "Topics in Graph Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA3233"
+    ]
+  },
+  {
+    "code": "MA4247",
+    "name": "Complex Analysis II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA3111",
+      "MA3111S"
+    ]
+  },
+  {
+    "code": "MA4251",
+    "name": "Stochastic Processes II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA3237",
+      "MA3239",
+      "GM3310",
+      "ST4238"
+    ],
+    "prerequisites": [
+      "MA3238",
+      "ST3236"
+    ]
+  },
+  {
+    "code": "MA4254",
+    "name": "Discrete Optimization",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA3235"
+    ],
+    "prerequisites": [
+      "MA2215",
+      "MA3252",
+      "DSC3214",
+      "DSN3701"
+    ]
+  },
+  {
+    "code": "MA4255",
+    "name": "Numerical Methods in Differential Equations",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ME4233"
+    ],
+    "prerequisites": [
+      "MA2213",
+      "DSA2102",
+      "MA3220"
+    ]
+  },
+  {
+    "code": "MA4260",
+    "name": "Stochastic Operations Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA2216",
+      "ST2131",
+      "ST2334",
+      "MA3236",
+      "MA3252",
+      "DSC3214",
+      "DSN3701"
+    ]
+  },
+  {
+    "code": "MA4261",
+    "name": "Coding and Cryptography",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA3201",
+      "MA3218",
+      "MA3265"
+    ]
+  },
+  {
+    "code": "MA4262",
+    "name": "Measure and Integration",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA3209"
+    ]
+  },
+  {
+    "code": "MA4263",
+    "name": "Introduction to Analytic Number Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA2202",
+      "MA2202S",
+      "MA3111",
+      "MA3111S"
+    ]
+  },
+  {
+    "code": "MA4264",
+    "name": "Game Theory",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC3312"
+    ],
+    "prerequisites": [
+      "MA3236",
+      "MA3252",
+      "DSC3214",
+      "DSN3701",
+      "MA2216",
+      "ST2131",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "MA4266",
+    "name": "Topology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA3209"
+    ]
+  },
+  {
+    "code": "MA4268",
+    "name": "Mathematics for Visual Data Processing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA2213"
+    ]
+  },
+  {
+    "code": "MA4269",
+    "name": "Mathematical Finance II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA3245",
+      "MA4257"
+    ],
+    "prerequisites": [
+      "MA1104",
+      "MA1506",
+      "MA1507",
+      "MA1511",
+      "MA2104",
+      "MA2311",
+      "MA3269"
+    ]
+  },
+  {
+    "code": "MA4270",
+    "name": "Data Modelling and Computation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA2213",
+      "DSA2102",
+      "MA2216",
+      "ST2131",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "MA4271",
+    "name": "Differential Geometry of Curves and Surfaces",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA3215"
+    ],
+    "prerequisites": [
+      "MA1104",
+      "MA2104",
+      "MA1507",
+      "MA1505",
+      "MA2311",
+      "MA2101",
+      "MA2101S"
+    ]
+  },
+  {
+    "code": "MA4291",
+    "name": "Undergraduate Topics in Mathematics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MA4292",
+    "name": "Undergraduate Topics in Mathematics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MA5198",
+    "name": "Graduate Seminar Module In Mathematics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MA5202",
+    "name": "Number Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA4203",
+      "MA5203"
+    ]
+  },
+  {
+    "code": "MA5203",
+    "name": "Graduate Algebra I",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA3201"
+    ]
+  },
+  {
+    "code": "MA5204",
+    "name": "Graduate Algebra IIA",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA5203"
+    ]
+  },
+  {
+    "code": "MA5205",
+    "name": "Graduate Analysis I",
+    "creditCount": 5.0,
+    "preclusions": [
+      "MA5215"
+    ],
+    "prerequisites": [
+      "MA4262"
+    ]
+  },
+  {
+    "code": "MA5206",
+    "name": "Graduate Analysis II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA4211",
+      "MA4262",
+      "MA5205"
+    ]
+  },
+  {
+    "code": "MA5209",
+    "name": "Algebraic Topology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA3251",
+      "MA4215",
+      "MA4266"
+    ]
+  },
+  {
+    "code": "MA5210",
+    "name": "Differentiable Manifolds",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA3209",
+      "MA3215",
+      "MA3251",
+      "MA4266"
+    ]
+  },
+  {
+    "code": "MA5211",
+    "name": "Lie Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA3201",
+      "MA5203",
+      "MA5218"
+    ]
+  },
+  {
+    "code": "MA5213",
+    "name": "Advanced Partial Differential Equations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA4221"
+    ]
+  },
+  {
+    "code": "MA5217",
+    "name": "Graduate Complex Analysis",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA4247"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MA5219",
+    "name": "Logic and Foundation of Mathematics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA4207"
+    ]
+  },
+  {
+    "code": "MA5232",
+    "name": "Modeling and Numerical Simulations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MA5233",
+    "name": "Computational Mathematics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA3228",
+      "MA4255",
+      "MA4230"
+    ]
+  },
+  {
+    "code": "MA5236",
+    "name": "Homology Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA5209",
+      "MA5210"
+    ]
+  },
+  {
+    "code": "MA5241",
+    "name": "Computational Harmonic Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA4229"
+    ]
+  },
+  {
+    "code": "MA5243",
+    "name": "Advanced Mathematical Programming",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA3236"
+    ]
+  },
+  {
+    "code": "MA5248",
+    "name": "Stochastic Analysis in Mathematical Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA4262",
+      "MA3245",
+      "MA4269"
+    ]
+  },
+  {
+    "code": "MA5251",
+    "name": "Spectral Methods And Applications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MA5295",
+    "name": "Dissertation For Msc By Coursework",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MA6202",
+    "name": "Topics In Algebra And Number Theory Ii",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MA6211",
+    "name": "Topics In Geometry And Topology I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MA6235",
+    "name": "Topics In Financial Mathematics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MA6252",
+    "name": "Topics In Applied Mathematics Ii",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MA6291",
+    "name": "Topics in Mathematics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MB5101",
+    "name": "The Cell as a Machine",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MB5102",
+    "name": "Topics in Mechanobiology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MB5101"
+    ]
+  },
+  {
+    "code": "MB5103",
+    "name": "Research Seminars in Mechanobiology",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MB5104",
+    "name": "Integrative Approach To Understand Cell Functions",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MB5105",
+    "name": "Microfabrication for Biologists",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MCI5001",
+    "name": "Clinical Epidemiology I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MCI5002",
+    "name": "Clinical Biostatistics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MCI5003",
+    "name": "Basic Clinical Pharmacology For Clinical Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MCI5004",
+    "name": "Molecular Biomarkers In Clinical Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MCI5005",
+    "name": "Ethics And Regulation Of Clinical Research",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MCI5006",
+    "name": "Clinical Epidemiology And Biostatistics Ii",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MCI5007",
+    "name": "Scientific Writing",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MCI5008",
+    "name": "Research Project",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MCI5009",
+    "name": "Health Services Research Methods for Clinicians",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MDG5108",
+    "name": "Biostatistics For Basic Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MDG5204",
+    "name": "Advanced Topics in Pharmacology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MDG5214",
+    "name": "Research Skills",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MDG5216",
+    "name": "Bioethical Evaluation of Health Policies in Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MDG5220",
+    "name": "Array and Omics",
+    "creditCount": 2.0,
+    "preclusions": [
+      "MDG5214"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MDG5221",
+    "name": "Viral vectors for manipulating gene expression",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MDG5223",
+    "name": "Stem Cells and Regenerative Medicine",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MDG5226",
+    "name": "Antimicrobial resistance and drug discovery",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MDG5229",
+    "name": "Advanced Topics in Signal Transduction",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MDG5231",
+    "name": "Topics in Biomedical and Behavioural Research Ethics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MDG5237",
+    "name": "Biomedical Innovation Capstone",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MDG5227",
+      "MDG5236"
+    ]
+  },
+  {
+    "code": "MDG5239",
+    "name": "Clinical Pharmacology II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MDG5238"
+    ]
+  },
+  {
+    "code": "MDG5302",
+    "name": "Independent\u00a0Study\u00a0Module (PCM)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MDG5771",
+    "name": "Graduate Research Seminar and Workshop",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME2101E",
+    "name": "Fundamentals of Mechanical Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM2101",
+      "TME2101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME2102",
+    "name": "Engineering Innovation and Modelling",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME2112",
+    "name": "Strength of Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EG1111"
+    ]
+  },
+  {
+    "code": "ME2114",
+    "name": "Mechanics of Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2112"
+    ]
+  },
+  {
+    "code": "ME2114E",
+    "name": "Mechanics of Materials II",
+    "creditCount": 3.0,
+    "preclusions": [
+      "TM1111",
+      "TME2114"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME2115",
+    "name": "Mechanics Of Machines",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC1431",
+      "PC1431FC",
+      "PC1431X"
+    ]
+  },
+  {
+    "code": "ME2121",
+    "name": "Engineering Thermodynamics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC1431",
+      "PC1431FC",
+      "PC1431X"
+    ]
+  },
+  {
+    "code": "ME2121E",
+    "name": "Engineering Thermodynamics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM1121",
+      "TME2121"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME2134",
+    "name": "Fluid Mechanics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC1431",
+      "PC1431FC",
+      "PC1431X"
+    ]
+  },
+  {
+    "code": "ME2134E",
+    "name": "Fluid Mechanics I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM1131",
+      "TME2134"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME2135",
+    "name": "Intermediate Fluid Mechanics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2134"
+    ]
+  },
+  {
+    "code": "ME2135E",
+    "name": "Fluid Mechanics II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM2131",
+      "TME2135"
+    ],
+    "prerequisites": [
+      "ME2134E"
+    ]
+  },
+  {
+    "code": "ME2142",
+    "name": "Feedback Control Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1506"
+    ]
+  },
+  {
+    "code": "ME2142E",
+    "name": "Feedback Control Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3142",
+      "TME2142"
+    ],
+    "prerequisites": [
+      "TM2401"
+    ]
+  },
+  {
+    "code": "ME2143E",
+    "name": "Sensors and Actuators",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM2141",
+      "TME2143"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME2151",
+    "name": "Principles of Mechanical Eng. Materials",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MLE1101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME2151E",
+    "name": "Principles of Mechanical Eng. Materials",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM1151",
+      "TME2151"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3000",
+    "name": "Independent Study 1",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3001",
+    "name": "Independent Study 2",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3103",
+    "name": "Mechanical Systems Design",
+    "creditCount": 6.0,
+    "preclusions": [
+      "ME3101",
+      "ME3102"
+    ],
+    "prerequisites": [
+      "ME2101",
+      "ME2103"
+    ]
+  },
+  {
+    "code": "ME3112E",
+    "name": "Mechanics of Machines",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM2112",
+      "TME3112"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3122",
+    "name": "Heat Transfer",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC1431FC",
+      "PC1431",
+      "PC1431X"
+    ]
+  },
+  {
+    "code": "ME3122E",
+    "name": "Heat Transfer",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM2122",
+      "TME3122"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3162",
+    "name": "Manufacturing Processes",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3162E",
+    "name": "Manufacturing Processes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM2162",
+      "TME3162"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3211",
+    "name": "Mechanics Of Solids",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2114"
+    ]
+  },
+  {
+    "code": "ME3211E",
+    "name": "Mechanics of Solids",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3211",
+      "TME3211"
+    ],
+    "prerequisites": [
+      "ME2114E"
+    ]
+  },
+  {
+    "code": "ME3221",
+    "name": "Sustainable EnergyConversion",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2121"
+    ]
+  },
+  {
+    "code": "ME3232",
+    "name": "Compressible Flow",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ME3231"
+    ],
+    "prerequisites": [
+      "ME2134"
+    ]
+  },
+  {
+    "code": "ME3233E",
+    "name": "Unsteady Flow in Fluid Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ME3233",
+      "TME3233"
+    ],
+    "prerequisites": [
+      "ME2135",
+      "ME2135E"
+    ]
+  },
+  {
+    "code": "ME3241",
+    "name": "Microprocessor Applications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3241E",
+    "name": "Microprocessor Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3241",
+      "TME3241"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3242",
+    "name": "Automation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3242E",
+    "name": "Automation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3242",
+      "TME3242"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3251",
+    "name": "Materials For Engineers",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2151"
+    ]
+  },
+  {
+    "code": "ME3251E",
+    "name": "Materials For Engineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3251",
+      "TME3251"
+    ],
+    "prerequisites": [
+      "ME2151E"
+    ]
+  },
+  {
+    "code": "ME3261",
+    "name": "Computer-Aided Design And Manufacturing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3261E",
+    "name": "Computer-Aided Design and Manufacturing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3261",
+      "TME3261"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3263",
+    "name": "Design For Manufacturing And Assembly",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3263E",
+    "name": "Design for Manufacturing and Assembly",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3263",
+      "TME3263"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3281",
+    "name": "Microsystems Design And Applications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME3291",
+    "name": "Numerical Methods In Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1505",
+      "MA1512",
+      "MA1513"
+    ]
+  },
+  {
+    "code": "ME4101",
+    "name": "Bachelor Of Engineering Dissertation",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME4101A",
+    "name": "Bachelor Of Engineering Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME4102",
+    "name": "Standards in Mechanical Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME4103",
+    "name": "Mechanical Engineering and Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME4105",
+    "name": "Specialization Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME4212",
+    "name": "Aircraft Structures",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2114"
+    ]
+  },
+  {
+    "code": "ME4213",
+    "name": "Vibration Theory And Applications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME4223",
+    "name": "Thermal Environmental Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2121",
+      "ME3122"
+    ]
+  },
+  {
+    "code": "ME4223E",
+    "name": "Thermal Environmental Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3223",
+      "TME4223"
+    ],
+    "prerequisites": [
+      "ME2121E",
+      "ME3122E"
+    ]
+  },
+  {
+    "code": "ME4225",
+    "name": "Applied Heat Transfer",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME3122"
+    ]
+  },
+  {
+    "code": "ME4225E",
+    "name": "Applied Heat Transfer",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM4225",
+      "TME4225"
+    ],
+    "prerequisites": [
+      "ME3122E"
+    ]
+  },
+  {
+    "code": "ME4226",
+    "name": "Energy and Thermal Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2121",
+      "ME3122"
+    ]
+  },
+  {
+    "code": "ME4227",
+    "name": "Internal Combustion Engines",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME4231",
+    "name": "Aerodynamics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2134"
+    ]
+  },
+  {
+    "code": "ME4233",
+    "name": "Computational Methods In Fluid Mechanics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2134"
+    ]
+  },
+  {
+    "code": "ME4241",
+    "name": "Aircraft Performance and Stability",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME4245",
+    "name": "Robot Mechanics and Control",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1506",
+      "ME2142",
+      "EE2010",
+      "EE3331C"
+    ]
+  },
+  {
+    "code": "ME4245E",
+    "name": "Robot Mechanics and Control",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM4245",
+      "TME4245"
+    ],
+    "prerequisites": [
+      "ME2142E",
+      "EE2010E",
+      "EE3331E"
+    ]
+  },
+  {
+    "code": "ME4246",
+    "name": "Modern Control System",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2142"
+    ]
+  },
+  {
+    "code": "ME4253",
+    "name": "Biomaterials Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2151"
+    ]
+  },
+  {
+    "code": "ME4255",
+    "name": "Materials Failure",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2151"
+    ]
+  },
+  {
+    "code": "ME4256",
+    "name": "Functional Materials and Devices",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2151",
+      "ME2143"
+    ]
+  },
+  {
+    "code": "ME4256E",
+    "name": "Functional Materials and Devices",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ME4256",
+      "TME4256"
+    ],
+    "prerequisites": [
+      "ME2151E",
+      "ME2143E"
+    ]
+  },
+  {
+    "code": "ME4261",
+    "name": "Tool Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME4261E",
+    "name": "Tool Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM4261",
+      "TME4261"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME4262",
+    "name": "Automation In Manufacturing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2162"
+    ]
+  },
+  {
+    "code": "ME4291",
+    "name": "Finite Element Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1505"
+    ]
+  },
+  {
+    "code": "ME5001",
+    "name": "Mechanical Engineering Project",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5106",
+    "name": "Engineering Acoustics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5161",
+    "name": "Optical Techniques In Experimental Stress Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5205",
+    "name": "Energy Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5207",
+    "name": "Solar Energy Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5300A",
+    "name": "Special Project in Computation and Modelling I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5300B",
+    "name": "Special Project in Computation and Modelling II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME5300A"
+    ]
+  },
+  {
+    "code": "ME5302",
+    "name": "Computational Fluid Mechanics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME2135"
+    ]
+  },
+  {
+    "code": "ME5304",
+    "name": "Experimental Fluid Mechanics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ME4234"
+    ],
+    "prerequisites": [
+      "ME2135"
+    ]
+  },
+  {
+    "code": "ME5309",
+    "name": "Jet and Rocket Propulsion",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ME5308"
+    ],
+    "prerequisites": [
+      "ME2134"
+    ]
+  },
+  {
+    "code": "ME5401",
+    "name": "Linear Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MCH5201",
+      "EE5101",
+      "EE5101R"
+    ],
+    "prerequisites": [
+      "EE4302",
+      "ME4246"
+    ]
+  },
+  {
+    "code": "ME5402",
+    "name": "Advanced Robotics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MCH5209",
+      "EE5106",
+      "EE5106R"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5403",
+    "name": "Computer Control Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5103",
+      "EE5103R",
+      "MCH5103",
+      "TD5241"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5404",
+    "name": "Neural Networks",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE5904",
+      "EE5904R",
+      "MCH5202"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5405",
+    "name": "Machine Vision",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5506",
+    "name": "Corrosion of Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5513",
+    "name": "Fracture And Fatigue Of Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5516",
+    "name": "Emerging Energy Conversion and Storage Technologies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5600A",
+    "name": "Project in Advanced Manufacturing I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME5608",
+      "ME5612",
+      "ME6505"
+    ]
+  },
+  {
+    "code": "ME5600B",
+    "name": "Project in Advanced Manufacturing II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ME5600A"
+    ]
+  },
+  {
+    "code": "ME5608",
+    "name": "Additive and Non-Conventional Manufacturing Processes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ME6605"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5608A",
+    "name": "Principles and Processes of Additive Manufacturing",
+    "creditCount": 2.0,
+    "preclusions": [
+      "ME5608"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5608B",
+    "name": "Hybrid Manufacturing",
+    "creditCount": 2.0,
+    "preclusions": [
+      "ME5608"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5611",
+    "name": "Sustainable Product Design & Manufacturing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5612",
+    "name": "Computer Aided Product Development",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ME6606"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5666",
+    "name": "Industrial Attachment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME5999",
+    "name": "Graduate Seminars",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME6101",
+    "name": "Research Topics In Applied Mechanics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME6205",
+    "name": "Advanced Topics in Heat and Mass Transfer",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ME5202"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ME6303",
+    "name": "Advanced Fluid Dynamics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME6401",
+    "name": "Topics In Mechatronics 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME6504",
+    "name": "Defects & Dislocations In Solids",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME6505",
+    "name": "Engineering Materials in Medicine",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME6604",
+    "name": "Modelling Of Machining Processes",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ME6999",
+    "name": "Doctoral Seminars",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MIC2000",
+    "name": "Infection and Immunology",
+    "creditCount": 3.0,
+    "preclusions": [
+      "MIC1000"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT1003",
+    "name": "Principles of Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC3230",
+      "EC2210",
+      "CS3261",
+      "IC3243",
+      "PR4201",
+      "BK2003",
+      "BZ1003",
+      "BH1003",
+      "MKT1003",
+      "MKT1003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT1003A",
+    "name": "Principles of Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC3230",
+      "EC2210",
+      "CS3261",
+      "IC3243",
+      "PR4201",
+      "BK2003",
+      "BZ1003",
+      "BH1003",
+      "MKT1003",
+      "MKT1003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT1003B",
+    "name": "Principles of Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC3230",
+      "EC2210",
+      "CS3261",
+      "IC3243",
+      "PR4201",
+      "BK2003",
+      "BZ1003",
+      "BH1003",
+      "MKT1003",
+      "MKT1003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT1003C",
+    "name": "Principles of Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC3230",
+      "EC2210",
+      "CS3261",
+      "IC3243",
+      "PR4201",
+      "BK2003",
+      "BZ1003",
+      "BH1003",
+      "MKT1003",
+      "MKT1003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT1003D",
+    "name": "Principles of Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC3230",
+      "EC2210",
+      "CS3261",
+      "IC3243",
+      "PR4201",
+      "BK2003",
+      "BZ1003",
+      "BH1003",
+      "MKT1003",
+      "MKT1003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT1003X",
+    "name": "Principles of Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC3230",
+      "EC2210",
+      "CS3261",
+      "IC3243",
+      "PR4201",
+      "BK2003",
+      "BZ1003",
+      "BH1003",
+      "MKT1003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT1705",
+    "name": "Principles of Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT1003",
+      "MKT1003X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT1705A",
+    "name": "Principles of Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT1003",
+      "MKT1003X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT1705B",
+    "name": "Principles of Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT1003",
+      "MKT1003X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT1705C",
+    "name": "Principles of Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT1003",
+      "MKT1003X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT1705D",
+    "name": "Principles of Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT1003",
+      "MKT1003X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT1705X",
+    "name": "Principles of Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT1003",
+      "MKT1003X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT2401A",
+    "name": "Asian Markets And Marketing Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH2401",
+      "BZ3601",
+      "BK3200",
+      "MKT2401B",
+      "MKT2401"
+    ],
+    "prerequisites": [
+      "MKT1003",
+      "BH1003",
+      "BZ1003",
+      "BK2003"
+    ]
+  },
+  {
+    "code": "MKT2401B",
+    "name": "Asian Markets And Marketing Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH2401",
+      "BZ3601",
+      "BK3200",
+      "MKT2401A",
+      "MKT2401"
+    ],
+    "prerequisites": [
+      "MKT1003",
+      "BH1003",
+      "BZ1003",
+      "BK2003"
+    ]
+  },
+  {
+    "code": "MKT2413",
+    "name": "Marketing Research",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH2413",
+      "BZ3614",
+      "BK3202",
+      "MKT2413A",
+      "MKT2413B"
+    ],
+    "prerequisites": [
+      "MKT1003",
+      "BH1003",
+      "BZ1003",
+      "BK2003"
+    ]
+  },
+  {
+    "code": "MKT2414",
+    "name": "Marketing Venture Challenge",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MKT1003"
+    ]
+  },
+  {
+    "code": "MKT2711",
+    "name": "Marketing Venture Challenge",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MKT1705"
+    ]
+  },
+  {
+    "code": "MKT3401A",
+    "name": "Marketing Strategy: Analysis and Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MKT1003",
+      "MKT1003X"
+    ]
+  },
+  {
+    "code": "MKT3401B",
+    "name": "Marketing Strategy: Analysis and Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MKT1003",
+      "MKT1003X"
+    ]
+  },
+  {
+    "code": "MKT3402",
+    "name": "Consumer Behaviour",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3420",
+      "BZ3605",
+      "BK3203",
+      "MKT3402A",
+      "MKT3402B"
+    ],
+    "prerequisites": [
+      "MKT1003",
+      "BH1003",
+      "BZ1003",
+      "BK2003"
+    ]
+  },
+  {
+    "code": "MKT3402A",
+    "name": "Consumer Behaviour",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3402",
+      "BZ3602",
+      "BK3201",
+      "MKT3402A",
+      "MKT3402B"
+    ],
+    "prerequisites": [
+      "MKT1003",
+      "BH1003",
+      "BZ1003",
+      "BK2003"
+    ]
+  },
+  {
+    "code": "MKT3402B",
+    "name": "Consumer Behaviour",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3402",
+      "BZ3602",
+      "BK3201",
+      "MKT3402A",
+      "MKT3402B"
+    ],
+    "prerequisites": [
+      "MKT1003",
+      "BH1003",
+      "BZ1003",
+      "BK2003"
+    ]
+  },
+  {
+    "code": "MKT3402C",
+    "name": "Consumer Behaviour",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3420",
+      "BZ3605",
+      "BK3203",
+      "MKT3402A",
+      "MKT3402B"
+    ],
+    "prerequisites": [
+      "MKT1003",
+      "BH1003",
+      "BZ1003",
+      "BK2003"
+    ]
+  },
+  {
+    "code": "MKT3412",
+    "name": "Services Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3412",
+      "BH3412A",
+      "BH3412B",
+      "BZ3612",
+      "BK3205",
+      "MKT3412A",
+      "MKT3412B"
+    ],
+    "prerequisites": [
+      "MKT1003",
+      "BH1003",
+      "BZ1003",
+      "BK2003"
+    ]
+  },
+  {
+    "code": "MKT3416",
+    "name": "Business-to-Business Marketing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MKT1003"
+    ]
+  },
+  {
+    "code": "MKT3417",
+    "name": "Customer Relationship Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS4266"
+    ],
+    "prerequisites": [
+      "MKT1003",
+      "MKT1003X"
+    ]
+  },
+  {
+    "code": "MKT3418",
+    "name": "Product And Brand Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3418",
+      "BZ3603",
+      "MKT3418A",
+      "MKT3418B"
+    ],
+    "prerequisites": [
+      "MKT1003",
+      "BH1003",
+      "BZ1003",
+      "BK2003"
+    ]
+  },
+  {
+    "code": "MKT3420",
+    "name": "Advertising & Promotion Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MKT1003",
+      "MKT1003X"
+    ]
+  },
+  {
+    "code": "MKT3426",
+    "name": "Global Marketing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MKT1003",
+      "MKT1003X"
+    ]
+  },
+  {
+    "code": "MKT3428",
+    "name": "Wealth Management Marketing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MKT1003",
+      "MKT1003X"
+    ]
+  },
+  {
+    "code": "MKT3429",
+    "name": "Independent Study in Marketing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT3701A",
+    "name": "Marketing Strategy: Analysis and Practice",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT2401",
+      "RE3704"
+    ],
+    "prerequisites": [
+      "MKT1705",
+      "MKT1705X"
+    ]
+  },
+  {
+    "code": "MKT3701B",
+    "name": "Marketing Strategy: Analysis and Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT3702",
+    "name": "Consumer Behaviour",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT3402"
+    ],
+    "prerequisites": [
+      "MKT1705",
+      "MKT1705X"
+    ]
+  },
+  {
+    "code": "MKT3711",
+    "name": "Services Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT3412"
+    ],
+    "prerequisites": [
+      "MKT1705",
+      "MKT1705X"
+    ]
+  },
+  {
+    "code": "MKT3715",
+    "name": "Business-to-Business Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT3416"
+    ],
+    "prerequisites": [
+      "MKT1705",
+      "MKT1705X"
+    ]
+  },
+  {
+    "code": "MKT3717",
+    "name": "Product & Brand Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT3418"
+    ],
+    "prerequisites": [
+      "MKT1705",
+      "MKT1705X"
+    ]
+  },
+  {
+    "code": "MKT3718",
+    "name": "Advertising & Promotion Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT3420",
+      "NM3215"
+    ],
+    "prerequisites": [
+      "MKT1705",
+      "MKT1705X"
+    ]
+  },
+  {
+    "code": "MKT3721",
+    "name": "Global Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT2412"
+    ],
+    "prerequisites": [
+      "MKT1705",
+      "MKT1705X"
+    ]
+  },
+  {
+    "code": "MKT3761A",
+    "name": "TIM: Wealth Management Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT3422A",
+      "MKT3428"
+    ],
+    "prerequisites": [
+      "MKT1705",
+      "MKT1705X"
+    ]
+  },
+  {
+    "code": "MKT4412",
+    "name": "Marketing Theory: Cultivating Critical Thinking",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MKT2401",
+      "MKT2401A",
+      "MKT2401B"
+    ]
+  },
+  {
+    "code": "MKT4413",
+    "name": "Pricing Strategy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MKT2401"
+    ]
+  },
+  {
+    "code": "MKT4417",
+    "name": "Consumer Decision Making",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT4419",
+    "name": "Advanced Independent Study in Marketing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MKT4420",
+    "name": "Marketing Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MKT2401"
+    ]
+  },
+  {
+    "code": "MKT4712",
+    "name": "Marketing Theory: Cultivating Critical Thinking",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT4412"
+    ],
+    "prerequisites": [
+      "MKT3701",
+      "RE3704"
+    ]
+  },
+  {
+    "code": "MKT4714",
+    "name": "Consumer Decision Making",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT4417"
+    ],
+    "prerequisites": [
+      "BSP1703",
+      "BSP1707",
+      "EC1101E",
+      "EC1301",
+      "MKT3701",
+      "RE3704"
+    ]
+  },
+  {
+    "code": "MKT4811",
+    "name": "Pricing Strategy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT4413"
+    ],
+    "prerequisites": [
+      "MKT3701",
+      "RE3704"
+    ]
+  },
+  {
+    "code": "MKT4812",
+    "name": "Marketing Analytics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT4415C",
+      "MKT4420"
+    ],
+    "prerequisites": [
+      "MKT3701",
+      "RE3704"
+    ]
+  },
+  {
+    "code": "MLE1001",
+    "name": "Materials Science & Engrg Principles & Practice I",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MLE1002",
+    "name": "Materials Science & Engineering Principles & Practice II",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MLE2101",
+    "name": "Introduction to Structure of Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC1221",
+      "PC1222",
+      "MLE1111",
+      "MLE1001",
+      "MLE1002"
+    ]
+  },
+  {
+    "code": "MLE2102",
+    "name": "Thermodynamics and Phase Diagrams",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC1221",
+      "PC1222",
+      "MLE1111",
+      "MLE1001",
+      "MLE1002"
+    ]
+  },
+  {
+    "code": "MLE2103",
+    "name": "Phase Transformation and Kinetics",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE2102",
+      "MLE1111",
+      "MLE1001",
+      "MLE1002"
+    ]
+  },
+  {
+    "code": "MLE2104",
+    "name": "Mechanical Properties of Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EG1109FC",
+      "EG1109",
+      "MLE1101",
+      "MLE2101",
+      "MLE1111",
+      "MLE1001",
+      "MLE1002"
+    ]
+  },
+  {
+    "code": "MLE2105",
+    "name": "Electronic Properties of Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE1001",
+      "MLE1002",
+      "MLE1101",
+      "MLE2101",
+      "MLE1111"
+    ]
+  },
+  {
+    "code": "MLE2111",
+    "name": "Materials Properties Laboratory",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE1101",
+      "MLE1111",
+      "PC1221",
+      "PC1222",
+      "MLE1001",
+      "MLE1002"
+    ]
+  },
+  {
+    "code": "MLE3101",
+    "name": "Materials Characterization Laboratory",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE1101",
+      "MLE2101",
+      "MLE1001",
+      "MLE1002"
+    ]
+  },
+  {
+    "code": "MLE3102",
+    "name": "Degradation and Failure of Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE1101",
+      "MLE2102",
+      "MLE1111",
+      "MLE1001",
+      "MLE1002"
+    ]
+  },
+  {
+    "code": "MLE3103",
+    "name": "Materials Design and Selection",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE1101",
+      "MLE2104",
+      "MLE1001",
+      "MLE1002"
+    ]
+  },
+  {
+    "code": "MLE3104",
+    "name": "Polymeric and Composite Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE1101",
+      "CM1121",
+      "CM1501",
+      "MLE1111",
+      "MLE1001",
+      "MLE1002"
+    ]
+  },
+  {
+    "code": "MLE3105",
+    "name": "Dielectric and Magnetic Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE1101",
+      "MLE2105",
+      "MLE1111",
+      "MLE1001",
+      "MLE1002"
+    ]
+  },
+  {
+    "code": "MLE3111",
+    "name": "Materials Processing Laboratory",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE2101",
+      "MLE2111"
+    ]
+  },
+  {
+    "code": "MLE3202",
+    "name": "Materials for Biointerfaces",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE1101",
+      "MLE1111",
+      "MLE1001",
+      "MLE1002"
+    ]
+  },
+  {
+    "code": "MLE3203",
+    "name": "Engineering Materials",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MLE2106",
+      "MLE2107"
+    ],
+    "prerequisites": [
+      "MLE1111",
+      "MLE1001",
+      "MLE2102",
+      "MLE1002"
+    ]
+  },
+  {
+    "code": "MLE4101",
+    "name": "B.Eng. Dissertation",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE2103",
+      "MLE2104",
+      "MLE2105",
+      "MLE3101"
+    ]
+  },
+  {
+    "code": "MLE4101A",
+    "name": "BEng Dissertation",
+    "creditCount": 6.0,
+    "preclusions": [
+      "MLE4101"
+    ],
+    "prerequisites": [
+      "MLE2103",
+      "MLE2104",
+      "MLE3101"
+    ]
+  },
+  {
+    "code": "MLE4101R",
+    "name": "Integrated B.ENG./B.SC. (Hons) Dissertation",
+    "creditCount": 16.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE2103",
+      "MLE2104",
+      "MLE2105",
+      "MLE3101"
+    ]
+  },
+  {
+    "code": "MLE4102",
+    "name": "Design Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE2103"
+    ]
+  },
+  {
+    "code": "MLE4201",
+    "name": "Advanced Materials Characterisation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE3101"
+    ]
+  },
+  {
+    "code": "MLE4202",
+    "name": "Selected Advanced Topics on Polymers",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE3104"
+    ]
+  },
+  {
+    "code": "MLE4203",
+    "name": "Polymeric Biomedical Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE3104",
+      "BN3301"
+    ]
+  },
+  {
+    "code": "MLE4205",
+    "name": "Theory and Modelling of Materials Properties",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE2101"
+    ]
+  },
+  {
+    "code": "MLE4206",
+    "name": "Current topics on Nanomaterials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE2104",
+      "MLE2105"
+    ]
+  },
+  {
+    "code": "MLE4207",
+    "name": "Growth Aspects Of Semiconductors",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4436"
+    ],
+    "prerequisites": [
+      "MLE2101"
+    ]
+  },
+  {
+    "code": "MLE4208",
+    "name": "Photovoltaics Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE2105",
+      "EE3406"
+    ]
+  },
+  {
+    "code": "MLE4210",
+    "name": "Materials for energy storage and conversion",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE2107",
+      "MLE2105"
+    ]
+  },
+  {
+    "code": "MLE4212",
+    "name": "Advanced Structural Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MLE3102",
+      "MLE3203",
+      "MLE2106"
+    ]
+  },
+  {
+    "code": "MLE5104",
+    "name": "Physical Properties Of Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MLE5301",
+    "name": "Metallic & Ceramic Materials in Additive Manufacturing",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MLE5666",
+    "name": "Industrial Attachment Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MLE5999",
+    "name": "Graduate Seminars",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MLE6101",
+    "name": "Thermodynamics And Kinetics Of Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MLE6103",
+    "name": "Structures Of Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MLE6999",
+    "name": "Doctoral Seminars",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MNO1001",
+    "name": "Management And Organisation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BE2106",
+      "EG1423",
+      "CS1303",
+      "BK2002",
+      "BZ1001",
+      "BH1001",
+      "MNO1001",
+      "HR2001",
+      "HR2101",
+      "HR3111",
+      "HR3308",
+      "MNO1001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MNO1001A",
+    "name": "Management And Organisation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BE2106",
+      "EG1423",
+      "CS1303",
+      "BK2002",
+      "BZ1001",
+      "BH1001",
+      "MNO1001",
+      "HR2001",
+      "HR2101",
+      "HR3111",
+      "HR3308",
+      "MNO1001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MNO1001B",
+    "name": "Management And Organisation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BE2106",
+      "EG1423",
+      "CS1303",
+      "BK2002",
+      "BZ1001",
+      "BH1001",
+      "MNO1001",
+      "HR2001",
+      "HR2101",
+      "HR3111",
+      "HR3308",
+      "MNO1001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MNO1001C",
+    "name": "Management And Organisation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BE2106",
+      "EG1423",
+      "CS1303",
+      "BK2002",
+      "BZ1001",
+      "BH1001",
+      "MNO1001",
+      "HR2001",
+      "HR2101",
+      "HR3111",
+      "HR3308",
+      "MNO1001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MNO1001D",
+    "name": "Management And Organisation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BE2106",
+      "EG1423",
+      "CS1303",
+      "BK2002",
+      "BZ1001",
+      "BH1001",
+      "MNO1001",
+      "HR2001",
+      "HR2101",
+      "HR3111",
+      "HR3308",
+      "MNO1001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MNO1001X",
+    "name": "Management And Organisation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BE2106",
+      "EG1423",
+      "CS1303",
+      "BK2002",
+      "BZ1001",
+      "BH1001",
+      "MNO1001",
+      "HR2001",
+      "HR2101",
+      "HR3111",
+      "HR3308",
+      "MNO1001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MNO1706A",
+    "name": "Organisational Behavior",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MNO1001",
+      "MNO1001X",
+      "PL3239"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MNO1706B",
+    "name": "Organisational Behavior",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MNO1001",
+      "MNO1001X",
+      "PL3239"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MNO1706C",
+    "name": "Organisational Behavior",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MNO1001",
+      "MNO1001X",
+      "PL3239"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MNO1706D",
+    "name": "Organisational Behavior",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MNO1001",
+      "MNO1001X",
+      "PL3239"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MNO1706X",
+    "name": "Organisational Behavior",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MNO1001",
+      "MNO1001X",
+      "PL3239"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MNO2007",
+    "name": "Leadership and Ethics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MNO1001"
+    ]
+  },
+  {
+    "code": "MNO2009",
+    "name": "Entrepreneurship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MNO1001"
+    ]
+  },
+  {
+    "code": "MNO2302",
+    "name": "Human Resource Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH2302",
+      "BZ3504",
+      "BK3300",
+      "MNO2302A",
+      "PL3239",
+      "PS3245"
+    ],
+    "prerequisites": [
+      "MNO1001",
+      "BH1001",
+      "BZ1001",
+      "BK2002",
+      "HR2001",
+      "HR2101",
+      "HR3111",
+      "HR3308"
+    ]
+  },
+  {
+    "code": "MNO2705A",
+    "name": "Leadership and Decision Making under Uncertainty",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MNO1706",
+      "MNO1706X",
+      "PL3239"
+    ]
+  },
+  {
+    "code": "MNO2705B",
+    "name": "Leadership and Decision Making under Uncertainty",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MNO1706",
+      "MNO1706X",
+      "PL3239"
+    ]
+  },
+  {
+    "code": "MNO2705C",
+    "name": "Leadership and Decision Making under Uncertainty",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MNO1706",
+      "MNO1706X",
+      "PL3239"
+    ]
+  },
+  {
+    "code": "MNO2706",
+    "name": "Business Communication for Leaders (ACC)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ES2002"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "MNO2706"
+    ]
+  },
+  {
+    "code": "MNO3301",
+    "name": "Organisational Behaviour",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3301",
+      "BZ3501",
+      "BK3309M",
+      "PS3243"
+    ],
+    "prerequisites": [
+      "MNO1001",
+      "BH1001",
+      "BZ1001",
+      "BK2002",
+      "HR2001",
+      "HR2101",
+      "HR3111",
+      "HR3308"
+    ]
+  },
+  {
+    "code": "MNO3303",
+    "name": "Organisational Effectiveness",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3303",
+      "BZ3502",
+      "BK4309D",
+      "BK3309N"
+    ],
+    "prerequisites": [
+      "MNO1001",
+      "BH1001",
+      "BZ1001",
+      "BK2002",
+      "HR2001",
+      "HR2101",
+      "HR3111",
+      "HR3308"
+    ]
+  },
+  {
+    "code": "MNO3313J",
+    "name": "TILHCM: Employee and Organizational Misbehaviours",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MNO1001"
+    ]
+  },
+  {
+    "code": "MNO3320",
+    "name": "Managing Change",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH3313A",
+      "BZ3503",
+      "BK3305"
+    ],
+    "prerequisites": [
+      "MNO1001",
+      "MNO2007",
+      "AY2009",
+      "MNO2007"
+    ]
+  },
+  {
+    "code": "MNO3323",
+    "name": "Management of Employee Relations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MNO1001",
+      "MNO2007",
+      "AY2009",
+      "MNO2007"
+    ]
+  },
+  {
+    "code": "MNO3329",
+    "name": "Independent Study in Leadership & Human Capital Mgmt",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MNO3330",
+    "name": "Social Entrepreneurship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MNO3333",
+    "name": "Human Capital Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MNO2302"
+    ],
+    "prerequisites": [
+      "MNO1706",
+      "MNO2705"
+    ]
+  },
+  {
+    "code": "MNO3701",
+    "name": "Human Capital Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MNO2302"
+    ],
+    "prerequisites": [
+      "MNO1706",
+      "MNO1706X",
+      "PL3239"
+    ]
+  },
+  {
+    "code": "MNO3711",
+    "name": "Managing Change",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MNO3320"
+    ],
+    "prerequisites": [
+      "MNO1706",
+      "MNO1706X",
+      "PL3239"
+    ]
+  },
+  {
+    "code": "MNO3713",
+    "name": "Management of Employee Relations",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MNO3323"
+    ],
+    "prerequisites": [
+      "MNO1706",
+      "MNO1706X",
+      "PL3239"
+    ]
+  },
+  {
+    "code": "MNO3811",
+    "name": "Social Entrepreneurship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MNO3330"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MNO4313J",
+    "name": "SILHCM: Talent Development and Performing with Impact",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MNO1706",
+      "MNO1706X"
+    ]
+  },
+  {
+    "code": "MNO4314",
+    "name": "Consulting to Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MNO1001",
+      "MNO2007"
+    ]
+  },
+  {
+    "code": "MNO4319",
+    "name": "Adv Independent Study in Leadership & Human Capital Mgt",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS1102E",
+    "name": "Malays - Tradition, Conflict and Change",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MS1101E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MS2210",
+    "name": "Malay Culture & Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS2211",
+    "name": "Criticism in Modern Malay Literature",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS2212",
+    "name": "Law and Malay Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS2213",
+    "name": "Malay Families and Households",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS2215",
+    "name": "The Malays in History",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS3209",
+    "name": "The Malays of Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA3203"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MS3211",
+    "name": "Political Culture of the Malays",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS3212",
+    "name": "Classical Malay Literature",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS3213",
+    "name": "Ideology & Ideas on Malay Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS3216",
+    "name": "Gender in Malay Societies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS3218",
+    "name": "The Religious Life of the Malays",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MS4203"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MS3550",
+    "name": "Malay Studies Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3550"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MS4101",
+    "name": "Theory and Practice in Malay Studies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS4201",
+    "name": "Social Change in the Malay World 1900-1965",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS4204",
+    "name": "The Malay Middle Class",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "MS4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MS4660",
+    "name": "Independent Study Module",
+    "creditCount": 5.0,
+    "preclusions": [
+      "MS4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MS4880A",
+    "name": "Orientations in Muslim Resurgence Movements",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS4880B",
+    "name": "Malays Encountering Globalization: Culture and Identity",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS5101",
+    "name": "Social Science And Malay Studies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS5201",
+    "name": "Critiques In Malay Studies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS5660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MS6660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MS6201",
+    "name": "Literature and Art in Malay Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS6660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MS6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MST5001",
+    "name": "Structures And Properties Of Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MST5002",
+    "name": "Materials Characterisation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT3001",
+    "name": "Systems Thinking and Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT4001",
+    "name": "Innovation and Entrepreneurial Strategy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT4002",
+    "name": "Technology Management Strategy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT4003",
+    "name": "Engineering Product Development",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TR3001",
+      "EE3031"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5001",
+    "name": "IP Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5002",
+    "name": "Management of Industrial R&D",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5003",
+    "name": "Creativity And Innovation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5006",
+    "name": "Strategic & New Product Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5007",
+    "name": "Management Of Technological Innovation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5008",
+    "name": "Corporate Entrepreneurship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5010",
+    "name": "Technology Forecasting & Intelligence",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MT5010A",
+      "MT5010B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5011",
+    "name": "Engineering Business Finance Fundamentals",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5012",
+    "name": "Marketing Of High-Technology Products And Innovations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5900",
+    "name": "Mot Research Project",
+    "creditCount": 8.0,
+    "preclusions": [
+      "MT5910",
+      "SDM5990"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5901",
+    "name": "Management Practicum",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5902",
+    "name": "Management Extended Practicum",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5911",
+    "name": "Venture Funding",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5912",
+    "name": "Frugal Innovation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5913",
+    "name": "TechLaunch - Experiential Entrepreneurship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5920",
+    "name": "Enterprise Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT5999",
+    "name": "Graduate Seminars",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MT6999",
+    "name": "Doctoral Seminars",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1101",
+    "name": "Composition Major Study 1A",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1107",
+    "name": "Large Ensembles 1A",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1109",
+    "name": "Foundations for String Chamber Music",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1111",
+    "name": "Piano Ensemble 1A",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1112",
+    "name": "Piano Ensemble 1B",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1115",
+    "name": "Foundations of Vocal Accompaniment / Sight-Reading",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1149",
+    "name": "Practical Skills for the Versatile Percussionist A",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1153",
+    "name": "Noon Recital Series 1A",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1154",
+    "name": "Noon Recital Series 1B",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1157",
+    "name": "Solfege 1",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1161",
+    "name": "Major Study 1A",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1162",
+    "name": "Major Study 1B",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA1161"
+    ]
+  },
+  {
+    "code": "MUA1163",
+    "name": "The Profession of Music 1",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1165",
+    "name": "Music and Machines",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1170",
+    "name": "Fundamentals of Music Production and Recording 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1172",
+    "name": "Critical Listening 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1190",
+    "name": "Applied Voice Major Study 1A",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1192",
+    "name": "Chamber Singers 1",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1193",
+    "name": "Chamber Singers 2",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1196",
+    "name": "Diction for Singers 1",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1201",
+    "name": "Rudiments of Musicianship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA1270",
+    "name": "Interdisciplinary Electronic Arts Survey",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2101",
+    "name": "Composition Major Study 2A",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2107",
+    "name": "Large Ensembles 2A",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2109",
+    "name": "Chamber Music",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MUA1116"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2110",
+    "name": "Chamber Music in Mixed Ensemble",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MUA1116"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2131",
+    "name": "Contemporary Music Performance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2153",
+    "name": "Noon Recital Series 2A",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2154",
+    "name": "Noon Recital Series 2B",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2161",
+    "name": "Major Study 2A",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA1162"
+    ]
+  },
+  {
+    "code": "MUA2162",
+    "name": "Major Study 2B",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2161"
+    ]
+  },
+  {
+    "code": "MUA2163",
+    "name": "Leading and Guiding Through Music",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2170",
+    "name": "Multitrack Recording 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2172",
+    "name": "Room Acoustics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2175",
+    "name": "RAS Project 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2176",
+    "name": "RAS Project 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2175"
+    ]
+  },
+  {
+    "code": "MUA2182",
+    "name": "Percussion Audition Techniques 2A",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA1150"
+    ]
+  },
+  {
+    "code": "MUA2184",
+    "name": "Orchestral Repertoire for Double Bass 2A",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA1107"
+    ]
+  },
+  {
+    "code": "MUA2186",
+    "name": "Orchestral Repertoire for Harp 2A",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA1107"
+    ]
+  },
+  {
+    "code": "MUA2190",
+    "name": "Applied Voice Major Study 2A",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2191",
+    "name": "Applied Voice Major Study 2B",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2192",
+    "name": "Chambers Singers 3",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2193",
+    "name": "Chambers Singers 4",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2201",
+    "name": "Keyboard Literature I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2205",
+    "name": "Rhythmical Devices in Performance",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2206",
+    "name": "Harmonic Hearing for Performers",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2208",
+    "name": "Advanced Contemporary Music Performance",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2209",
+    "name": "Advanced Contemporary Music Performance",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2240",
+    "name": "Collaborative Piano - Piano Ensemble",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MUA2155"
+    ],
+    "prerequisites": [
+      "MUA1112"
+    ]
+  },
+  {
+    "code": "MUA2241",
+    "name": "Collaborative Piano - Vocal Accompaniment",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MUA2155",
+      "MUA2242",
+      "MUA2243"
+    ],
+    "prerequisites": [
+      "MUA1115"
+    ]
+  },
+  {
+    "code": "MUA2242",
+    "name": "Collaborative Piano - Instrumental Accompaniment",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MUA2155",
+      "MUA2241",
+      "MUA2243"
+    ],
+    "prerequisites": [
+      "MUA1116"
+    ]
+  },
+  {
+    "code": "MUA2243",
+    "name": "Collaborative Piano - Chamber Music",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MUA2155",
+      "MUA2241",
+      "MUA2242"
+    ],
+    "prerequisites": [
+      "MUA1116"
+    ]
+  },
+  {
+    "code": "MUA2255",
+    "name": "Applied Secondary A",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2256",
+    "name": "Applied Secondary B",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2270",
+    "name": "Synthesis and Signal Processing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA2271",
+    "name": "Virtual Instrument Sound Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3101",
+    "name": "Composition Major Study 3A",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3107",
+    "name": "Large Ensembles 3A",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3109",
+    "name": "Chamber Music",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2109"
+    ]
+  },
+  {
+    "code": "MUA3110",
+    "name": "Chamber Music in Mixed Ensemble",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2110"
+    ]
+  },
+  {
+    "code": "MUA3113",
+    "name": "Keyboard Skills For Piano Majors III",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3116",
+    "name": "Pedagogy for Orchestral Instrumentalists",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3131",
+    "name": "Orchestral Excerpts for Strings 3A",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3153",
+    "name": "Noon Recital Series 3A",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3154",
+    "name": "Noon Recital Series 3B",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3161",
+    "name": "Major Study 3A",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2162"
+    ]
+  },
+  {
+    "code": "MUA3162",
+    "name": "Major Study 3B",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA3161"
+    ]
+  },
+  {
+    "code": "MUA3163",
+    "name": "Musical Pathways",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3164",
+    "name": "Career Development Project",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3170",
+    "name": "Audio Postproduction I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2171"
+    ]
+  },
+  {
+    "code": "MUA3175",
+    "name": "AAS Project 3",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2176"
+    ]
+  },
+  {
+    "code": "MUA3176",
+    "name": "RAS Project 4",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA3175"
+    ]
+  },
+  {
+    "code": "MUA3177",
+    "name": "Music Programming & Production",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2163"
+    ]
+  },
+  {
+    "code": "MUA3178",
+    "name": "MS / MCP 3rd Year Project",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3179",
+    "name": "Capstone Project for Second Major in Music",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3181",
+    "name": "Advanced Concepts in Orchestral Repertoire I",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2181"
+    ]
+  },
+  {
+    "code": "MUA3182",
+    "name": "Percussion Audition Techniques 3A",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2183"
+    ]
+  },
+  {
+    "code": "MUA3184",
+    "name": "Orchestral Repertoire for Double Bass 3A",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2120"
+    ]
+  },
+  {
+    "code": "MUA3188",
+    "name": "Live Sound Reinforcement",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2170",
+      "MUA2171"
+    ]
+  },
+  {
+    "code": "MUA3191",
+    "name": "Junior Recital in Voice",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3194",
+    "name": "Voice Literature 1",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3201",
+    "name": "Advanced Contemporary Music Performance",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3205",
+    "name": "Jazz Study and Performance 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUT2118"
+    ]
+  },
+  {
+    "code": "MUA3216",
+    "name": "Performance and Communication",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3218",
+    "name": "Introduction to Piano Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3221",
+    "name": "Intensive Music Engagement Practicum",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3222",
+    "name": "SEAsian Regional Creative Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3224",
+    "name": "Intermediate Keyboard Studies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3226",
+    "name": "Collaboratory",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3228",
+    "name": "Analysis from a Keyboard Perspective",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3230",
+    "name": "Music Cognition",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E"
+    ]
+  },
+  {
+    "code": "MUA3240",
+    "name": "Collaborative Piano - Piano Ensemble",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2240",
+      "MUA2155"
+    ]
+  },
+  {
+    "code": "MUA3241",
+    "name": "Collaborative Piano - Vocal Accompaniment",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2241",
+      "MUA2155",
+      "MUA2242",
+      "MUA2243"
+    ]
+  },
+  {
+    "code": "MUA3242",
+    "name": "Collaborative Piano - Instrumental Accompaniment",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2242",
+      "MUA2155",
+      "MUA2241",
+      "MUA2243"
+    ]
+  },
+  {
+    "code": "MUA3243",
+    "name": "Collaborative Piano - Chamber Music",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA2243",
+      "MUA2155",
+      "MUA2241",
+      "MUA2242"
+    ]
+  },
+  {
+    "code": "MUA3255",
+    "name": "Applied Secondary C",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3256",
+    "name": "Applied Secondary D",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3260",
+    "name": "Internship in Music Related Pathways",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3261",
+    "name": "Career Development Group Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3264",
+    "name": "Career Development Independent Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA3271",
+    "name": "Acoustics and Sound Production for Performers",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA4101",
+    "name": "Composition Major Study 4A",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA3102"
+    ]
+  },
+  {
+    "code": "MUA4107",
+    "name": "Large Ensembles 4A",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA4108",
+    "name": "Leadership Skills in an Orchestral Context",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA4109",
+    "name": "Chamber Music",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA3109"
+    ]
+  },
+  {
+    "code": "MUA4110",
+    "name": "Chamber Music in Mixed Ensemble",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA3110"
+    ]
+  },
+  {
+    "code": "MUA4113",
+    "name": "Piano Pedagogy A",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA4153",
+    "name": "Noon Recital Series 4A",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA4154",
+    "name": "Noon Recital Series 4B",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA4161",
+    "name": "Major Study 4A",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA3162"
+    ]
+  },
+  {
+    "code": "MUA4171",
+    "name": "Audio for Media",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA4172",
+    "name": "Internship in Audio Arts and Sciences 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA4175",
+    "name": "RAS Final Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA3176"
+    ]
+  },
+  {
+    "code": "MUA4176",
+    "name": "Music Production and Marketing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA1170",
+      "MUA1171",
+      "MUA2170",
+      "MUA2170"
+    ]
+  },
+  {
+    "code": "MUA4181",
+    "name": "Advanced Concepts in Orchestral Repertoire II",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA3181"
+    ]
+  },
+  {
+    "code": "MUA4190",
+    "name": "Applied Voice Major Study 4A",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA4191",
+    "name": "Senior Recital in Voice",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA4203",
+    "name": "Advanced Conducting I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA3163"
+    ]
+  },
+  {
+    "code": "MUA4205",
+    "name": "Advanced Conducting II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA4203",
+      "MUA4204"
+    ]
+  },
+  {
+    "code": "MUA4231",
+    "name": "Orchestral Excerpts for Strings 4A",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA5115",
+    "name": "Ensemble Study 5A",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA5116",
+    "name": "Ensemble Study 5B",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA5115"
+    ]
+  },
+  {
+    "code": "MUA5161",
+    "name": "Major Study 5A",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA5162",
+    "name": "Major Study 5B",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUA6115",
+    "name": "Ensemble Study 6A",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA5116"
+    ]
+  },
+  {
+    "code": "MUA6116",
+    "name": "Ensemble Study 6B",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA6115"
+    ]
+  },
+  {
+    "code": "MUA6161",
+    "name": "Major Study 6A",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA5162"
+    ]
+  },
+  {
+    "code": "MUA6162",
+    "name": "Major Study 6B",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUA6161"
+    ]
+  },
+  {
+    "code": "MUH1100",
+    "name": "Understanding and Describing Music",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUH1101",
+    "name": "Foundations for Musical Discovery",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUH2201",
+    "name": "Classical Styles and Romantic Spirits",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUH2203",
+    "name": "Music of the Church and State",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUH4204",
+    "name": "Music History for Post-Graduate Placement",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUL1105",
+    "name": "Italian for Singers I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUL1107",
+    "name": "French for Singers 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUL1109",
+    "name": "German for Singers 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUT1101",
+    "name": "Introduction to Musical Concepts and Materials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUT1201",
+    "name": "Introduction to Classical Music Composition",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUT2204",
+    "name": "Formal Practices",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUT1101"
+    ]
+  },
+  {
+    "code": "MUT2205",
+    "name": "Text and Music",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUT1101"
+    ]
+  },
+  {
+    "code": "MUT3113",
+    "name": "Orchestration A",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUT3201",
+    "name": "Modern Music",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUT2118"
+    ]
+  },
+  {
+    "code": "MUT3214",
+    "name": "Concerto and Cadenza",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUT1101"
+    ]
+  },
+  {
+    "code": "MUT3215",
+    "name": "Fundamentals of Composition",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUT1121"
+    ]
+  },
+  {
+    "code": "MUT3221",
+    "name": "Writing for Chinese Ensembles",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUT3224",
+    "name": "Teaching Music Online",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MUT4201",
+    "name": "Graduate Theory Preparation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MUT1101"
+    ]
+  },
+  {
+    "code": "MW5200",
+    "name": "MSc Science Communication Project",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MW5201",
+    "name": "Topics in Science Communication",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MW5202",
+    "name": "Innovations in Science Teaching",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "MW5203",
+    "name": "Frontier Topics in Science",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM1101E",
+    "name": "Communications, New Media and Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM1101X",
+    "name": "Communications, New Media and Society",
+    "creditCount": 4.0,
+    "preclusions": [
+      "NM1101E",
+      "NM1101FC"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM2101",
+    "name": "Theories of Communications and New Media",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "NM1101E",
+      "NM1101E"
+    ]
+  },
+  {
+    "code": "NM2103",
+    "name": "Quantitative Research Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM2104",
+    "name": "Qualitative Communication Research Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM2201",
+    "name": "Intercultural Communication",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM2203",
+    "name": "Social Media in Communication Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM2207",
+    "name": "Computational Media Literacy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM2207Y",
+    "name": "Computational Media Literacy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "NM2207"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM2208",
+    "name": "Principles of Visual Communication",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM2209",
+    "name": "Social Psychology of New Media",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM2212",
+    "name": "Visual Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM2213",
+    "name": "Introduction to Human-Computer Interaction Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM2219",
+    "name": "Principles of Communication Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM2219Y",
+    "name": "Principles of Communication Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "NM2219"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM2220",
+    "name": "Introduction to Media Writing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM2302",
+    "name": "Mobility and New Media",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM2303",
+    "name": "Fake News, Lies and Spin: How to Sift Fact from Fiction",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3203",
+    "name": "Copyright and New Media",
+    "creditCount": 4.0,
+    "preclusions": [
+      "NM3880A"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3210",
+    "name": "Cybercrime and Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3211",
+    "name": "News Reporting and Editing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "NM2221"
+    ],
+    "prerequisites": [
+      "NM2220"
+    ]
+  },
+  {
+    "code": "NM3215",
+    "name": "Advertising Strategies",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MKT3420"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3216",
+    "name": "Game Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3217",
+    "name": "Design for Strategic Communications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3219",
+    "name": "Writing for Communication Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3222",
+    "name": "Interactive Storytelling",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3230",
+    "name": "Photographic and Video Storytelling",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3232",
+    "name": "Strategic Communication: Concepts",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3232Y",
+    "name": "Strategic Communication: Conce",
+    "creditCount": 4.0,
+    "preclusions": [
+      "NM3232"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3233",
+    "name": "Strategic Communication: Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "NM3220"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3237",
+    "name": "Health Communication",
+    "creditCount": 4.0,
+    "preclusions": [
+      "NM4880D",
+      "NM4220"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3237Y",
+    "name": "Health Communication",
+    "creditCount": 4.0,
+    "preclusions": [
+      "NM3237"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3240",
+    "name": "Digital Media and Political Communication",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3550Y",
+    "name": "Communications & New Media Internship",
+    "creditCount": 12.0,
+    "preclusions": [
+      "NM3550",
+      "INM3550"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM3551",
+    "name": "FASS Undergraduate Research Opportunity (UROP)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4102",
+    "name": "Advanced Communications & New Media Research",
+    "creditCount": 5.0,
+    "preclusions": [
+      "NM4101"
+    ],
+    "prerequisites": [
+      "NM2102",
+      "NM2103",
+      "NM2104",
+      "NM2101",
+      "NM2103",
+      "NM2104"
+    ]
+  },
+  {
+    "code": "NM4203",
+    "name": "Infocomm Technology Policy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "IF5203",
+      "NM5203",
+      "NM5203R"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4204",
+    "name": "Media Ethics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4206",
+    "name": "Media and Communications Regulation",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4209",
+    "name": "Advanced Game Design",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4210",
+    "name": "User Experience Design",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4219",
+    "name": "New Media in Health Communication",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4221",
+    "name": "Writing for Health Communication and New Media",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4225",
+    "name": "Design Fiction",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4227",
+    "name": "Playable Art",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4230",
+    "name": "Communication for Social Change",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4231",
+    "name": "Advanced Photographic and Video Storytelling",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "NM3230"
+    ]
+  },
+  {
+    "code": "NM4238",
+    "name": "Software Studies",
+    "creditCount": 5.0,
+    "preclusions": [
+      "NM3238"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4239",
+    "name": "Digital Propaganda and Public Opinion",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "NM4660"
+    ],
+    "prerequisites": [
+      "NM4101",
+      "NM4102",
+      "NM4101",
+      "NM4102"
+    ]
+  },
+  {
+    "code": "NM4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "NM4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4881A",
+    "name": "Topics in Media Studies: Social Media",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4881B",
+    "name": "Postcolonial Approaches to Media and Communication",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4881D",
+    "name": "Media, Rhetoric, and the Public Sphere",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4881E",
+    "name": "Photography, Visual Rhetoric, and Public Culture",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4883D",
+    "name": "New Media Production and Public Engagement",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM4883F",
+    "name": "Financial Journalism",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "NM2220"
+    ]
+  },
+  {
+    "code": "NM5204",
+    "name": "Computer-Mediated Environments",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IF5204"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM5204R",
+    "name": "Computer-Mediated Environments",
+    "creditCount": 5.0,
+    "preclusions": [
+      "IF5204"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM5660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IF5660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM6101",
+    "name": "Advanced Theories In Cnm",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM6103",
+    "name": "Quantitative Research Methods in Communications and New Media",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM6104",
+    "name": "Qualitative Research Methods in Communications and New Media",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NM6660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IF6660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NM6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR1107A",
+    "name": "Nursing Practice Experience 1.1",
+    "creditCount": 2.0,
+    "preclusions": [
+      "NUR1107"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR1110",
+    "name": "Effective Communication for Health Professionals",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR1114",
+    "name": "Fundamentals of Nursing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR1117",
+    "name": "Anatomy and Physiology I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "AY1104",
+      "PY1105",
+      "PY1106"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR1118",
+    "name": "Anatomy and Physiology II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "AY1104",
+      "PY1105",
+      "PY1106"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR1119",
+    "name": "Medical-Surgical Nursing I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "NUR2114"
+    ],
+    "prerequisites": [
+      "NUR1114",
+      "NUR1108"
+    ]
+  },
+  {
+    "code": "NUR1121",
+    "name": "Pathophysiology and Pharmacology for Nurses I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "NUR2117"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR1122C",
+    "name": "Health Assessment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR1201C",
+    "name": "Health Continuum for Older Adults",
+    "creditCount": 4.0,
+    "preclusions": [
+      "NUR1113"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR1202C",
+    "name": "Clinical Experience I",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR2106A",
+    "name": "Nursing Practice Experience 2.1",
+    "creditCount": 2.0,
+    "preclusions": [
+      "NUR2106"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR2107A",
+    "name": "Nursing Practice Experience 2.2",
+    "creditCount": 8.0,
+    "preclusions": [
+      "NUR2107"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR2113",
+    "name": "Mental Health Nursing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "NUR1116"
+    ]
+  },
+  {
+    "code": "NUR2118",
+    "name": "Pathophysiology and Pharmacology for Nurses II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "NUR1121"
+    ]
+  },
+  {
+    "code": "NUR2120",
+    "name": "Professional Nursing Practice, Ethics and Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "NUR1110"
+    ]
+  },
+  {
+    "code": "NUR2122",
+    "name": "Psychology for Nurses",
+    "creditCount": 4.0,
+    "preclusions": [
+      "NUR1116"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR2202C",
+    "name": "Pathophysiology, Pharmacology and Nursing Practice II",
+    "creditCount": 8.0,
+    "preclusions": [
+      "NUR2116",
+      "NUR2118"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR2204C",
+    "name": "Women and Children Health",
+    "creditCount": 4.0,
+    "preclusions": [
+      "NUR2121"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR3105A",
+    "name": "Nursing Practice Experience 3.1",
+    "creditCount": 2.0,
+    "preclusions": [
+      "NUR3105"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR3113",
+    "name": "Medical-Surgical Nursing III",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR3114",
+    "name": "Leadership and Management",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR3116A",
+    "name": "Transition to Professional Practice Experience",
+    "creditCount": 10.0,
+    "preclusions": [
+      "NUR3116"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR3117",
+    "name": "Community Integrated Health Care",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR3118",
+    "name": "Consolidated Clinical Simulation Nursing Practice",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": [
+      "NUR3105A"
+    ]
+  },
+  {
+    "code": "NUR3202C",
+    "name": "Research and Evidence-based Healthcare",
+    "creditCount": 4.0,
+    "preclusions": [
+      "NUR3109"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR4101B",
+    "name": "Evidence-based Health Care Practice",
+    "creditCount": 6.0,
+    "preclusions": [
+      "NUR4101"
+    ],
+    "prerequisites": [
+      "NUR3109"
+    ]
+  },
+  {
+    "code": "NUR4103B",
+    "name": "Applied Research Methods",
+    "creditCount": 6.0,
+    "preclusions": [
+      "NUR4103",
+      "NUR4103A"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR4104B",
+    "name": "Honours Project in Nursing",
+    "creditCount": 14.0,
+    "preclusions": [
+      "NUR4104"
+    ],
+    "prerequisites": [
+      "NUR4102A",
+      "NUR4103A"
+    ]
+  },
+  {
+    "code": "NUR5002",
+    "name": "Statistics for Health Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR5003",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR5009",
+    "name": "Principles & Practice of Palliative Care",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR5013",
+    "name": "Grant Writing and Writing for Publications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR5201",
+    "name": "Professional Development and Transformation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR5203",
+    "name": "Evidence-based Healthcare",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR5207",
+    "name": "Ethics in Healthcare",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR5302",
+    "name": "Advanced Gerontological Nursing (Adult Health)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR5303",
+    "name": "Integrated Primary and Community Care (Adult Health)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR5311",
+    "name": "Clinical Practicum I (AH, AC & MH)",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR5312",
+    "name": "Clinical Practicum II (AH, AC & MH)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR5502",
+    "name": "Advanced Critical Care Nursing I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR5503",
+    "name": "Advanced Critical Care Nursing II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR5607",
+    "name": "Approaches to Clinical Signs and Symptoms(Paediatrics)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "NUR5601",
+      "NUR5602"
+    ]
+  },
+  {
+    "code": "NUR5608",
+    "name": "Management of the Acute Paediatric Patients",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "NUR5601",
+      "NUR5602"
+    ]
+  },
+  {
+    "code": "NUR5611",
+    "name": "Clinical Practicum I (PAED)",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR5612",
+    "name": "Clinical Practicum II (Paediatrics)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "NUR5601",
+      "NUR5602"
+    ]
+  },
+  {
+    "code": "NUR5801G",
+    "name": "Integrated Clinical Decision Making and Management I",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR5802G",
+    "name": "Integrated Clinical Decision Making and Management II",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR6001",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR6003",
+    "name": "Research Methods",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR6004",
+    "name": "Systematic Review and Meta-Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR6005",
+    "name": "Measurement Theory and Instrument Validation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR6006",
+    "name": "Intervention Research in Nursing and Health Sciences",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "NUR6007",
+    "name": "Research Leadership and Professional Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5001",
+    "name": "Independent Study Module",
+    "creditCount": 8.0,
+    "preclusions": [
+      "OT5001A",
+      "OT5001B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5001A",
+    "name": "Independent Study Module: Subsea Engineering",
+    "creditCount": 8.0,
+    "preclusions": [
+      "OT5001",
+      "OT5001B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5001B",
+    "name": "Independent Study Module: Petroleum Engineering",
+    "creditCount": 8.0,
+    "preclusions": [
+      "OT5001",
+      "OT5001A"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5102",
+    "name": "Oil & Gas Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5202",
+    "name": "Analysis & Design of Offshore Structures",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE5202"
+    ],
+    "prerequisites": [
+      "CE2155"
+    ]
+  },
+  {
+    "code": "OT5203",
+    "name": "Design of Floating Structures",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "OT5201",
+      "AY2011",
+      "CE5887",
+      "AY2010"
+    ]
+  },
+  {
+    "code": "OT5204",
+    "name": "Moorings & Risers",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CE5307",
+      "OT5201"
+    ]
+  },
+  {
+    "code": "OT5204A",
+    "name": "Moorings and Risers - Statics",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5204B",
+    "name": "Mooring and Risers - Dynamics",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5205",
+    "name": "Offshore Pipelines",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5206",
+    "name": "Offshore Foundations",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE5206"
+    ],
+    "prerequisites": [
+      "CE2112"
+    ]
+  },
+  {
+    "code": "OT5206A",
+    "name": "Shallow Offshore Foundations",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5206B",
+    "name": "Deep Offshore Foundations",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5207",
+    "name": "Arctic Offshore Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5301",
+    "name": "Subsea Systems Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5304",
+    "name": "Subsea Construction & Operational Support",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5401",
+    "name": "Geoscience for Petroleum Exploration",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5402",
+    "name": "Geophysical Imaging of the Earth Interior",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5404",
+    "name": "Reservoir Characterization and Rock Physics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5405",
+    "name": "Enhanced Oil Recovery",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5406",
+    "name": "Petroleum Production Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "OT5407",
+    "name": "Petroleum Geomechanics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PA1113",
+    "name": "Basic Pharmacology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AY1130"
+    ]
+  },
+  {
+    "code": "PA1113A",
+    "name": "Basic Pharmacology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "NUR5102"
+    ]
+  },
+  {
+    "code": "PA2131",
+    "name": "Pharmacology",
+    "creditCount": 1.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PC1141",
+    "name": "Introduction to Classical Mechanics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC1431",
+      "PC1431FC",
+      "PC1431X",
+      "PC1433"
+    ],
+    "prerequisites": [
+      "PC1221",
+      "PC1221FC",
+      "PC1221X",
+      "PC1222",
+      "PC1222X"
+    ]
+  },
+  {
+    "code": "PC1142",
+    "name": "Introduction to Thermodynamics and Optics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC1431",
+      "PC1431FC",
+      "PC1431X"
+    ],
+    "prerequisites": [
+      "PC1221",
+      "PC1221FC",
+      "PC1221X",
+      "PC1222",
+      "PC1222X"
+    ]
+  },
+  {
+    "code": "PC1143",
+    "name": "Introduction to Electricity & Magnetism",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC1432",
+      "PC1432X"
+    ],
+    "prerequisites": [
+      "PC1221",
+      "PC1221FC",
+      "PC1221X",
+      "PC1222",
+      "PC1222X"
+    ]
+  },
+  {
+    "code": "PC1144",
+    "name": "Introduction to Modern Physics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC1432",
+      "PC1432X"
+    ],
+    "prerequisites": [
+      "PC1221",
+      "PC1221FC",
+      "PC1221X",
+      "PC1222",
+      "PC1222X"
+    ]
+  },
+  {
+    "code": "PC1221",
+    "name": "Fundamentals of Physics I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC1141",
+      "PC1142",
+      "PC1431",
+      "PC1431FC",
+      "PC1431X",
+      "PC1221FC",
+      "PC1221X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PC1221X",
+    "name": "Fundamentals of Physics 1",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC1141",
+      "PC1142",
+      "PC1431",
+      "PC1431FC",
+      "PC1431X",
+      "PC1221",
+      "PC1221FC"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PC1222",
+    "name": "Fundamentals of Physics II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC1143",
+      "PC1144",
+      "PC1432",
+      "PC1432X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PC1222X",
+    "name": "Fundamentals of Physics II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC1222",
+      "PC1143",
+      "PC1144",
+      "PC1432",
+      "PC1432X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PC1322",
+    "name": "Understanding the Universe",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEH1031"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PC1421",
+    "name": "Physics for Life Sciences",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PC1431",
+    "name": "Physics IE",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC1141",
+      "PC1142",
+      "PC1433",
+      "PC1431FC",
+      "PC1431X"
+    ],
+    "prerequisites": [
+      "PC1221",
+      "PC1221FC",
+      "PC1221X",
+      "PC1222",
+      "PC1222X"
+    ]
+  },
+  {
+    "code": "PC1432",
+    "name": "Physics IIE",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC1143",
+      "PC1144",
+      "PC1432X"
+    ],
+    "prerequisites": [
+      "PC1221",
+      "PC1221FC",
+      "PC1221X",
+      "PC1222",
+      "PC1222X"
+    ]
+  },
+  {
+    "code": "PC1433",
+    "name": "Mechanics and Waves",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC1141",
+      "PC1431",
+      "PC1431FC",
+      "PC1431X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PC2020",
+    "name": "Electromagnetics for Electrical Engineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC2131",
+      "PC2232"
+    ],
+    "prerequisites": [
+      "MA1511",
+      "MA1512"
+    ]
+  },
+  {
+    "code": "PC2130",
+    "name": "Quantum Mechanics I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC2130B"
+    ],
+    "prerequisites": [
+      "PC1144",
+      "PC1432",
+      "PC1432X",
+      "MA1101R",
+      "MA1513",
+      "MA1508E",
+      "MA1102R",
+      "MA1505",
+      "MA1511",
+      "MA1512"
+    ]
+  },
+  {
+    "code": "PC2130B",
+    "name": "Applied Quantum Physics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC2130"
+    ],
+    "prerequisites": [
+      "PC1144",
+      "PC1432",
+      "PC1432X",
+      "PC1433"
+    ]
+  },
+  {
+    "code": "PC2131",
+    "name": "Electricity & Magnetism I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC1144",
+      "PC1432",
+      "PC1432X",
+      "MA1101R",
+      "MA1513",
+      "MA1508E",
+      "MA1102R",
+      "MA1505",
+      "MA1511",
+      "MA1512"
+    ]
+  },
+  {
+    "code": "PC2132",
+    "name": "Classical Mechanics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC1144",
+      "PC1432",
+      "PC1432X",
+      "MA1101R",
+      "MA1513",
+      "MA1508E",
+      "MA1102R",
+      "MA1505",
+      "MA1511",
+      "MA1512"
+    ]
+  },
+  {
+    "code": "PC2133",
+    "name": "Applied Solid State Physics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC3235",
+      "PC2133"
+    ],
+    "prerequisites": [
+      "PC1144",
+      "PC1433"
+    ]
+  },
+  {
+    "code": "PC2134",
+    "name": "Mathematical Mtds In Physics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1101R",
+      "MA1102R"
+    ]
+  },
+  {
+    "code": "PC2193",
+    "name": "Experimental Physics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC1141",
+      "PC1142",
+      "PC1143",
+      "PC1144",
+      "PC1431",
+      "PC1431FC",
+      "PC1431X",
+      "PC1432",
+      "PC1432X",
+      "PC1433"
+    ]
+  },
+  {
+    "code": "PC2230",
+    "name": "Thermodynamics and Statistical Mechanics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC1142",
+      "PC1144",
+      "PC1431",
+      "PC1431FC",
+      "PC1431X",
+      "MA1102R"
+    ]
+  },
+  {
+    "code": "PC2232",
+    "name": "Physics for Electrical Engineers",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "EE2011"
+    ]
+  },
+  {
+    "code": "PC2239",
+    "name": "Special Problems in Undergrad Physics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PC2267",
+    "name": "Biophysics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC1143",
+      "PC1432",
+      "PC1432X",
+      "PC1421"
+    ]
+  },
+  {
+    "code": "PC2288",
+    "name": "Basic UROPS in Physics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC1141",
+      "PC1142"
+    ]
+  },
+  {
+    "code": "PC2289",
+    "name": "Basic UROPS in Physics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC1141",
+      "PC1142"
+    ]
+  },
+  {
+    "code": "PC3130",
+    "name": "Quantum Mechanics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC2130",
+      "PC2130B",
+      "PC2134"
+    ]
+  },
+  {
+    "code": "PC3193",
+    "name": "Experimental Physics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC2193"
+    ]
+  },
+  {
+    "code": "PC3231",
+    "name": "Electricity & Magnetism II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ESP2104"
+    ],
+    "prerequisites": [
+      "PC2131"
+    ]
+  },
+  {
+    "code": "PC3232",
+    "name": "Nuclear & Particle Physics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC3232B"
+    ],
+    "prerequisites": [
+      "PC2130",
+      "PC2130B"
+    ]
+  },
+  {
+    "code": "PC3232B",
+    "name": "Applied Nuclear Physics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC3232"
+    ],
+    "prerequisites": [
+      "PC1144",
+      "PC1432",
+      "PC1432X",
+      "PC2232",
+      "PC2020",
+      "PC2130B"
+    ]
+  },
+  {
+    "code": "PC3233",
+    "name": "Atomic & Molecular Physics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC2130",
+      "PC2130B"
+    ]
+  },
+  {
+    "code": "PC3235",
+    "name": "Solid State Physics I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3406",
+      "PC2133"
+    ],
+    "prerequisites": [
+      "PC2130",
+      "PC2130B"
+    ]
+  },
+  {
+    "code": "PC3236",
+    "name": "Computational Methods in Physics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC2134"
+    ]
+  },
+  {
+    "code": "PC3238",
+    "name": "Fluid Dynamics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC2134",
+      "PC3236"
+    ]
+  },
+  {
+    "code": "PC3239",
+    "name": "Special Problems in Undergrad Physics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PC3241",
+    "name": "Solid State Devices",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2004"
+    ],
+    "prerequisites": [
+      "PC2131",
+      "PC2231",
+      "PC3235",
+      "MLE2104",
+      "PC2133",
+      "EE2005"
+    ]
+  },
+  {
+    "code": "PC3243",
+    "name": "Photonics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC2131",
+      "PC2231",
+      "PC3130",
+      "PC3241",
+      "PC3235",
+      "PC2133",
+      "EE2005"
+    ]
+  },
+  {
+    "code": "PC3246",
+    "name": "Astrophysics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC2130",
+      "PC2132"
+    ]
+  },
+  {
+    "code": "PC3247",
+    "name": "Modern Optics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC2231"
+    ],
+    "prerequisites": [
+      "PC2131",
+      "EE2005"
+    ]
+  },
+  {
+    "code": "PC3251",
+    "name": "Nanophysics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SP2251"
+    ]
+  },
+  {
+    "code": "PC3267",
+    "name": "Biophysics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC2131",
+      "PC2267",
+      "EE2011"
+    ]
+  },
+  {
+    "code": "PC3274",
+    "name": "Mathematical Methods in Physics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC2134"
+    ]
+  },
+  {
+    "code": "PC3288",
+    "name": "Advanced UROPS in Physics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PC3289",
+    "name": "Advanced UROPS in Physics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PC3294",
+    "name": "Radiation Laboratory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3232",
+      "PC3232B"
+    ]
+  },
+  {
+    "code": "PC3311",
+    "name": "Undergraduate Professional Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3311"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PC3312",
+    "name": "Enhanced Undergraduate Professional Internship Programme",
+    "creditCount": 12.0,
+    "preclusions": [
+      "XX3312"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PC4199",
+    "name": "Honours Project in Physics",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PC4199R",
+    "name": "Integrated B.ENG./B.SC. (Hons) Dissertation",
+    "creditCount": 16.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PC4228",
+    "name": "Device Physics for Quantum Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3130"
+    ]
+  },
+  {
+    "code": "PC4230",
+    "name": "Quantum Mechanics III",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PC4130"
+    ],
+    "prerequisites": [
+      "PC3130"
+    ]
+  },
+  {
+    "code": "PC4236",
+    "name": "Computational Condensed Matter Physics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3235"
+    ]
+  },
+  {
+    "code": "PC4240",
+    "name": "Solid State Physics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3235"
+    ]
+  },
+  {
+    "code": "PC4241",
+    "name": "Statistical Mechanics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC2230"
+    ]
+  },
+  {
+    "code": "PC4242",
+    "name": "Electrodynamics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3231"
+    ]
+  },
+  {
+    "code": "PC4243",
+    "name": "Atomic & Molecular Physics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3233"
+    ]
+  },
+  {
+    "code": "PC4245",
+    "name": "Particle Physics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3232",
+      "PC3130"
+    ]
+  },
+  {
+    "code": "PC4246",
+    "name": "Quantum Optics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3130",
+      "PC3243"
+    ]
+  },
+  {
+    "code": "PC4248",
+    "name": "General Relativity",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3274"
+    ]
+  },
+  {
+    "code": "PC4249",
+    "name": "Astrophysics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3246"
+    ]
+  },
+  {
+    "code": "PC4253",
+    "name": "Thin Film Technology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MLE5201"
+    ],
+    "prerequisites": [
+      "PC3235",
+      "PC3241",
+      "PC3242"
+    ]
+  },
+  {
+    "code": "PC4259",
+    "name": "Surface Physics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3130",
+      "PC3242",
+      "EE2004",
+      "EE3431C",
+      "EE2143"
+    ]
+  },
+  {
+    "code": "PC4262",
+    "name": "Remote Sensing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3231"
+    ]
+  },
+  {
+    "code": "PC4267",
+    "name": "Biophysics III",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3267"
+    ]
+  },
+  {
+    "code": "PC4274",
+    "name": "Mathematical Methods in Physics III",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3274"
+    ]
+  },
+  {
+    "code": "PC5198",
+    "name": "Graduate Seminar Module In Physics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PC5202",
+    "name": "Advanced Statistical Mechanics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC4241"
+    ]
+  },
+  {
+    "code": "PC5204",
+    "name": "Special Topics In Physics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3235",
+      "PC4241"
+    ]
+  },
+  {
+    "code": "PC5204A",
+    "name": "Soft Materials and Flexible Devices",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PC5204B",
+    "name": "Selected Topics in Physics: Analytic Approximations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3274",
+      "PC4274"
+    ]
+  },
+  {
+    "code": "PC5206",
+    "name": "Selected Topics in Quantum Field Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC4130",
+      "PC4230",
+      "PC5201"
+    ]
+  },
+  {
+    "code": "PC5209",
+    "name": "Accelerator Based Materials Characterisation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC4244",
+      "PC4212",
+      "PC4261"
+    ]
+  },
+  {
+    "code": "PC5210",
+    "name": "Advanced Dynamics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3274",
+      "PC3130"
+    ]
+  },
+  {
+    "code": "PC5212",
+    "name": "Physics of Nanostructures",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC4130",
+      "PC4240",
+      "PC4201",
+      "PC4214"
+    ]
+  },
+  {
+    "code": "PC5213",
+    "name": "Advanced Biophysics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC4267",
+      "PC4268"
+    ]
+  },
+  {
+    "code": "PC5214",
+    "name": "Principles Of Experimental Physics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PC5215",
+    "name": "Numerical Recipes With Applications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3236"
+    ]
+  },
+  {
+    "code": "PC5228",
+    "name": "Quantum Information and Computation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3130"
+    ]
+  },
+  {
+    "code": "PC5239",
+    "name": "Special Problems In Physics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PC5247",
+    "name": "Photonics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC3247"
+    ]
+  },
+  {
+    "code": "PC5288",
+    "name": "M.sc Coursework Thesis For Physics",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PC5289",
+    "name": "M.sc.(coursework) Thesis For Applied Physics",
+    "creditCount": 16.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF1101",
+    "name": "Fundamentals of Project Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF1103",
+    "name": "Digital Construction",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF1106",
+    "name": "Introduction to Measurement",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF1102"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF1107",
+    "name": "Project And Facilities Management Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF2101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF1108",
+    "name": "Introduction to Building Performance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF1104"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2101",
+    "name": "Project and Facilities Management Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2102",
+    "name": "Structural Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF2501"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2103",
+    "name": "Measurement (Building Works)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2105",
+    "name": "Research Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2106",
+    "name": "Project & Facilities Communication Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2107",
+    "name": "Construction Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2108",
+    "name": "Project Cost Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2110",
+    "name": "Fundamentals of Facilities Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF1105"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2201",
+    "name": "Scope and Design Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2203",
+    "name": "Quality and Productivity Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2205",
+    "name": "Project Finance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF2204"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2304",
+    "name": "Operations and Maintenance Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF4309",
+      "AY2018"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2305",
+    "name": "Event Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF4307",
+      "AY2017"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2306",
+    "name": "Event Management Case Studies",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF4308",
+      "AY2017"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2402",
+    "name": "Work Experience Internship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2501",
+    "name": "Structural Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF2102",
+      "AY2018"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2502",
+    "name": "Development Technology and Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2504",
+    "name": "Materials Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF2505",
+    "name": "M&E Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF2104",
+      "PF2503"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF3201",
+    "name": "Measurement (Specialist Works)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PF2503",
+      "PF2505",
+      "AY2014",
+      "AY2017"
+    ]
+  },
+  {
+    "code": "PF3205",
+    "name": "Advanced Measurement",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PF2102",
+      "PF2501",
+      "AY2014",
+      "AY2017"
+    ]
+  },
+  {
+    "code": "PF3206",
+    "name": "Project Scheduling and Control",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF3101",
+      "PF3104",
+      "AY2018"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF3207",
+    "name": "Project Management Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF3301",
+    "name": "Maintainability of Facilities",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF3302",
+    "name": "Energy Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PF2503",
+      "PF2505",
+      "AY2014",
+      "AY2017"
+    ]
+  },
+  {
+    "code": "PF3304",
+    "name": "Facilities Management Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF3305",
+    "name": "Facilities Planning and Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PF2102",
+      "PF2501",
+      "AY2014",
+      "AY2017"
+    ]
+  },
+  {
+    "code": "PF3401",
+    "name": "Practical Training Scheme",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF3501",
+    "name": "Intelligent Facilities",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF4101",
+    "name": "Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF4102",
+    "name": "Contract and Procurement Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF4202",
+    "name": "Safety, Health and Environmental Mgt",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF4208",
+      "AY2018"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF4203",
+    "name": "Project Dispute Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF4206",
+    "name": "Building Information Modelling",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF4207",
+    "name": "Project Risk Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF3104",
+      "AY2018"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF4301",
+    "name": "Strategic Facilities Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF3307",
+      "AY2018"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF4305",
+    "name": "Green Development",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF4502",
+      "AY2018"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF4306",
+    "name": "REITs Facilities Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PF4307",
+    "name": "Event Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF2305",
+      "AY2018"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF4308",
+    "name": "Event Management Case Studies",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PF2306",
+      "AY2018"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PF4501",
+    "name": "Total Building Performance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH2201",
+    "name": "Introduction to Philosophy Of Science",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM2025"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PH2206",
+    "name": "Founders of Modern Philosophy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2028"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PH2207",
+    "name": "Hume and Kant",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH2208",
+    "name": "Applied Ethics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2029"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PH2209",
+    "name": "Philosophy of Art",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2002"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PH2211",
+    "name": "Philosophy of Religion",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH2213",
+    "name": "Metaphysics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH2222",
+    "name": "Greek Philosophy (Socrates and Plato)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PH3209",
+      "GEK2036"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PH2241",
+    "name": "Philosophy of Mind",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PH3212"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PH2242",
+    "name": "Philosophy of Language",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PH3210"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PH3201",
+    "name": "Philosophy of Social Science",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH3203",
+    "name": "Moral Philosophy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH3206",
+    "name": "Recent Philosophy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH3230",
+    "name": "Normative Ethical Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH3245",
+    "name": "Language and Thought",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PH2241",
+      "PH3212",
+      "PH2242",
+      "PH3210"
+    ]
+  },
+  {
+    "code": "PH3246",
+    "name": "Paradoxes",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PH2110",
+      "GEM2006"
+    ]
+  },
+  {
+    "code": "PH3248",
+    "name": "Social and Formal Epistemology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PH2111",
+      "GEK2048",
+      "PH2243"
+    ]
+  },
+  {
+    "code": "PH3249",
+    "name": "Decision and Social Choice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GEM2006",
+      "GET1028"
+    ]
+  },
+  {
+    "code": "PH3261",
+    "name": "Kant's Critique of Pure Reason",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH4202",
+    "name": "Political Philosophy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH4205",
+    "name": "Topics in East Asian Philosophy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PH2301",
+      "PH2302",
+      "PH2301",
+      "PH2302"
+    ]
+  },
+  {
+    "code": "PH4206",
+    "name": "A Major Philosopher",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH4209",
+    "name": "Greek Thinkers",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH4211",
+    "name": "Issues in Epistemology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH4212",
+    "name": "Issues in Philosophy of Mind",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH4240",
+    "name": "Issues in Metaphysics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH4242",
+    "name": "Issues in Philosophy of Language",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "PH4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PH4550",
+    "name": "Internship: Philosophy for Teaching",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PH4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PH5660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH6210",
+    "name": "Topics In History Of Western Philosophy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH6320",
+    "name": "Traditions In Asian Philosophy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH6540",
+    "name": "Topics In Analytic Philosophy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH6660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH6760",
+    "name": "Philosophical Topics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PH6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PHS1120",
+    "name": "Essential Topics in Pharmaceutical Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR1110A"
+    ]
+  },
+  {
+    "code": "PL1101E",
+    "name": "Introduction to Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PL2131",
+    "name": "Research and Statistical Methods I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UQF2101B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PL2132",
+    "name": "Research and Statistical Methods II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL1101E",
+      "PL2131"
+    ]
+  },
+  {
+    "code": "PL3231",
+    "name": "Independent Research Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132"
+    ]
+  },
+  {
+    "code": "PL3232",
+    "name": "Biological Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E"
+    ]
+  },
+  {
+    "code": "PL3233",
+    "name": "Cognitive Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E"
+    ]
+  },
+  {
+    "code": "PL3234",
+    "name": "Developmental Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E"
+    ]
+  },
+  {
+    "code": "PL3235",
+    "name": "Social Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E"
+    ]
+  },
+  {
+    "code": "PL3236",
+    "name": "Abnormal Psychology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SW3217"
+    ],
+    "prerequisites": [
+      "PL1101E"
+    ]
+  },
+  {
+    "code": "PL3239",
+    "name": "Industrial and Organisational Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132"
+    ]
+  },
+  {
+    "code": "PL3240",
+    "name": "Group Dynamics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL3235"
+    ]
+  },
+  {
+    "code": "PL3242",
+    "name": "Health Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E"
+    ]
+  },
+  {
+    "code": "PL3243",
+    "name": "Sensation and Perception",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL3233"
+    ]
+  },
+  {
+    "code": "PL3244",
+    "name": "Adolescent Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL3234"
+    ]
+  },
+  {
+    "code": "PL3250",
+    "name": "Human Performance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL3233"
+    ]
+  },
+  {
+    "code": "PL3252",
+    "name": "Social-Cognitive Perspectives on Emotion",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PL3880B"
+    ],
+    "prerequisites": [
+      "PL1101E",
+      "PL3235"
+    ]
+  },
+  {
+    "code": "PL3254",
+    "name": "Introduction to Trauma Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL3236"
+    ]
+  },
+  {
+    "code": "PL3256",
+    "name": "Infant Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3234"
+    ]
+  },
+  {
+    "code": "PL3257",
+    "name": "Introduction to Clinical Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL3236"
+    ]
+  },
+  {
+    "code": "PL3260",
+    "name": "Moral Development",
+    "creditCount": 4.0,
+    "preclusions": [
+      "YSS4221"
+    ],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132"
+    ]
+  },
+  {
+    "code": "PL3281",
+    "name": "Lab in Cognitive Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3233"
+    ]
+  },
+  {
+    "code": "PL3281C",
+    "name": "Lab in Reading Processes",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3233"
+    ]
+  },
+  {
+    "code": "PL3282",
+    "name": "Lab in Social Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3235"
+    ]
+  },
+  {
+    "code": "PL3282A",
+    "name": "Lab in Interpersonal Relationships",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3235"
+    ]
+  },
+  {
+    "code": "PL3283",
+    "name": "Lab in Developmental Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3234"
+    ]
+  },
+  {
+    "code": "PL3283B",
+    "name": "Lab in Development of Communication",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3234"
+    ]
+  },
+  {
+    "code": "PL3284",
+    "name": "Lab in Applied Psychology (Scale Construction)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132"
+    ]
+  },
+  {
+    "code": "PL3287",
+    "name": "Lab in Clinical/Abnormal Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3236"
+    ]
+  },
+  {
+    "code": "PL3289",
+    "name": "Lab in Decision Science",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3235"
+    ]
+  },
+  {
+    "code": "PL3551",
+    "name": "FASS Undergraduate Research Opportunity (UROP)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PL4201",
+    "name": "Psychometrics and Psychological Testing",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PL5223"
+    ],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236"
+    ]
+  },
+  {
+    "code": "PL4203",
+    "name": "Cognition",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3233",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3233"
+    ]
+  },
+  {
+    "code": "PL4205",
+    "name": "Developmental Processes",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3234",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3234"
+    ]
+  },
+  {
+    "code": "PL4206",
+    "name": "Cognitive Neuroscience",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3232",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3232"
+    ]
+  },
+  {
+    "code": "PL4207",
+    "name": "Social Psychology: Theories and Methods",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3235",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3235"
+    ]
+  },
+  {
+    "code": "PL4219",
+    "name": "Advanced Abnormal Psychology",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PL4880A"
+    ],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3236",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3236"
+    ]
+  },
+  {
+    "code": "PL4221",
+    "name": "Early Language Development",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3234",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3234"
+    ]
+  },
+  {
+    "code": "PL4223",
+    "name": "Introduction to Clinical Neuropsychology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3236",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3236"
+    ]
+  },
+  {
+    "code": "PL4224",
+    "name": "Child Abnormal Psychology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3236",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3236"
+    ]
+  },
+  {
+    "code": "PL4226",
+    "name": "Correctional Psychology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3236",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3236"
+    ]
+  },
+  {
+    "code": "PL4228",
+    "name": "Criminal Forensic Psychology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3235",
+      "PL3236",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3235",
+      "PL3236"
+    ]
+  },
+  {
+    "code": "PL4229",
+    "name": "Psychological Therapies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3236",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3236"
+    ]
+  },
+  {
+    "code": "PL4233",
+    "name": "Psychology of Negotiation",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SW3208"
+    ],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3239",
+      "PL3232",
+      "PL3236",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3239",
+      "PL3232",
+      "PL3236"
+    ]
+  },
+  {
+    "code": "PL4235",
+    "name": "The Psychology of Moral Judgments",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSS4206A"
+    ],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3234",
+      "PL3235",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3234",
+      "PL3235"
+    ]
+  },
+  {
+    "code": "PL4236",
+    "name": "Autism Spectrum and Related Conditions",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3234",
+      "PL3236",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3234",
+      "PL3236"
+    ]
+  },
+  {
+    "code": "PL4237",
+    "name": "Evidence-Based Treatments for Trauma",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3254",
+      "PL3232",
+      "PL3236",
+      "PL3236",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3254",
+      "PL3232",
+      "PL3236",
+      "PL3236"
+    ]
+  },
+  {
+    "code": "PL4239",
+    "name": "Social Psychology of the Unconscious",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PL4880I"
+    ],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3235",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3235"
+    ]
+  },
+  {
+    "code": "PL4241",
+    "name": "Exploring Consciousness \u2013 Theory and Neuroscience",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3232",
+      "PL3233",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3232",
+      "PL3233"
+    ]
+  },
+  {
+    "code": "PL4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "PL4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PL4501",
+    "name": "Integrated Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "PL4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PL4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PL4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PL4880F",
+    "name": "Addictive Behaviours",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3236",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3236"
+    ]
+  },
+  {
+    "code": "PL4880K",
+    "name": "Parenting and Child Development",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3234",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3234"
+    ]
+  },
+  {
+    "code": "PL4880L",
+    "name": "Applying Cognitive Psychology to Learning & Instruction",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3233",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3233"
+    ]
+  },
+  {
+    "code": "PL4880M",
+    "name": "Social Psychology and Technology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3235",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3235"
+    ]
+  },
+  {
+    "code": "PL4880P",
+    "name": "Psychology of Religion",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236"
+    ]
+  },
+  {
+    "code": "PL4880Q",
+    "name": "Psychology of Bilingualism",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3233",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3233"
+    ]
+  },
+  {
+    "code": "PL4880R",
+    "name": "Issues in Adolescent Developmt",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3234",
+      "PL1101E",
+      "PL2131",
+      "PL2132",
+      "PL3232",
+      "PL3236",
+      "PL3234"
+    ]
+  },
+  {
+    "code": "PL5221",
+    "name": "Analysis Of Psychological Data Using Glm",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PL5102",
+      "PL6102"
+    ],
+    "prerequisites": [
+      "PL2101Y",
+      "PL2131",
+      "PL2132"
+    ]
+  },
+  {
+    "code": "PL5221R",
+    "name": "Analysis of Psychological Data using GLM",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PL5102",
+      "PL6102"
+    ],
+    "prerequisites": [
+      "PL2101Y",
+      "PL2131",
+      "PL2132"
+    ]
+  },
+  {
+    "code": "PL5222",
+    "name": "Multivariate Statistics in Psychology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PL4204"
+    ],
+    "prerequisites": [
+      "PL2101Y",
+      "PL2131",
+      "PL2102Y",
+      "PL2132"
+    ]
+  },
+  {
+    "code": "PL5222R",
+    "name": "Multivariate Statistics in Psychology",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PL4204"
+    ],
+    "prerequisites": [
+      "PL2101Y",
+      "PL2131",
+      "PL2102Y",
+      "PL2132"
+    ]
+  },
+  {
+    "code": "PL5225",
+    "name": "Structural Equation Modeling",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL2101Y",
+      "PL2131",
+      "PL2102Y",
+      "PL2132",
+      "PL5221"
+    ]
+  },
+  {
+    "code": "PL5225R",
+    "name": "Structural Equation Modeling",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PL2101Y",
+      "PL2131",
+      "PL2102Y",
+      "PL2132",
+      "PL5221"
+    ]
+  },
+  {
+    "code": "PL5305",
+    "name": "Advanced Social Psychology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PL6223"
+    ],
+    "prerequisites": [
+      "PL3235"
+    ]
+  },
+  {
+    "code": "PL5305R",
+    "name": "Advanced Social Psychology",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PL6223"
+    ],
+    "prerequisites": [
+      "PL3235"
+    ]
+  },
+  {
+    "code": "PL5306",
+    "name": "Advanced Clinical Psychology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PL6210"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PL5306R",
+    "name": "Advanced Clinical Psychology",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PL6210"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PL5308",
+    "name": "Advanced Social and Cognitive Neuroscience",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PL6204"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PL5308R",
+    "name": "Advanced Social and Cognitive Neuroscience",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PL6204"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PL5660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PL5220"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PL6208",
+    "name": "Empirical Research Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PL6215",
+    "name": "Selected Applications In Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PL6660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PL6220",
+      "PL6220A",
+      "PL6220B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PL6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PL6883",
+    "name": "Selected Topics in Cognitive Psychology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PLB1201",
+    "name": "Psychology in Everyday Life",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1064",
+      "PL1101E",
+      "PLB1201",
+      "PLB1201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PLC5001",
+    "name": "Psychological Assessment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PLC5002",
+    "name": "Adult Psychopathology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PLC5003",
+    "name": "Health across the lifespan",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PLC5004",
+    "name": "Psychological Intervention And Therapy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PLC5005",
+    "name": "Child Psychopathology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PLC5002"
+    ]
+  },
+  {
+    "code": "PLC5006",
+    "name": "Ethics and Professional Issues",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PLC5011"
+    ]
+  },
+  {
+    "code": "PLC5007",
+    "name": "Advanced Psychological Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PLC5011",
+      "PLC5004"
+    ]
+  },
+  {
+    "code": "PLC5008",
+    "name": "Graduate Research Methods",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PLC5009",
+    "name": "Research Proposal",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PLC5010",
+    "name": "Research Project",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PLC5011A",
+    "name": "Clinical Placement 1",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PLC5004",
+      "PLC5001"
+    ]
+  },
+  {
+    "code": "PLC5012B",
+    "name": "Clinical Placement 2",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PLC5013C",
+    "name": "Clinical Placement 3",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PLC5012"
+    ]
+  },
+  {
+    "code": "PLS8001",
+    "name": "Cultivating Collaboration",
+    "creditCount": 1.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PLS8003",
+    "name": "Cultivating Resilience",
+    "creditCount": 1.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PM5000",
+    "name": "Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PM5101",
+    "name": "Project Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PM5103",
+    "name": "Contract Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PM5105",
+    "name": "Development Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PM5106",
+    "name": "Design Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PM5107",
+    "name": "Time And Cost Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PM5109",
+    "name": "Project Management Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PM5111",
+    "name": "Special Topics In Project Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PM5112",
+    "name": "Research Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PM5113",
+    "name": "Managing Projects using BIM",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PM5114",
+    "name": "Managing Complex Projects",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PM5115",
+    "name": "Project Finance Contracts and Agreements",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PM5116",
+    "name": "Project Finance Case Studies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5010",
+    "name": "The LKY School Course",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5105",
+    "name": "Cost Benefit Analysis in Public Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5110A",
+    "name": "Policy Analysis Exercise",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5138",
+    "name": "Econometrics for Public Policy Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5141",
+    "name": "Post-Crisis Economics and Policy Implications for Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5142",
+    "name": "Liveable and Sustainable Cities - A Singapore Case-study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5144",
+    "name": "Decision and Game Theory for Public Managers",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5146",
+    "name": "Decentralization, Governance & Sustainable Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5147",
+    "name": "Asian Global Cities",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5149",
+    "name": "Big Data, Official Statistics, and Public Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5150",
+    "name": "Social Welfare in East Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5156",
+    "name": "Moral Reasoning in the Policy Process",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5158",
+    "name": "International Relations of Asia after WWII",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5164",
+    "name": "International Conflict Analysis and Resolution",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5165",
+    "name": "Market Failures and Government Intervention",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5168",
+    "name": "Public Service Leadership",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5174",
+    "name": "International Politics: The Rules of the Game",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5176",
+    "name": "China and the Global Economy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5178",
+    "name": "Leadership and Decision-making Skills",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5180",
+    "name": "Trade Policy and Global Value Chains",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5181",
+    "name": "State Fragility and Peacemaking",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5184",
+    "name": "Communications for Public Leadership",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5187",
+    "name": "The Foreign Policy of Global Business",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5188",
+    "name": "Social Entrepreneurship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5189",
+    "name": "Practices in Better and Effective Governance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5191",
+    "name": "Public Administration, Technology and Innovation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5192",
+    "name": "Data Analytics: Science, Art and Applications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5193",
+    "name": "Asian International and Strategic Thought",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5194",
+    "name": "Natural Disasters, Environment and Climate Change",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5196",
+    "name": "Education Economics and Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5198",
+    "name": "Chinese Political Leadership and Economic Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5199",
+    "name": "The Economics of Corruption in Growth and Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5203",
+    "name": "Behavioral Economics and Public Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PP5101",
+      "PP5301",
+      "PP5501"
+    ]
+  },
+  {
+    "code": "PP5212",
+    "name": "Financial Issues, Trade and Investment in Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PP5101",
+      "PP5102"
+    ]
+  },
+  {
+    "code": "PP5215",
+    "name": "Changes in Singapore Political Economy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC2373",
+      "SSA2220"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5216",
+    "name": "Economic Growth in Developing Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5217",
+    "name": "Innovation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PP5242M"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5220",
+    "name": "Innovation and Technology Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5223",
+    "name": "Population Ageing, Public Policy, and Family",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5224",
+    "name": "Value- Focused Negotiations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5228",
+    "name": "Evidence-Informed Policy Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5236",
+    "name": "Poverty, Inequality, and Public Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5239",
+    "name": "Understanding and Managing Corruption",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5242J",
+    "name": "Effective Implementation: Learning from Effective Implementers",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5266",
+    "name": "Global Health Policy And Issues",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5267",
+    "name": "Urban Transport Policy: A Global View",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5269",
+    "name": "Environmental Economics and Public Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5274",
+    "name": "Financial Management for Policy Makers",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5298",
+    "name": "Singapore's Development Experience",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5301",
+    "name": "Economic Reasoning And Policy",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5303",
+    "name": "Public Management",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5308",
+    "name": "Frameworks For Policy Analysis",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5313",
+    "name": "Topics in Public Management",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5401",
+    "name": "Policy Challenges",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5402",
+    "name": "Policy Process and Institutions",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5403",
+    "name": "Economic Foundations for Public Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5405",
+    "name": "Public Administration and Politics",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PP5402"
+    ]
+  },
+  {
+    "code": "PP5406",
+    "name": "Quantitative Research Methods for Public Policy 1",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5407",
+    "name": "Quantitative Research Methods for Public Policy 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PP5406"
+    ]
+  },
+  {
+    "code": "PP5408",
+    "name": "Qualitative Research Methods for Public Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5504",
+    "name": "Public Finance And Budgeting",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5507",
+    "name": "Policy Innovation Lab",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5509",
+    "name": "Pensions and Retirement Policies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5510",
+    "name": "Governing Cities of Tomorrow",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5511",
+    "name": "Systemic and Integrated Policy Design and Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5701",
+    "name": "Economic Applications for Public Organizations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5702",
+    "name": "Public Administration in Theory and Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5703",
+    "name": "Public Finance and Budgeting",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5704",
+    "name": "Policy Analysis and Programme Evaluation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5705",
+    "name": "Comparative Public Policy and Management: Singapore and Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5712",
+    "name": "International Economic Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5714",
+    "name": "International Financial Policy and Issues",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5722",
+    "name": "Strategic Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5723",
+    "name": "Political Economy of Taiwan, Hong Kong and Singapore",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5801",
+    "name": "Economic Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5802",
+    "name": "Policy Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5803",
+    "name": "Public Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5804",
+    "name": "Governance Study Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5901",
+    "name": "Introduction to International Relations Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5902",
+    "name": "International Security - Concepts, Issues & Policies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5903",
+    "name": "International Political Economy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5904",
+    "name": "Research Methods in International Affairs",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5905",
+    "name": "Foreign Policy Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5906",
+    "name": "International Economic Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP5908",
+    "name": "Global Governance in a Changing World",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP6702",
+    "name": "Foundations Of Public Policy: Theories And Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP6703",
+    "name": "Foundations of Public Administration",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP6704",
+    "name": "The Economics of Public Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PP5101"
+    ]
+  },
+  {
+    "code": "PP6705",
+    "name": "The Politics of Public Policy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PP5268"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PP6706",
+    "name": "Quantitative Methods for Public Policy Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PP6701"
+    ]
+  },
+  {
+    "code": "PP6707",
+    "name": "Qualitative Methods for Public Policy Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP6708",
+    "name": "Research Design in Public Policy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PP6770",
+    "name": "Public Policy Graduate Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR1110",
+    "name": "Foundations for Medicinal Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR1110A",
+    "name": "Foundations for Medicinal Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PR1110"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PR1111",
+    "name": "Pharmaceutical biochemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR1111A",
+    "name": "Pharmaceutical Biochemistry",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PR1111"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PR1120",
+    "name": "Microbiology in Pharmacy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR1140",
+    "name": "Pharmacy Professional Skills Development I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR1301",
+    "name": "Complementary Medicine and Health",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1507"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PR2114",
+    "name": "Formulation & Technology I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR2115",
+    "name": "Medicinal Chemistry for Drug Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR1110"
+    ]
+  },
+  {
+    "code": "PR2122",
+    "name": "Biotechnology for Pharmacy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR1111"
+    ]
+  },
+  {
+    "code": "PR2131",
+    "name": "Pharmacy Professional Skills Development II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR1140"
+    ]
+  },
+  {
+    "code": "PR2133",
+    "name": "Pharmacotherapeutics I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PA1113",
+      "PR1111"
+    ]
+  },
+  {
+    "code": "PR2134",
+    "name": "Self Care",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PX2108",
+      "PA1113",
+      "PR1140"
+    ]
+  },
+  {
+    "code": "PR2135",
+    "name": "Pharmacotherapeutics II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PX2108",
+      "PA1113"
+    ]
+  },
+  {
+    "code": "PR2143",
+    "name": "Pharmaceutical Analysis for Quality Assurance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CN4233E",
+      "CN4233R"
+    ],
+    "prerequisites": [
+      "PR1110"
+    ]
+  },
+  {
+    "code": "PR2202",
+    "name": "Cosmetics & Perfumes",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR2288",
+    "name": "Basic UROPS in Pharmacy I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR1110"
+    ]
+  },
+  {
+    "code": "PR2289",
+    "name": "Basic UROPS in Pharmacy II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR1110"
+    ]
+  },
+  {
+    "code": "PR3116",
+    "name": "Concepts in Pharmacokinetics and Biopharmaceutics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PA1113"
+    ]
+  },
+  {
+    "code": "PR3117",
+    "name": "Formulation & Technology II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR2114"
+    ]
+  },
+  {
+    "code": "PR3124",
+    "name": "Pharmacotherapeutics III",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR1120",
+      "PR2133"
+    ]
+  },
+  {
+    "code": "PR3136",
+    "name": "Pharmacotherapeutics IV",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR2135"
+    ]
+  },
+  {
+    "code": "PR3137",
+    "name": "Pharmacy Professional Skills Development III",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR2131",
+      "PR2134",
+      "PR3124",
+      "PR3146"
+    ]
+  },
+  {
+    "code": "PR3144",
+    "name": "Principles of Research Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GER1000"
+    ]
+  },
+  {
+    "code": "PR3145",
+    "name": "Compliance & Good Practices in Pharmacy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR2143"
+    ]
+  },
+  {
+    "code": "PR3146",
+    "name": "Pharmacy Law in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR1140"
+    ]
+  },
+  {
+    "code": "PR3202",
+    "name": "Community Health & Preventative Care",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PR3122"
+    ],
+    "prerequisites": [
+      "PR2134"
+    ]
+  },
+  {
+    "code": "PR3288",
+    "name": "Advanced UROPS in Pharmacy I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR2288",
+      "PR2289"
+    ]
+  },
+  {
+    "code": "PR3289",
+    "name": "Advanced UROPS in Pharmacy II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR2288",
+      "PR2289"
+    ]
+  },
+  {
+    "code": "PR3301",
+    "name": "Pharmaceutical Dosage Forms",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR4138",
+    "name": "Pharmacy Professional Skills Development IV",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR3137",
+      "PR3136",
+      "PR3146",
+      "PR2134"
+    ]
+  },
+  {
+    "code": "PR4196",
+    "name": "Pharmacy Research Project and Scientific Communication",
+    "creditCount": 16.0,
+    "preclusions": [
+      "PR4199"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES1102",
+      "ES1103"
+    ]
+  },
+  {
+    "code": "PR4197",
+    "name": "Pharmacy Internship I",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR2134",
+      "PR2133",
+      "PR2135",
+      "PR3146"
+    ]
+  },
+  {
+    "code": "PR4198",
+    "name": "Pharmacy Internship II",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR2134",
+      "PR2133",
+      "PR2135",
+      "PR3146"
+    ]
+  },
+  {
+    "code": "PR4201",
+    "name": "Pharmaceutical Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BH1003",
+      "MKT1003",
+      "CS3261"
+    ],
+    "prerequisites": [
+      "PR1140"
+    ]
+  },
+  {
+    "code": "PR4205",
+    "name": "Bioorganic Principles of Medicinal Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR2115"
+    ]
+  },
+  {
+    "code": "PR4207",
+    "name": "Applied Pharmacokinetics and Toxicokinetics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR3116"
+    ]
+  },
+  {
+    "code": "PR5113",
+    "name": "Clinical Pharmacokinetics & Therapeutic Drug Monitoring",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5130",
+    "name": "Advanced Pharmacotherapy I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5131",
+    "name": "Advanced Pharmacotherapy Ii",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5132",
+    "name": "Advanced Pharmacotherapy Iii",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5133",
+    "name": "Advanced Pharmacotherapy in Special Populations",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5134",
+    "name": "Physical Assessment and Diagnostic Tests",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5135",
+    "name": "Foundations In Advanced Pharmacy Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5136",
+    "name": "Pharmd Seminar",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5150",
+    "name": "Ambulatory Care Clerkship",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5151",
+    "name": "Acute Care Medicine Clerkship",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5152",
+    "name": "Adult General Medicine Clerkship",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5153",
+    "name": "Critical Care Clerkship",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5154",
+    "name": "Drug Information Clerkship",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5198",
+    "name": "Graduate Seminar Module In Pharmacy",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5211",
+    "name": "Pharmaceutical Analysis Iv",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR2104",
+      "PR2143",
+      "PR4203"
+    ]
+  },
+  {
+    "code": "PR5212",
+    "name": "Advanced Topics in Medicinal Chemistry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR3101",
+      "PR2115"
+    ]
+  },
+  {
+    "code": "PR5213",
+    "name": "Pharmaceutical Process Validation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5214",
+    "name": "Advances In Tablet Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR3117",
+      "PR3301"
+    ]
+  },
+  {
+    "code": "PR5216",
+    "name": "Advances In Drug Delivery",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR4205"
+    ]
+  },
+  {
+    "code": "PR5217",
+    "name": "Formulation Science",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR2101",
+      "PR3102",
+      "PR4106",
+      "PR3117",
+      "PR3301"
+    ]
+  },
+  {
+    "code": "PR5218",
+    "name": "Practical In Product Development (Lab Rotations)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR2101",
+      "PR3102",
+      "PR4106",
+      "PR3117",
+      "PR3301"
+    ]
+  },
+  {
+    "code": "PR5220",
+    "name": "Bioprocess Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR2122",
+      "PR3104",
+      "PR3301"
+    ]
+  },
+  {
+    "code": "PR5221",
+    "name": "Molecular Targets in Drug Discovery",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR2122",
+      "PR3104"
+    ]
+  },
+  {
+    "code": "PR5222",
+    "name": "Drug Metabolism",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PR5115",
+      "PR3106",
+      "PR3116",
+      "LSM3211",
+      "LSM4212",
+      "LSM4211"
+    ]
+  },
+  {
+    "code": "PR5230",
+    "name": "Pharmacoeconomics and Outcomes Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5234",
+    "name": "Pharmacogenomics and Pharmacogenetics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5239",
+    "name": "Clinical Pharmacy Research Project",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5250",
+    "name": "Elective Clerkship I",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5251",
+    "name": "Elective Clerkship II",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PR5252",
+    "name": "Elective Clerkship III",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS1101E",
+    "name": "Introduction to Politics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1003K",
+      "GEK1003",
+      "PS1101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS2203",
+    "name": "Ancient Western Political Thought",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS2231",
+      "EU2218",
+      "PS2201B",
+      "PS2218",
+      "EU2203"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS2204",
+    "name": "Modern Western Political Thought",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EU2204"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS2234",
+    "name": "Introduction to Comparative Politics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS2204B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS2237",
+    "name": "Introduction to International Relations",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS2207",
+      "PS2207B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS2240",
+    "name": "Introduction to Public Administration",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS2210B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS2244",
+    "name": "Public Administration in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA2222"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS2245",
+    "name": "Southeast Asian Politics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS2215B",
+      "SE2213"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS2247",
+    "name": "South Asian Politics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS2214B",
+      "PS2217B",
+      "PS3217B",
+      "SN2211",
+      "SN3221"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS2248",
+    "name": "Chinese Politics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS3205B",
+      "PS3250"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS2249",
+    "name": "Government and Politics of Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2003",
+      "GEM2003K",
+      "PS1102",
+      "PS2101",
+      "PS2101B",
+      "SS2209PS",
+      "SSA2209"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS2251",
+    "name": "The Region in the Postcolonial World",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS2255",
+    "name": "Politics of the Middle East",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2025"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS2257",
+    "name": "Contemporary African Politics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS2258",
+    "name": "Introduction to Political Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS3232",
+    "name": "Democratic Theory",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS3202B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS3236",
+    "name": "Ethnicity and Religion in Asian Politics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS3201",
+      "PS3206B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS3237",
+    "name": "Women and Politics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS3207B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS3238",
+    "name": "International Political Economy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK3001",
+      "GEM3001K",
+      "PS3207",
+      "PS3208B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS3240",
+    "name": "International Security",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS3210B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS3249",
+    "name": "Singapore's Foreign Policy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS3219B",
+      "SSA3205",
+      "SS3205PS"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS3251",
+    "name": "International and Regional Organisations",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS3254",
+      "EU3228"
+    ],
+    "prerequisites": [
+      "PS1101E",
+      "PS2237"
+    ]
+  },
+  {
+    "code": "PS3257",
+    "name": "Political Inquiry",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS2102",
+      "PS2102B",
+      "PS2231B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS3258",
+    "name": "Research Methods in Political Science",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PS3257"
+    ]
+  },
+  {
+    "code": "PS3260",
+    "name": "Politics and the Visual",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK3005"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS3267",
+    "name": "German Political Thought",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS3272",
+    "name": "The International Relations of Sub-Saharan Africa",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS3274",
+    "name": "Environmental Politics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS3311",
+    "name": "International Ethics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "YSS3270",
+      "PS3233"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS3550",
+    "name": "Political Science Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3550"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS3551",
+    "name": "FASS Undergraduate Research Opportunity (UROP )",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS3880G",
+    "name": "Topics in PS: Research Design and Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PS3257"
+    ]
+  },
+  {
+    "code": "PS4203",
+    "name": "China's Foreign Policy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4205",
+    "name": "Contemporary Politics of Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4206",
+    "name": "Regional Security in the Asia Pacific",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4208",
+    "name": "Theories of International Relations",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4209",
+    "name": "Public Organisation Theory and Practice",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4219",
+    "name": "Comparative Political Thought",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PS3201B",
+      "PS3231"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4224",
+    "name": "State and Society",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PS4204"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4228",
+    "name": "Comparative Democratic Politics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4230",
+    "name": "Public Sector Reforms in China",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4231",
+    "name": "Social Theory and International Relations",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PS3880B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4233",
+    "name": "Existentialist Political Theory",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4234",
+    "name": "Identity Politics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4235",
+    "name": "War Termination and the Stability of Peace",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4237",
+    "name": "Capitalism and Political Theory",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PS2258",
+      "PS2204"
+    ]
+  },
+  {
+    "code": "PS4311",
+    "name": "International Relations in Political Thought",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PS4213"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "PS4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PS4401",
+      "PS4401S"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4882A",
+    "name": "Topics in IR: Globalisation, Security and the State",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4882D",
+    "name": "Topics in IR: Politics of Global Migration",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4882E",
+    "name": "Topics in IR: Arms Control",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4882H",
+    "name": "Topics in IR: Food Politics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4882I",
+    "name": "Topics in IR: International Society",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS4883A",
+    "name": "Topics in PT: Orientalism and Femininity",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS5111",
+    "name": "Research Design In Political Science",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS5101",
+      "PS6101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS5111R",
+    "name": "Research Design in Political Science",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PS5101",
+      "PS6101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS5314",
+    "name": "Seminar In International Relations",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IZ5102",
+      "PS5208",
+      "PS6208",
+      "PS6301A",
+      "PS6401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS5314R",
+    "name": "Seminar in Int'l Relations",
+    "creditCount": 5.0,
+    "preclusions": [
+      "IZ5102",
+      "PS5208",
+      "PS6208",
+      "PS6301A",
+      "PS6401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "PS5316",
+    "name": "Seminar In Public Administration",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS5316R",
+    "name": "Seminar In Public Administration",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS5506",
+    "name": "Globalization and Public Governance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS5506R",
+    "name": "Globalization and Public Governance",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS6603",
+    "name": "Topics in Research Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PS5111"
+    ]
+  },
+  {
+    "code": "PS6660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PS6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "PX2108",
+    "name": "Basic Human Pathology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AY1130",
+      "PY1131"
+    ]
+  },
+  {
+    "code": "PY1131",
+    "name": "Human Anatomy & Physiology II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "AY1130"
+    ]
+  },
+  {
+    "code": "QF3101",
+    "name": "Investment Instruments: Theory and Computation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA1104",
+      "MA1505",
+      "MA1507",
+      "MA2104",
+      "MA2222",
+      "QF2101",
+      "MA3269"
+    ]
+  },
+  {
+    "code": "QF3310",
+    "name": "Undergraduate Professional Internship Programme",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3310"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "QF3311",
+    "name": "Undergraduate Professional Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3311"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "QF3312",
+    "name": "Enhanced Undergraduate Professional Internship Programme",
+    "creditCount": 12.0,
+    "preclusions": [
+      "XX3312"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "QF4102",
+    "name": "Financial Modelling and Computation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "QF3101"
+    ]
+  },
+  {
+    "code": "QF4199",
+    "name": "Honours Project in Quantitative Finance",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "QF5201",
+    "name": "Interest Rate Theory and Credit Risk",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "QF5202",
+    "name": "Structured Products",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "QF5203",
+    "name": "Risk Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "QF5204",
+    "name": "Numerical Methods in Quantitative Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "QF5205",
+    "name": "Topics in Quantitative Finance I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "QF5207",
+    "name": "Investment and Portfolio Selection",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "QF5210",
+    "name": "Financial Time Series: Theory and Computation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "QF3101",
+      "MA4269"
+    ]
+  },
+  {
+    "code": "QT5101",
+    "name": "Quantum measurements and statistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC2130",
+      "PC3130"
+    ]
+  },
+  {
+    "code": "QT5198",
+    "name": "Graduate Seminar In Quantum Information",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "QT5201Q",
+    "name": "Quantum Algorithms",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE1701",
+    "name": "Urban Land Use and Development",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE1102"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "RE1702",
+    "name": "Real Estate Data Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE1703",
+    "name": "Principles of Law for Real Estate",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BSP1702",
+      "BSP1702X"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "RE1704",
+    "name": "Principles of Real Estate Economics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC1301",
+      "EC1101E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "RE1705",
+    "name": "Real Estate Finance and Accounting",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE1101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "RE1706",
+    "name": "Design and Construction",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE1105"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "RE1901",
+    "name": "Real Estate Wealth Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE1301"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "RE2301",
+    "name": "GIS for Real Estate",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE3490"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "RE2701",
+    "name": "Urban Planning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE2103",
+      "AR2223"
+    ],
+    "prerequisites": [
+      "RE1701"
+    ]
+  },
+  {
+    "code": "RE2702",
+    "name": "Land Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE2105"
+    ],
+    "prerequisites": [
+      "RE1703"
+    ]
+  },
+  {
+    "code": "RE2704",
+    "name": "Introduction to Real Estate Valuation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE1104"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "RE2705",
+    "name": "Urban Economics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE2102",
+      "EC3381"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "RE2706",
+    "name": "Real Estate and Infrastructure Finance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE2104"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "RE2707",
+    "name": "Asset and Property Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE1103"
+    ],
+    "prerequisites": [
+      "RE1706"
+    ]
+  },
+  {
+    "code": "RE2708",
+    "name": "Computational Thinking and Programming for Real Estate",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE2801",
+    "name": "Research Methodology in Real Estate",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE3201"
+    ],
+    "prerequisites": [
+      "RE1702"
+    ]
+  },
+  {
+    "code": "RE3000",
+    "name": "Work Experience Internship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE3101",
+    "name": "Advanced Real Estate Valuation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE2107"
+    ]
+  },
+  {
+    "code": "RE3102",
+    "name": "Advanced Topics In Urban Planning",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE4490"
+    ],
+    "prerequisites": [
+      "RE2103"
+    ]
+  },
+  {
+    "code": "RE3103",
+    "name": "Real Estate Development",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE3381"
+    ],
+    "prerequisites": [
+      "RE2101",
+      "RE2102"
+    ]
+  },
+  {
+    "code": "RE3104",
+    "name": "Real Estate Investment Analysis",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE3281"
+    ],
+    "prerequisites": [
+      "RE2104"
+    ]
+  },
+  {
+    "code": "RE3105",
+    "name": "Regional Real Estate Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE3103"
+    ]
+  },
+  {
+    "code": "RE3106",
+    "name": "Residential Property Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE2106"
+    ]
+  },
+  {
+    "code": "RE3107",
+    "name": "Real Estate Practice And Ethics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE4180"
+    ],
+    "prerequisites": [
+      "RE2104",
+      "RE2107"
+    ]
+  },
+  {
+    "code": "RE3201",
+    "name": "Research Methodology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE2801"
+    ],
+    "prerequisites": [
+      "RE2101",
+      "RE2104"
+    ]
+  },
+  {
+    "code": "RE3211",
+    "name": "Real Estate Finance Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE2105"
+    ]
+  },
+  {
+    "code": "RE3212",
+    "name": "Corporate Investment In Real Estate",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE3104"
+    ]
+  },
+  {
+    "code": "RE3221",
+    "name": "Real Estate Development Law",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE2105"
+    ]
+  },
+  {
+    "code": "RE3222",
+    "name": "Urban Design And Conservation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE3102"
+    ]
+  },
+  {
+    "code": "RE4000",
+    "name": "Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [
+      "RE4181"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "RE4001",
+    "name": "Real Estate Case Study",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE4182"
+    ],
+    "prerequisites": [
+      "RE4182"
+    ]
+  },
+  {
+    "code": "RE4202",
+    "name": "Real Estate Internship Programme",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE4203",
+    "name": "Topics in Real Estate (Summer Programme)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE2101"
+    ]
+  },
+  {
+    "code": "RE4204",
+    "name": "Advanced Real Estate Marketing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE2106"
+    ]
+  },
+  {
+    "code": "RE4210",
+    "name": "Real Estate Finance Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE4211",
+      "RE4212"
+    ]
+  },
+  {
+    "code": "RE4211",
+    "name": "Reit Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE3104"
+    ]
+  },
+  {
+    "code": "RE4212",
+    "name": "Real Estate Securitization",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE3104"
+    ]
+  },
+  {
+    "code": "RE4213",
+    "name": "Real Estate Risk Analysis And Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE3104",
+      "RE4211",
+      "RE4212"
+    ]
+  },
+  {
+    "code": "RE4221",
+    "name": "Advanced Urban Planning Theories and Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE3102"
+    ]
+  },
+  {
+    "code": "RE4222",
+    "name": "Public Policy and Real Estate Markets",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE2102",
+      "RE3102"
+    ]
+  },
+  {
+    "code": "RE4223",
+    "name": "Urban Planning In Asian Cities",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE3102"
+    ]
+  },
+  {
+    "code": "RE4301",
+    "name": "Housing Markets and Housing Policies",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE4291"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "RE5000",
+    "name": "Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE5001",
+    "name": "Real Estate Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE5003",
+    "name": "Real Estate Investment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE5004",
+    "name": "Real Estate Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE5005",
+    "name": "Real Estate Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE5006",
+    "name": "Portfolio and Asset Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE5009",
+    "name": "Commercial Real Estate Appraisal",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE5011",
+    "name": "International Field Study",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE5012",
+    "name": "Integrative Field Project",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE5013",
+    "name": "Urban Policy & Real Estate Markets",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE5014",
+    "name": "Real Estate Investment Trusts & Property Funds",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE5015",
+    "name": "Spatial Information Systems (SIS) for Urban Planning",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE5016",
+    "name": "Real Estate Securitisation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE5018",
+    "name": "Statutory Valuation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "RE5009"
+    ]
+  },
+  {
+    "code": "RE5770",
+    "name": "Graduate Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE6007",
+    "name": "Research Topics In Real Estate",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "RE6770",
+    "name": "Phd Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SA4101",
+    "name": "Software Analysis and Design",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SA4102",
+    "name": "Enterprise Solutions Design and Development",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SA4104",
+    "name": "Software Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SA4105",
+    "name": "Web Application Development",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SA4106",
+    "name": "AD Project",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SA4107",
+    "name": "Industrial Attachment Project",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SA4108",
+    "name": "Mobile Application Development",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC1101E",
+    "name": "Making Sense of Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2101",
+    "name": "Methods of Social Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2202",
+    "name": "Sociology of Work",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2204",
+    "name": "Social Inequalities : Who Gets Ahead?",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2205",
+    "name": "Sociology of Family",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2206",
+    "name": "Culture & Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2207",
+    "name": "Peoples & Cultures of Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2208",
+    "name": "Baby or No Baby: Population Dynamics at a Crossroads",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2209",
+    "name": "Money, Business and Social Networks",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2210",
+    "name": "Sociology of Popular Culture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2211",
+    "name": "Medical Sociology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2212",
+    "name": "Sociology of Deviance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2213",
+    "name": "Childhood and Youth",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2214",
+    "name": "Media and Culture",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IF2214"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2215",
+    "name": "The Sociology of Food",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2216",
+    "name": "Emotions and Social Life",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2217",
+    "name": "Sociology of Tourism",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2218",
+    "name": "Anthropology and the Human Condition",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2220",
+    "name": "Gender Studies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2221",
+    "name": "Humans and Natures",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2222",
+    "name": "Sociology of Sports",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC2225",
+    "name": "The Social Life of Art",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3101",
+    "name": "Social Thought & Social Theory",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EU3224"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3202",
+    "name": "From Modernization to Globalization",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3203",
+    "name": "Race and Ethnic Relations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3204",
+    "name": "Sociology of Education",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3205",
+    "name": "Sociology of Power:Who Gets to Rule?",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3206",
+    "name": "Urban Sociology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3207",
+    "name": "Cultures of Kinship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3208",
+    "name": "Religion in Society & Culture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3209",
+    "name": "Data Analysis in Social Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SC2101",
+      "GL2104"
+    ]
+  },
+  {
+    "code": "SC3211",
+    "name": "Science, Technology & Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3212",
+    "name": "Southeast Asia in a Globalizing World",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3213",
+    "name": "Visual Ethnography: Theory and Practice",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IF3213"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3214",
+    "name": "Sociology of Life Course and Ageing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3215",
+    "name": "Law and Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3216",
+    "name": "Self and Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3219",
+    "name": "Sexuality in Comparative Perspective",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3220",
+    "name": "Ritual, Performance and Symbolic Action",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3221",
+    "name": "Qualitative Inquiry",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3222",
+    "name": "Social Transformations in Modern China",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3223",
+    "name": "Visual Culture I: Seeing & Representing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3224",
+    "name": "Theory and Practice in Cultural Studies",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XD3101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3226",
+    "name": "Markets and Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3228",
+    "name": "Senses and Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3229",
+    "name": "Comparing Deviance: Perverts & Scandalous Improprieties",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC3551",
+    "name": "FASS Undergraduate Research Opportunity (UROP)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4101",
+    "name": "Practising Anthropology and Sociology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4201",
+    "name": "Contemporary Social Theory",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4202",
+    "name": "Reading Ethnographies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4203",
+    "name": "Sociology of Organizations",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4205",
+    "name": "Sociology of Language & Communication",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4206",
+    "name": "Urban Anthropology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4209",
+    "name": "Interpretive Sociology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4210",
+    "name": "Sociology of Migration",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4212",
+    "name": "Social Memory",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4218",
+    "name": "Religions, Secularity, Post-Secularity",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4219",
+    "name": "Social Origins and Consequences of Financial Crises",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4221",
+    "name": "Comparative Analysis of Human Rights",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SC4208A"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4222",
+    "name": "Body and Society",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SC4208B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4223",
+    "name": "Health and Social Behaviour",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SC4214A"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4224",
+    "name": "Welfare and Social Justice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SC4215D"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4226",
+    "name": "Cultural Production: Power, Voice, Policies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4227",
+    "name": "Gender, Sex and Power",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4228",
+    "name": "Making Sense of Violence",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "SC4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SC4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4880",
+    "name": "Selected Topics in Socio'gy & Anthrop'gy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SC4208"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4880B",
+    "name": "Advanced Sociological Analysis of Singapore Society",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4881",
+    "name": "Selected Topics in Health & Society",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SC4214"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4882",
+    "name": "Issues in State and Society",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SC4215"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4882A",
+    "name": "Perspectives on State & Society",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SC4215A"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4882B",
+    "name": "Citizenship, Nation and Globalization",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SC4215B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC4883",
+    "name": "Selected Topics in Law and Justice",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SC4216"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC5101",
+    "name": "Graduate Research Methods",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SC6101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC5101R",
+    "name": "Graduate Research Methods",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC5102",
+    "name": "Quantitative Data Analysis",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SC6101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC5102R",
+    "name": "Quantitative Data Analysis",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SC6101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC5219",
+    "name": "Tourism: Culture, Society and the Environment",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SC5211D"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC5770",
+    "name": "Graduate Research Seminar for Masters students",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SC6770"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC6102",
+    "name": "Sociological Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC6212",
+    "name": "Global Transformations",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SC6211A"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC6214",
+    "name": "Gender, Culture And Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC6224",
+    "name": "Producing Ethnography",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC6228",
+    "name": "Social Stratification and Mobility",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SC6660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SC6660",
+      "SC6660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SC6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SDM5001",
+    "name": "Systems Architecture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SDM5002",
+    "name": "Systems Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SDM5003",
+    "name": "Knowledge Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SDM5004",
+    "name": "Systems Engineering Project Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE5208",
+      "DTS5720"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SDM5010",
+    "name": "Model-Based Systems Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DTS5725"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SDM5990",
+    "name": "Sdm Research Project",
+    "creditCount": 8.0,
+    "preclusions": [
+      "MT5910",
+      "MT5900"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SE1101E",
+    "name": "Southeast Asia: A Changing Region",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1008",
+      "GEM1008K",
+      "SSA1202",
+      "SS1203SE"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SE2210",
+    "name": "Popular Culture in Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SE4215"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SE2212",
+    "name": "Cities and Urban Life in Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE2213",
+    "name": "Politics in Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SE2281",
+      "SSA2207",
+      "SS2207SE",
+      "SC2207"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SE2218",
+    "name": "Changing Economic Landscape of SE Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE2219",
+    "name": "Culture and Power in Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE2221",
+    "name": "Old and New Music in Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE2223",
+    "name": "Doing Research In Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE2225",
+    "name": "Forbidden Pleasures: Vice in Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE2227",
+    "name": "Southeast Asian Gardens: History and Symbolism",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE2660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAT2201",
+      "LAV1201",
+      "LAV2201"
+    ]
+  },
+  {
+    "code": "SE3214",
+    "name": "Heritage and Heritagescapes in Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE3216",
+    "name": "Migration and Diaspora in Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE3218",
+    "name": "Industrialising Singapore and SE Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SE2215"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SE3224",
+    "name": "Thai Drawing and Painting",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE3228",
+    "name": "The Universe Unraveling: Narratives of War in Indochina",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE3230",
+    "name": "Seen and Unseen: Explorations in Balinese Theatre",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE3232",
+    "name": "Death and Dying in Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE3233",
+    "name": "Martial Arts in Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SE3880B"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SE3550",
+    "name": "Southeast Asian Studies Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3550"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SE3660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LAT2201",
+      "LAV1201",
+      "LAV2201"
+    ]
+  },
+  {
+    "code": "SE4101",
+    "name": "Southeast Asia Studies: Theory and Practice",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE4210",
+    "name": "Ancient Kingdoms of Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE4217",
+    "name": "Southeast Asia in the Global Economy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE4226",
+    "name": "Doing Ethnography in Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE4227",
+    "name": "Nationalism in Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "SE4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SE4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SE4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5151",
+    "name": "Approaches To The Study Of Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5201",
+    "name": "Supervised Research Project",
+    "creditCount": 8.0,
+    "preclusions": [
+      "SE5660"
+    ],
+    "prerequisites": [
+      "SE5151"
+    ]
+  },
+  {
+    "code": "SE5221",
+    "name": "Landscapes of Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GE5214"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5221R",
+    "name": "Landscapes of Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5222",
+    "name": "The Arts In Contemporary Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5222R",
+    "name": "The Arts In Contemporary Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5224",
+    "name": "Religion and Society in Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5224R",
+    "name": "Religion and Society in Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5226",
+    "name": "Race And Ethnicity In Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5226R",
+    "name": "Race And Ethnicity In Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5229",
+    "name": "Anthropological Approaches To Se Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5229R",
+    "name": "Anthropological Approaches to SE Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5244",
+    "name": "Country Studies: The Philippines",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5244R",
+    "name": "Country Studies: The Philippines",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5247",
+    "name": "Country Studies: Vietnam",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5247R",
+    "name": "Country Studies: Vietnam",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE5660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SE5201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SE6660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SE6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SG4206",
+    "name": "Enterprise Integration",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SG5101",
+    "name": "Software Analysis & Design",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SG4101"
+    ]
+  },
+  {
+    "code": "SG5103",
+    "name": "Software Quality Management",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SG5116",
+    "name": "Software Engineering Project",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SG5208",
+    "name": "Object Oriented Design Patterns",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SG5209",
+    "name": "Enterprise Java",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SG5211",
+    "name": "Business Process Management",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SG5221",
+    "name": "Independent Work 2",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SG5225",
+    "name": "Architecting Software Solutions",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SG5228",
+    "name": "Digital Innovation and Design",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SG5236",
+    "name": "Machine Learning for Software Engineers",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SG5237",
+    "name": "Secure Software Life Cycle",
+    "creditCount": 3.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5002",
+    "name": "Fundamentals in Industrial Safety",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5003",
+    "name": "Fundamentals In Environmental Protection",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5101",
+    "name": "Industrial Toxicology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5102",
+    "name": "Occupational Ergonomics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5105",
+    "name": "Noise and Other Physical Hazards",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5107",
+    "name": "Industrial Ventilation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5108",
+    "name": "Chemical Hazard Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SH5004"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5109",
+    "name": "Biostatistics and Epidemiology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5110",
+    "name": "Chemical Hazard Evaluation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SH5004"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5201",
+    "name": "Hazard Identification & Evaluation Techniques",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5202",
+    "name": "Quantified Risk Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5203",
+    "name": "Emergency Planning",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5204",
+    "name": "Safety Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5205",
+    "name": "Incident Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SH5203"
+    ]
+  },
+  {
+    "code": "SH5401",
+    "name": "Safety, Health, Environment & Quality Management System",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ESE5602"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5403",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SH5404",
+    "name": "Safety Health and Environmental Project",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SLP5113",
+    "name": "Professional Practice 3",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SLP5114",
+    "name": "Intervention And Management - Children 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SLP5115",
+    "name": "Intervention And Management - Adults 2",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SLP5116",
+    "name": "Research Project 2",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SLP5117",
+    "name": "Professional Practice Issues",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SLP5118",
+    "name": "Professional Practice 4",
+    "creditCount": 6.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN1101E",
+    "name": "South Asia : People, Culture, Develop'm",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN2213",
+    "name": "Governance and Politics in South Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS2247"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SN2234",
+    "name": "Gender and Society in South Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN2261",
+    "name": "The Emergence of Contemporary South Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN2271",
+    "name": "Religion and Society in South Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN2274",
+    "name": "South Asian Cultures: An Introduction",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN2275",
+    "name": "Contemporary Tamil Literature",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SN2291"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SN2277",
+    "name": "Indian Communities in Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN2280",
+    "name": "Marriage, Sex, Love in South Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN2283",
+    "name": "China-India Interactions: Changing Perspectives",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN2284",
+    "name": "Making Sense of Regions in South Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN3223",
+    "name": "International Relations of South Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN3261",
+    "name": "Exile, Indenture, IT: Global South Asians",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN3274",
+    "name": "South Asian Cinema",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN3275",
+    "name": "Tamil Culture and Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN3281",
+    "name": "The Story of Indian Business",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN3282",
+    "name": "Violence and Visual Cultures in South Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN3550",
+    "name": "Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3550"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SN4101",
+    "name": "Approaches to the Study of South Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN4221",
+    "name": "Regional Conflict & Cooperation in Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "SN4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SN4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SN4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SN5660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN6660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SN6770",
+    "name": "South Asia Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SP1230",
+    "name": "NUS H3 Science Research Programme",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SP1541",
+    "name": "Exploring Science Communication through Popular Science",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SP1203",
+      "ENV1202",
+      "SP2171",
+      "ES1541",
+      "ES1601",
+      "SP1541"
+    ],
+    "prerequisites": [
+      "ES1000",
+      "ES1103",
+      "SP1541"
+    ]
+  },
+  {
+    "code": "SP2171",
+    "name": "Discovering Science",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SP2173",
+    "name": "Atoms to Molecules",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SP2174",
+    "name": "The Cell",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SP2173"
+    ]
+  },
+  {
+    "code": "SP2251",
+    "name": "Science at the Nanoscale",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "PC1144",
+      "PC1432",
+      "PC1432X",
+      "CM1101",
+      "CM1131",
+      "PC1321",
+      "GEK1509"
+    ]
+  },
+  {
+    "code": "SP3172",
+    "name": "Integrated Science Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SP3175",
+    "name": "The Earth",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SP2174"
+    ]
+  },
+  {
+    "code": "SP3176",
+    "name": "The Universe",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SP3175"
+    ]
+  },
+  {
+    "code": "SP3202",
+    "name": "Evidence in Forensic Science",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GEK1542"
+    ]
+  },
+  {
+    "code": "SP3203",
+    "name": "Aquatic Ecology Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2251",
+      "GE2229"
+    ]
+  },
+  {
+    "code": "SP4261",
+    "name": "Articulating Probability and Statistics in Court",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1306"
+    ]
+  },
+  {
+    "code": "SP4262",
+    "name": "Forensic Human Identification",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM1306"
+    ]
+  },
+  {
+    "code": "SPH2101",
+    "name": "Public Health and Epidemiology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH2102",
+    "name": "Lifestyle, Behaviour and Public Health",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH2103",
+    "name": "Systems and Policies to improve Health",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH2104",
+    "name": "Public Health Nutrition",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH2105",
+    "name": "Introduction to Global Health",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH2106",
+    "name": "Health in the Later Years",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH2107",
+    "name": "Social Determinants of Health",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH2201",
+    "name": "Health of the Poor in Asia",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH3101",
+    "name": "Biostatistics for Public Health",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "BN2102",
+      "DSC2008",
+      "EC2303",
+      "PL2131",
+      "PR1142",
+      "PR2103",
+      "SC3209",
+      "ST1131",
+      "ST1232",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "SPH3102",
+    "name": "Public Health Communication",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH3103",
+    "name": "Public Health Economics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH3104",
+    "name": "Infectious disease epidemiology and public health",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SPH2101"
+    ]
+  },
+  {
+    "code": "SPH3109",
+    "name": "Designing Public Health Programmes",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "GEK1900",
+      "SPH2101"
+    ]
+  },
+  {
+    "code": "SPH3201",
+    "name": "Public Health Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5001",
+    "name": "Foundations of Public Health",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5002",
+    "name": "Public Health Research Methods",
+    "creditCount": 8.0,
+    "preclusions": [
+      "CO5102",
+      "CO5103"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5003",
+    "name": "Health Behaviour and Communication",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5203"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5004",
+    "name": "Introduction to Health Policy and Policy Analysis",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5104"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5005",
+    "name": "Practicum",
+    "creditCount": 8.0,
+    "preclusions": [
+      "CO5210"
+    ],
+    "prerequisites": [
+      "SPH5002",
+      "CO5102",
+      "CO5103"
+    ]
+  },
+  {
+    "code": "SPH5101",
+    "name": "Advanced Quantitative Methods I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5218"
+    ],
+    "prerequisites": [
+      "CO5103",
+      "SPH5002"
+    ]
+  },
+  {
+    "code": "SPH5102",
+    "name": "Design, Conduct and Analysis of Clinical Trials",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5220"
+    ],
+    "prerequisites": [
+      "SPH5002",
+      "CO5102",
+      "CO5103"
+    ]
+  },
+  {
+    "code": "SPH5103",
+    "name": "Collection, Management & Analysis of Quantitative Data",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5232"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5104",
+    "name": "Healthcare Analytics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5237"
+    ],
+    "prerequisites": [
+      "SPH5002",
+      "CO5103"
+    ]
+  },
+  {
+    "code": "SPH5201",
+    "name": "Control of Communicable Diseases",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5202",
+    "name": "Control of Non-Communicable Diseases",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5203",
+    "name": "Advanced Epidemiology I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5215"
+    ],
+    "prerequisites": [
+      "SPH5002",
+      "CO5102",
+      "CO5103"
+    ]
+  },
+  {
+    "code": "SPH5204",
+    "name": "Nutrition and Health - Fundamentals and Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5229"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5205",
+    "name": "Urban Outbreak Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5301",
+    "name": "Occupational Health Practice",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5304"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5302",
+    "name": "Occupational Toxicology and Industrial Hygiene",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5305",
+      "CO5306"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5303",
+    "name": "Workplace Assessment",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5317"
+    ],
+    "prerequisites": [
+      "CO5305",
+      "CO5306",
+      "SPH5302"
+    ]
+  },
+  {
+    "code": "SPH5304",
+    "name": "Occupational Ergonomics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5312"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5305",
+    "name": "Clinical Occupational Medicine",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5307"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5306",
+    "name": "Environmental Health",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5202"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5307",
+    "name": "Principles of Workplace Health",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5401",
+    "name": "Health Economics and Financing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5204"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5402",
+    "name": "Management of Healthcare Organisations",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5205"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5403",
+    "name": "Medical & Humanitarian Emergencies",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5206"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5404",
+    "name": "Measuring and Managing Quality of Care",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5208"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5405",
+    "name": "Introduction to Health Services Research",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5214"
+    ],
+    "prerequisites": [
+      "SPH5002",
+      "CO5102",
+      "CO5103"
+    ]
+  },
+  {
+    "code": "SPH5406",
+    "name": "Contemporary Global Health Issues",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5221"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5407",
+    "name": "Programme Evaluation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5222"
+    ],
+    "prerequisites": [
+      "SPH5002",
+      "CO5102",
+      "CO5103"
+    ]
+  },
+  {
+    "code": "SPH5408",
+    "name": "Public Health and Ageing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5230"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5409",
+    "name": "Qualitative Methods in Public Health",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5233"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5410",
+    "name": "Developing health proposals using DME skills & tools",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5234"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5411",
+    "name": "Information Technology in Healthcare",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5235"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5412",
+    "name": "Economic Methods in Health Technology Assessment",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5236"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5413",
+    "name": "Women\u2019s, Children\u2019s and Adolescents\u2019 Health",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5414",
+    "name": "Informatics for Health",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5501",
+    "name": "Public Health Communication",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5226"
+    ],
+    "prerequisites": [
+      "CO5203",
+      "SPH5003"
+    ]
+  },
+  {
+    "code": "SPH5801",
+    "name": "Field Practice",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5231"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5880A",
+    "name": "Special Topics in Epidemiology and Disease Control",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5880"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5880B",
+    "name": "Special Topics in Quantitative Methods",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5880"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5880C",
+    "name": "Special Topics in Environmental/Occupational Health",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5880"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5880D",
+    "name": "Special Topics in Health Policy and Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5880"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5880E",
+    "name": "Special Topics in Health Services Research",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5880"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5880F",
+    "name": "Special Topics in Health Promotion",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5880"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5880G",
+    "name": "Special Topics in Global Health",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5880"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5890A",
+    "name": "Independent Study in Epidemiology and Disease Control",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5223"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5890B",
+    "name": "Independent Study in Quantitative Methods",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5223"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5890C",
+    "name": "Independent Study in Environmental / Occupational Health",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5223"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5890D",
+    "name": "Independent Study in Health Policy and Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5223"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5890E",
+    "name": "Independent Study in Health Services Research",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5223"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5890F",
+    "name": "Independent Study in Health Promotion",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5223"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH5890G",
+    "name": "Independent Study in Global Health Programs: Planning and Evaluation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CO5223"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6001",
+    "name": "Advanced Epidemiology II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CO5102",
+      "CO5103"
+    ]
+  },
+  {
+    "code": "SPH6002",
+    "name": "Advanced Quantitative Methods II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "CO5103"
+    ]
+  },
+  {
+    "code": "SPH6004",
+    "name": "Advanced Biostatistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6201A",
+    "name": "Independent Study (Epidemiology and Disease Control)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6201B",
+    "name": "Independent Study (Biostatistics)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6201C",
+    "name": "Independent Study (Environmental / Occupational Health)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6201D",
+    "name": "Independent Study (Health Policy and Systems)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6201E",
+    "name": "Independent Study (Health Services Research)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6201F",
+    "name": "Independent Study (Health Promotion)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6201G",
+    "name": "Independent Study (Global Health)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6770",
+    "name": "Graduate Research Seminar in Public Health",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6880A",
+    "name": "Special Topics in Epidemiology and Disease Control",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6880B",
+    "name": "Special Topics in Biostatistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6880C",
+    "name": "Special Topics in Environmental / Occupational Health",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6880D",
+    "name": "Special Topics in Health Policy and Systems",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6880E",
+    "name": "Special Topics in Health Services Research",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6880F",
+    "name": "Special Topics in Health Promotion",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SPH6880G",
+    "name": "Special Topics in Global Health",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA1201",
+    "name": "Singapore Society",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GES1028"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA1202",
+    "name": "Southeast Asia: A Changing Region",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK1008",
+      "GEM1008K",
+      "SE1101E",
+      "SS1203SE"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA1206",
+    "name": "Representing Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GES1023"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA1207",
+    "name": "Singapore Literature in English: Selected Texts",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA1207FC",
+      "GES1025"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA1208",
+    "name": "Everyday Life of Chinese Singaporeans: Past & Present (taught in English)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GES1005"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2202",
+    "name": "Changing Landscapes of Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2001",
+      "GES1003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2203",
+    "name": "Singapore\u2019s Business History",
+    "creditCount": 4.0,
+    "preclusions": [
+      "HY2239",
+      "GES1009"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2204",
+    "name": "Nation-Building in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "HY2229",
+      "GES1010"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2205",
+    "name": "Singapore and Japan: Historical and Contemporary Relationships",
+    "creditCount": 4.0,
+    "preclusions": [
+      "JS2224",
+      "GES1015"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2206",
+    "name": "Islam and Contemporary Malay Society",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GES1014",
+      "MS2205"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2207",
+    "name": "Politics in Southeast Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SE2213",
+      "SE2281",
+      "SS2207SE"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2209",
+    "name": "Government and Politics of Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEK2003",
+      "GEM2003K",
+      "PS1102",
+      "PS2101B",
+      "PS2101",
+      "PS2249",
+      "SS2209PS"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2211",
+    "name": "The Evolution of a Global City-State",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GES1011"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2214",
+    "name": "Singapore and India: Emerging Relations",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GES1006"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2215",
+    "name": "The Biophysical Environment of Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GES1004"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2218",
+    "name": "Singapore Film: Performance of Identity",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TS2238",
+      "GES1029"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2219",
+    "name": "South Asia in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GES1007"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2220",
+    "name": "Global Economic Dimensions of Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC2373",
+      "PP5215",
+      "GES1002",
+      "SSA2220T",
+      "GES1002T"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2220T",
+    "name": "Global Economic Dimensions Of Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EC2202",
+      "EC2373",
+      "GES1002T",
+      "SSA2220",
+      "GES1002"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2221",
+    "name": "Popular Culture in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "HY2254",
+      "GES1012"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA2222",
+    "name": "Public Administration in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS2244"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA3201",
+    "name": "Singapore English-Language Theatre",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TS3235",
+      "SSA3201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA3203",
+    "name": "The Malays of Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MS3209"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSA3205",
+    "name": "Singapore's Foreign Policy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PS3219B",
+      "SS3205PS",
+      "PS3249"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSB1204T",
+    "name": "Labour Law In Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSB1204",
+      "GES1000",
+      "GES1000T"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSD1203",
+    "name": "Real Estate Development & Investment Law",
+    "creditCount": 4.0,
+    "preclusions": [
+      "BSP1004",
+      "BSP1004X",
+      "SSB2212",
+      "GES1024"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSD2210",
+    "name": "Managing Singapore's Built Environment",
+    "creditCount": 4.0,
+    "preclusions": [
+      "RE1102",
+      "GES1019"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSE1201",
+    "name": "Building a Dynamic Singapore - Role of Engineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GES1017"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSS1207",
+    "name": "Natural Heritage of Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GES1021"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SSY2223",
+    "name": "Western Music within a Singaporean Context",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GES1020"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ST1131",
+    "name": "Introduction to Statistics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ST1131A",
+      "ST1232",
+      "ST2334",
+      "CE2407",
+      "CN3421",
+      "EC2231",
+      "EC2303",
+      "PR2103",
+      "DSC2008"
+    ],
+    "prerequisites": [
+      "MA1301",
+      "MA1301FC",
+      "MA1301X"
+    ]
+  },
+  {
+    "code": "ST1232",
+    "name": "Statistics for Life Sciences",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ST1131",
+      "ST1131A",
+      "ST2334",
+      "CE2407",
+      "CN3421",
+      "EC2231",
+      "EC2303",
+      "PR2103",
+      "DSC2008"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ST2131",
+    "name": "Probability",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA2216",
+      "ST2334",
+      "CE2407"
+    ],
+    "prerequisites": [
+      "MA1102",
+      "MA1102R",
+      "MA1312",
+      "MA1507",
+      "MA1505",
+      "MA1505C",
+      "MA1521"
+    ]
+  },
+  {
+    "code": "ST2132",
+    "name": "Mathematical Statistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA2216",
+      "ST2131",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "ST2137",
+    "name": "Computer Aided Data Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST1131",
+      "ST1131A",
+      "ST1232",
+      "ST2334",
+      "ST2131",
+      "MA2216"
+    ]
+  },
+  {
+    "code": "ST2288",
+    "name": "Basic UROPS in Statistics and Applied Probability I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST1131",
+      "ST1232"
+    ]
+  },
+  {
+    "code": "ST2289",
+    "name": "Basic UROPS in Statistics and Applied Probability II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST1131",
+      "ST1232"
+    ]
+  },
+  {
+    "code": "ST2334",
+    "name": "Probability and Statistics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ST1131",
+      "ST1131A",
+      "ST1232",
+      "ST2131",
+      "MA2216",
+      "CE2407",
+      "EC2231",
+      "EC2303",
+      "PR2103",
+      "DSC2008",
+      "ME4273"
+    ],
+    "prerequisites": [
+      "MA1102R",
+      "MA1312",
+      "MA1505",
+      "MA1507",
+      "MA1521"
+    ]
+  },
+  {
+    "code": "ST3131",
+    "name": "Regression Analysis",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ST2335",
+      "EC3303"
+    ],
+    "prerequisites": [
+      "ST2131",
+      "MA2216",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "ST3232",
+    "name": "Design & Analysis of Experiments",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2132",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "ST3233",
+    "name": "Applied Time Series Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2132",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "ST3236",
+    "name": "Stochastic Processes I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA3238"
+    ],
+    "prerequisites": [
+      "MA1101",
+      "MA1101R",
+      "MA1311",
+      "MA1508",
+      "ST2131",
+      "MA2216"
+    ]
+  },
+  {
+    "code": "ST3239",
+    "name": "Survey Methodology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "MA2216",
+      "ST2131",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "ST3240",
+    "name": "Multivariate Statistical Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST3131"
+    ]
+  },
+  {
+    "code": "ST3241",
+    "name": "Categorical Data Analysis I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST3131"
+    ]
+  },
+  {
+    "code": "ST3242",
+    "name": "Introduction to Survival Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2132"
+    ]
+  },
+  {
+    "code": "ST3243",
+    "name": "Statistical Methods in Epidemiology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2132",
+      "ST2131",
+      "MA2216"
+    ]
+  },
+  {
+    "code": "ST3244",
+    "name": "Demographic Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST1131"
+    ]
+  },
+  {
+    "code": "ST3246",
+    "name": "Statistical Models for Actuarial Science",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2132"
+    ]
+  },
+  {
+    "code": "ST3247",
+    "name": "Simulation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2131",
+      "ST2334",
+      "MA2216",
+      "CS1010",
+      "CS1010E",
+      "CS1010S",
+      "CS1010FC",
+      "IT1006"
+    ]
+  },
+  {
+    "code": "ST3248",
+    "name": "Statistical Learning I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ST4240"
+    ],
+    "prerequisites": [
+      "ST2132",
+      "ST2334"
+    ]
+  },
+  {
+    "code": "ST3288",
+    "name": "Advanced UROPS in Statistics & Applied Probability I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ST3289",
+    "name": "Advanced UROPS in Statistics & Applied Probability II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ST3312",
+    "name": "Enhanced Undergraduate Professional Internship Programme",
+    "creditCount": 12.0,
+    "preclusions": [
+      "XX3312"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ST4199",
+    "name": "Honours Project in Statistics",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ST4231",
+    "name": "Computer Intensive Statistical Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2132"
+    ]
+  },
+  {
+    "code": "ST4232",
+    "name": "Nonparametric Statistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2132"
+    ]
+  },
+  {
+    "code": "ST4233",
+    "name": "Linear Models",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST3131"
+    ]
+  },
+  {
+    "code": "ST4234",
+    "name": "Bayesian Statistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2132"
+    ]
+  },
+  {
+    "code": "ST4238",
+    "name": "Stochastic Processes II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA4251"
+    ],
+    "prerequisites": [
+      "MA3238",
+      "ST3236"
+    ]
+  },
+  {
+    "code": "ST4241",
+    "name": "Design & Analysis of Clinical Trials",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST3242",
+      "ST2132"
+    ]
+  },
+  {
+    "code": "ST4242",
+    "name": "Analysis of Longitudinal Data",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST3131"
+    ]
+  },
+  {
+    "code": "ST4245",
+    "name": "Statistical Methods for Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST3131"
+    ]
+  },
+  {
+    "code": "ST4248",
+    "name": "Statistical Learning II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ST4240"
+    ],
+    "prerequisites": [
+      "ST3131",
+      "ST3248"
+    ]
+  },
+  {
+    "code": "ST5198",
+    "name": "Graduate Seminar Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ST5199",
+    "name": "Coursework Track Ii Project",
+    "creditCount": 16.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ST5201",
+    "name": "Statistical Foundations of Data Science",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ST5202",
+    "name": "Applied Regression Analysis",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ST5318"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ST5206",
+    "name": "Generalized Linear Models",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST4233"
+    ]
+  },
+  {
+    "code": "ST5210",
+    "name": "Multivariate Data Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST3240"
+    ]
+  },
+  {
+    "code": "ST5212",
+    "name": "Survival Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2132"
+    ]
+  },
+  {
+    "code": "ST5213",
+    "name": "Categorical Data Analysis Ii",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST3131"
+    ]
+  },
+  {
+    "code": "ST5214",
+    "name": "Advanced Probability Theory",
+    "creditCount": 4.0,
+    "preclusions": [
+      "MA5259"
+    ],
+    "prerequisites": [
+      "ST2131"
+    ]
+  },
+  {
+    "code": "ST5215",
+    "name": "Advanced Statistical Theory",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST2131",
+      "ST2132"
+    ]
+  },
+  {
+    "code": "ST5218",
+    "name": "Advanced Statistical Methods In Finance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST4245"
+    ]
+  },
+  {
+    "code": "ST5221",
+    "name": "Probability and Stochastic Processes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ST5214",
+      "MA5259"
+    ],
+    "prerequisites": [
+      "ST2131"
+    ]
+  },
+  {
+    "code": "ST5222",
+    "name": "Advanced Topics in Applied Statistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ST5223",
+    "name": "Statistical Models:Theory/Applications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ST5224",
+    "name": "Advanced Statistical Theory II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST5215"
+    ]
+  },
+  {
+    "code": "ST5226",
+    "name": "Spatial Statistics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST5201"
+    ]
+  },
+  {
+    "code": "ST5227",
+    "name": "Applied Data Mining",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ST5201",
+      "ST5202"
+    ]
+  },
+  {
+    "code": "STR1000",
+    "name": "Career Creation Starter Workshops",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "STR2000",
+    "name": "Career Creation Starter Clinics",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW1101E",
+    "name": "Social Work: A Heart-Head-Hand Connection",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW2101",
+    "name": "Working with Individuals and Families",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E"
+    ]
+  },
+  {
+    "code": "SW2104",
+    "name": "Human Development over the Lifespan",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW2105",
+    "name": "Values & Skills for Helping Relationships",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E"
+    ]
+  },
+  {
+    "code": "SW2106",
+    "name": "Social Group Work Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E"
+    ]
+  },
+  {
+    "code": "SW3101",
+    "name": "Social Work Research Methods",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E"
+    ]
+  },
+  {
+    "code": "SW3103A",
+    "name": "Social Work Field Practice (I)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105"
+    ]
+  },
+  {
+    "code": "SW3104",
+    "name": "Social Work Field Practice (II)",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW3103A"
+    ]
+  },
+  {
+    "code": "SW3105",
+    "name": "Community Work Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E"
+    ]
+  },
+  {
+    "code": "SW3207",
+    "name": "Social Work in Medical Settings",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW3209",
+    "name": "Counselling Theories & Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E"
+    ]
+  },
+  {
+    "code": "SW3213",
+    "name": "Working With Older Adults",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW3217",
+    "name": "Mental Health and Illness",
+    "creditCount": 4.0,
+    "preclusions": [
+      "PL3236"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SW3219",
+    "name": "Child-centric Social Work",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW3880",
+    "name": "Special Topics in Social Work",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW4101",
+    "name": "Advanced Family-Centred Swk Practice",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3104",
+      "SW4000",
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3104",
+      "SW4000"
+    ]
+  },
+  {
+    "code": "SW4102",
+    "name": "Social Policy and Planning",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3103A",
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3103A"
+    ]
+  },
+  {
+    "code": "SW4103",
+    "name": "Advanced Research and Evaluation",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3101",
+      "SW3103A",
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3101",
+      "SW3103A"
+    ]
+  },
+  {
+    "code": "SW4201",
+    "name": "Theory Building in Social Work Practice",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3104",
+      "SW4000",
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3104",
+      "SW4000"
+    ]
+  },
+  {
+    "code": "SW4202",
+    "name": "Special Areas of Social Work Practice",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3104",
+      "SW4000",
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3104",
+      "SW4000"
+    ]
+  },
+  {
+    "code": "SW4207",
+    "name": "Social Demography",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3104",
+      "SW4000",
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3104",
+      "SW4000"
+    ]
+  },
+  {
+    "code": "SW4208",
+    "name": "Social Gerontology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3103A",
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3103A"
+    ]
+  },
+  {
+    "code": "SW4209",
+    "name": "Law & Social Work Practice",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3104",
+      "SW4000",
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3104",
+      "SW4000"
+    ]
+  },
+  {
+    "code": "SW4213",
+    "name": "Social Networks & Social Support",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3103A",
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3103A"
+    ]
+  },
+  {
+    "code": "SW4216",
+    "name": "Advanced Studies in Community Work",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3103A",
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3103A"
+    ]
+  },
+  {
+    "code": "SW4221",
+    "name": "Social Work and Rehabilitation of Offenders",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "SW1101E",
+      "SW2101",
+      "SW2104",
+      "SW2105",
+      "SW3103A"
+    ]
+  },
+  {
+    "code": "SW4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "SW4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SW4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "SW4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SW5104",
+    "name": "Management of Human Service Organizations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW5107",
+    "name": "Program Development and Evaluation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW5111",
+    "name": "Advanced Practicum",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW5111A",
+    "name": "Practicum",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW5111B",
+    "name": "Practicum",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW5112",
+    "name": "Supervised Project",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW5207",
+    "name": "Working with Multi-Stressed Families",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW5207R",
+    "name": "Working with Multi-Stressed Families",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW5660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW5880",
+    "name": "Special Topics In Social Work",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW5880R",
+    "name": "Special Topics in Social Work",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW6101",
+    "name": "Social Theory In Social Work Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SW6660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SW6262"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "SWD5102",
+    "name": "Social Work With Groups And Community",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SWD5103",
+    "name": "Contemporary Social Work Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SWD5104",
+    "name": "Human Development in Context",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SWD5105",
+    "name": "Skills In Advanced Social Work Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SWD5120",
+    "name": "Social Work Practicum",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SW5120"
+    ],
+    "prerequisites": [
+      "SWD5103"
+    ]
+  },
+  {
+    "code": "SWD5269",
+    "name": "Working With Children And Youth",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SWD5283",
+    "name": "Disability And Rehabilitative Work",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "SWD5880",
+    "name": "Topics in Social Work",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TBA2101",
+    "name": "Building an Analytics Organisation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TBA2102",
+    "name": "Introduction to Business Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TBA2103",
+    "name": "Data Visualisation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TIC2001"
+    ]
+  },
+  {
+    "code": "TBA2104",
+    "name": "Predictive Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TBA3204",
+    "name": "Web Analytics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TBA2102"
+    ]
+  },
+  {
+    "code": "TC1005",
+    "name": "MATLAB Programming for Chemical Engineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCN1005"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TC1411",
+    "name": "Mathematics for Chemical Engineers 1",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCN1411"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TC1422",
+    "name": "Materials for Chemical Engineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCN1422"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TC2411",
+    "name": "Mathematics for Chemical Engineers 2",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCN2411"
+    ],
+    "prerequisites": [
+      "TC1411"
+    ]
+  },
+  {
+    "code": "TCE1109",
+    "name": "Statics And Mechanics of Materials",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE1109"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TCE2112",
+    "name": "Soil Mechanics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE2112"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TCE2134",
+    "name": "Hydraulics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE2134"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TCE2155",
+    "name": "Structural Mechanics and Materials",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE2155"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TCE2183",
+    "name": "Construction Project Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE2183"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TCE2184",
+    "name": "Infrastructure & the Environment",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE2184"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TCE3115",
+    "name": "Geotechnical Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE3115"
+    ],
+    "prerequisites": [
+      "TCE2112"
+    ]
+  },
+  {
+    "code": "TCE3116",
+    "name": "Foundation Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE3116"
+    ],
+    "prerequisites": [
+      "TCE2112"
+    ]
+  },
+  {
+    "code": "TCE3165",
+    "name": "Structural Concrete Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE3165"
+    ],
+    "prerequisites": [
+      "TCE2155"
+    ]
+  },
+  {
+    "code": "TCE3166",
+    "name": "Structural Steel Design and System",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CE3166"
+    ],
+    "prerequisites": [
+      "TCE2155"
+    ]
+  },
+  {
+    "code": "TCN1005",
+    "name": "MATLAB Programming for Chemical Engineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC1005"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TCN1111",
+    "name": "Chemical Engineering Principles",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC1101",
+      "CN1111E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TCN1411",
+    "name": "Mathematics for Chemical Engineers 1",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC1411"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TCN1422",
+    "name": "Materials for Chemical Engineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC1422"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TCN2116",
+    "name": "Chemical Kinetics And Reactor Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC2106",
+      "CN2116E"
+    ],
+    "prerequisites": [
+      "TCN1111"
+    ]
+  },
+  {
+    "code": "TCN2121",
+    "name": "Chemical Engineering Thermodynamics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC2111",
+      "CN2121E"
+    ],
+    "prerequisites": [
+      "TCN1111"
+    ]
+  },
+  {
+    "code": "TCN2122",
+    "name": "Fluid Mechanics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC2112",
+      "CN2122E"
+    ],
+    "prerequisites": [
+      "TCN2411"
+    ]
+  },
+  {
+    "code": "TCN2125",
+    "name": "Heat And Mass Transfer",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC2115",
+      "CN2125E"
+    ],
+    "prerequisites": [
+      "TCN2122"
+    ]
+  },
+  {
+    "code": "TCN2411",
+    "name": "Mathematics for Chemical Engineers 2",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC2411"
+    ],
+    "prerequisites": [
+      "CN1411",
+      "TCN1411"
+    ]
+  },
+  {
+    "code": "TCN3121",
+    "name": "Process Dynamics & Control",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC3111",
+      "CN3121E"
+    ],
+    "prerequisites": [
+      "TCN2411"
+    ]
+  },
+  {
+    "code": "TCN3124",
+    "name": "Particle Technology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC3114",
+      "CN3124E"
+    ],
+    "prerequisites": [
+      "TCN2122"
+    ]
+  },
+  {
+    "code": "TCN3132",
+    "name": "Separation Processes",
+    "creditCount": 5.0,
+    "preclusions": [
+      "TC2113",
+      "CN3132E"
+    ],
+    "prerequisites": [
+      "TCN1111",
+      "TCN2121",
+      "TCN2125"
+    ]
+  },
+  {
+    "code": "TCN3135",
+    "name": "Process Safety, Health and Environment",
+    "creditCount": 3.0,
+    "preclusions": [
+      "CN3135E"
+    ],
+    "prerequisites": [
+      "TCN2121",
+      "TCN2122"
+    ]
+  },
+  {
+    "code": "TCN3421",
+    "name": "Process Modeling & Numerical Simulation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC3411",
+      "CN3421E"
+    ],
+    "prerequisites": [
+      "TCN2116",
+      "TCN2121",
+      "TCN2125"
+    ]
+  },
+  {
+    "code": "TCN4122",
+    "name": "Process Synthesis and Simulation",
+    "creditCount": 3.0,
+    "preclusions": [
+      "CN4122E"
+    ],
+    "prerequisites": [
+      "TCN2116",
+      "TCN2121",
+      "TCN3124",
+      "TCN3132"
+    ]
+  },
+  {
+    "code": "TCN4205",
+    "name": "Pinch Analysis and Process Integration",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CN4205E"
+    ],
+    "prerequisites": [
+      "TCN2125",
+      "TCN3421"
+    ]
+  },
+  {
+    "code": "TCN4208",
+    "name": "Biochemical Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CN4208E"
+    ],
+    "prerequisites": [
+      "TC2106",
+      "CN2116E",
+      "TCN2116",
+      "TC2112",
+      "CN2122E",
+      "TCN2122"
+    ]
+  },
+  {
+    "code": "TCN4210",
+    "name": "Membrane Science And Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC4210",
+      "CN4210E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TCN4215",
+    "name": "Food Technology and Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC4215",
+      "CN4215E"
+    ],
+    "prerequisites": [
+      "TCN2122",
+      "TCN3132"
+    ]
+  },
+  {
+    "code": "TCN4216",
+    "name": "Electronic Materials Science",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC4216",
+      "CN4216E"
+    ],
+    "prerequisites": [
+      "TCN1422"
+    ]
+  },
+  {
+    "code": "TCN4227",
+    "name": "Advanced Process Control",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TC4227",
+      "CN4227E"
+    ],
+    "prerequisites": [
+      "TCN3121"
+    ]
+  },
+  {
+    "code": "TCN4233",
+    "name": "Good Manufacturing Practices in Pharmaceutical Industry",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CN4233R",
+      "PR2143",
+      "PR3145",
+      "PR4206",
+      "CN4233E"
+    ],
+    "prerequisites": [
+      "TCN2122",
+      "TCN2125"
+    ]
+  },
+  {
+    "code": "TCN4240",
+    "name": "Unit Operations and Processes for Effluent Treatment",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CN4240E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TCN4242",
+    "name": "Optimization of Chemical Processes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CN4242E"
+    ],
+    "prerequisites": [
+      "TCN2411",
+      "TCN3421"
+    ]
+  },
+  {
+    "code": "TCN4246",
+    "name": "Chemical And Bio-Catalysis",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CN4246E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TE2002",
+    "name": "Engineering Mathematics II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE2002"
+    ],
+    "prerequisites": [
+      "TE2102",
+      "TG1401"
+    ]
+  },
+  {
+    "code": "TE2003",
+    "name": "Advanced Mathematics for Engineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TE2401",
+      "TEE2003"
+    ],
+    "prerequisites": [
+      "TE2002"
+    ]
+  },
+  {
+    "code": "TE2101",
+    "name": "Programming Methodology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TE1122",
+      "TEE2101",
+      "TIC1001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TE3201",
+    "name": "Software Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE3201"
+    ],
+    "prerequisites": [
+      "TE2101"
+    ]
+  },
+  {
+    "code": "TE3801",
+    "name": "Robust Design Of Electronic Circuits",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TEE3801"
+    ],
+    "prerequisites": [
+      "EE2005E",
+      "EE2021E",
+      "TEE2027",
+      "TE2003"
+    ]
+  },
+  {
+    "code": "TE4001",
+    "name": "BTech Dissertation",
+    "creditCount": 12.0,
+    "preclusions": [
+      "TEE4001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TEE2002",
+    "name": "Engineering Mathematics II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TE2002"
+    ],
+    "prerequisites": [
+      "TE2102",
+      "TTG1401"
+    ]
+  },
+  {
+    "code": "TEE2003",
+    "name": "Advanced Mathematics for Engineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TE2401",
+      "TE2003"
+    ],
+    "prerequisites": [
+      "TEE2002"
+    ]
+  },
+  {
+    "code": "TEE2011",
+    "name": "Engineering Electromagnetics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2011E"
+    ],
+    "prerequisites": [
+      "TEE2002"
+    ]
+  },
+  {
+    "code": "TEE2023",
+    "name": "Signals and Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2009E",
+      "EE2010E",
+      "EE2023E"
+    ],
+    "prerequisites": [
+      "TTG1401"
+    ]
+  },
+  {
+    "code": "TEE2026",
+    "name": "Digital Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2020E",
+      "TEE2020"
+    ],
+    "prerequisites": [
+      "EE1002"
+    ]
+  },
+  {
+    "code": "TEE2027",
+    "name": "Electronic Circuits",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2004E",
+      "EE2005E",
+      "EE2021E",
+      "TEE2021"
+    ],
+    "prerequisites": [
+      "EG1112"
+    ]
+  },
+  {
+    "code": "TEE2028",
+    "name": "Microcontroller Programming and Interfacing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2007E",
+      "EE2024E",
+      "TEE2024"
+    ],
+    "prerequisites": [
+      "EE2020E",
+      "TEE2020",
+      "TEE2026"
+    ]
+  },
+  {
+    "code": "TEE2033",
+    "name": "Integrated System Lab",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2031E",
+      "EE2032E",
+      "TEE2031",
+      "TEE2032"
+    ],
+    "prerequisites": [
+      "EE2023E",
+      "TEE2023",
+      "EE2011E",
+      "TEE2011",
+      "EE2021E",
+      "TEE2021",
+      "TEE2027"
+    ]
+  },
+  {
+    "code": "TEE2101",
+    "name": "Programming Methodology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TE1122",
+      "TE2101",
+      "TIC1001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TEE3031",
+    "name": "Innovation & Enterprise I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM4209",
+      "TME4209",
+      "EE3001E",
+      "EE3031E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TEE3131",
+    "name": "Communication Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3103E",
+      "EE3131E"
+    ],
+    "prerequisites": [
+      "TEE2023"
+    ]
+  },
+  {
+    "code": "TEE3201",
+    "name": "Software Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TE3201"
+    ],
+    "prerequisites": [
+      "TEE2101"
+    ]
+  },
+  {
+    "code": "TEE3207",
+    "name": "Computer Architecture",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3207E"
+    ],
+    "prerequisites": [
+      "TEE2024",
+      "TEE2028"
+    ]
+  },
+  {
+    "code": "TEE3331",
+    "name": "Feedback Control Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE2010E",
+      "EE3331E"
+    ],
+    "prerequisites": [
+      "TEE2023"
+    ]
+  },
+  {
+    "code": "TEE3408",
+    "name": "Integrated Analog Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3408E"
+    ],
+    "prerequisites": [
+      "TEE2021",
+      "TEE2027"
+    ]
+  },
+  {
+    "code": "TEE3431",
+    "name": "Microelectronics Materials and Devices",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3406E",
+      "EE2004E",
+      "EE3431E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TEE3501",
+    "name": "Power Electronics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3501E"
+    ],
+    "prerequisites": [
+      "TEE2021",
+      "TEE2027"
+    ]
+  },
+  {
+    "code": "TEE3801",
+    "name": "Robust Design Of Electronic Circuits",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TE3801"
+    ],
+    "prerequisites": [
+      "TEE2021",
+      "TEE2027",
+      "TEE2003"
+    ]
+  },
+  {
+    "code": "TEE4001",
+    "name": "BTech Dissertation",
+    "creditCount": 12.0,
+    "preclusions": [
+      "TE4001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TEE4101",
+    "name": "Radio-Frequency (RF) Communications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4101E"
+    ],
+    "prerequisites": [
+      "TEE2011"
+    ]
+  },
+  {
+    "code": "TEE4112",
+    "name": "Radio Frequency Design and Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4112E"
+    ],
+    "prerequisites": [
+      "TEE2011"
+    ]
+  },
+  {
+    "code": "TEE4204",
+    "name": "Computer Networks",
+    "creditCount": 4.0,
+    "preclusions": [
+      "CS2105",
+      "CS3103",
+      "EE3204E",
+      "TEE3204",
+      "EE4204E"
+    ],
+    "prerequisites": [
+      "TEE2003"
+    ]
+  },
+  {
+    "code": "TEE4210",
+    "name": "Network Protocols and Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4210E",
+      "TIC2501"
+    ],
+    "prerequisites": [
+      "TEE2003"
+    ]
+  },
+  {
+    "code": "TEE4214",
+    "name": "Real-Time Embedded Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4214E",
+      "TIC2401"
+    ],
+    "prerequisites": [
+      "TEE2101",
+      "TEE2024",
+      "TEE2028"
+    ]
+  },
+  {
+    "code": "TEE4303",
+    "name": "Industrial Control Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3302E",
+      "TEE3302",
+      "EE4303E"
+    ],
+    "prerequisites": [
+      "TEE3331"
+    ]
+  },
+  {
+    "code": "TEE4305",
+    "name": "Introduction To Fuzzy/Neural Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4305E"
+    ],
+    "prerequisites": [
+      "TEE2023"
+    ]
+  },
+  {
+    "code": "TEE4407",
+    "name": "Analog Electronics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE3407E",
+      "TEE3407",
+      "EE4407E"
+    ],
+    "prerequisites": [
+      "TEE2021",
+      "TEE2027"
+    ]
+  },
+  {
+    "code": "TEE4415",
+    "name": "Integrated Digital Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4415E"
+    ],
+    "prerequisites": [
+      "TEE2020",
+      "TEE2026"
+    ]
+  },
+  {
+    "code": "TEE4435",
+    "name": "Modern Transistors and Memory Devices",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4408E",
+      "EE4412E",
+      "EE4435E"
+    ],
+    "prerequisites": [
+      "TEE2021",
+      "TEE2027"
+    ]
+  },
+  {
+    "code": "TEE4436",
+    "name": "Fabrication Process Technology",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4411E",
+      "EE4436E"
+    ],
+    "prerequisites": [
+      "TEE2021",
+      "TEE2027"
+    ]
+  },
+  {
+    "code": "TG1401",
+    "name": "Engineering Mathematics I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TE2102",
+      "TM1401",
+      "TTG1401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TG2415",
+    "name": "Ethics In Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TTG2415"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TG3001",
+    "name": "Industrial Practice",
+    "creditCount": 12.0,
+    "preclusions": [
+      "TG3002",
+      "TTG3002",
+      "TTG3001",
+      "TIC3901"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TG3002",
+    "name": "Industrial Practice",
+    "creditCount": 8.0,
+    "preclusions": [
+      "TG3001",
+      "TTG3001",
+      "TTG3002",
+      "TIC3901"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIC1001",
+    "name": "Introduction to Computing and Programming I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TE2101",
+      "TEE2101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIC1002",
+    "name": "Introduction to Computing and Programming II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TIC1001"
+    ]
+  },
+  {
+    "code": "TIC1101",
+    "name": "Professional, Ethical, and Social Issues in Computing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TIC1201",
+    "name": "Discrete Structures",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TMA1001"
+    ]
+  },
+  {
+    "code": "TIC2001",
+    "name": "Data Structures and Algorithms",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TIC1002",
+      "TIC1201"
+    ]
+  },
+  {
+    "code": "TIC2002",
+    "name": "Introduction to Software Engineering",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TIC2001"
+    ]
+  },
+  {
+    "code": "TIC2101",
+    "name": "Information Systems and Organisations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TIC2301",
+    "name": "Introduction to Information Security",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TIC1002"
+    ]
+  },
+  {
+    "code": "TIC2401",
+    "name": "Introduction to Computer Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4214E",
+      "TEE4214"
+    ],
+    "prerequisites": [
+      "TIC1002"
+    ]
+  },
+  {
+    "code": "TIC2501",
+    "name": "Computer Networks and Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "EE4210E",
+      "TEE4210"
+    ],
+    "prerequisites": [
+      "TIC1002"
+    ]
+  },
+  {
+    "code": "TIC2601",
+    "name": "Database and Web Applications",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TIC1002"
+    ]
+  },
+  {
+    "code": "TIE2010",
+    "name": "Introduction to Industrial System",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3161",
+      "IE2010E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIE2100",
+    "name": "Probability Models with Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC3215",
+      "IE2100E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIE2110",
+    "name": "Operations Research I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "DSC3214",
+      "MA2215",
+      "MA3236",
+      "IE2110E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIE2120",
+    "name": "Probability and Statistics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE2120E",
+      "TMA2103"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIE2130",
+    "name": "Quality Engineering I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM4271",
+      "IE2130E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIE2140",
+    "name": "Engineering Economy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE2140E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIE2150",
+    "name": "Human Factors Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE2150E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIE3010",
+    "name": "Systems Thinking and Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE3010E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIE3100",
+    "name": "Systems Design Project",
+    "creditCount": 8.0,
+    "preclusions": [
+      "IE3100E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIE3101",
+    "name": "Statistics for Engineering Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE3101E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIE3110",
+    "name": "Simulation",
+    "creditCount": 5.0,
+    "preclusions": [
+      "DSC3221",
+      "IE3110E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIE4220",
+    "name": "Supply Chain Modelling",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE4220E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIE4230",
+    "name": "Quality Engineering II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE4230E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIE4239",
+    "name": "Selected Topics in Quality Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE4239E"
+    ],
+    "prerequisites": [
+      "TIE2100",
+      "TIE3101"
+    ]
+  },
+  {
+    "code": "TIE4240",
+    "name": "Project Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE4240E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIE4242",
+    "name": "Cost Analysis And Management",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE4242E"
+    ],
+    "prerequisites": [
+      "TIE2140"
+    ]
+  },
+  {
+    "code": "TIE4259",
+    "name": "Selected Topics in Systems Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE4259E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TIE4299",
+    "name": "Selected Topics in Industrial Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE4299E"
+    ],
+    "prerequisites": [
+      "TIE2010"
+    ]
+  },
+  {
+    "code": "TM2401",
+    "name": "Engineering Mathematics II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TE2002",
+      "TC2401",
+      "TC1402",
+      "TM1402",
+      "TME2401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TM3101",
+    "name": "Mechanical Systems Design",
+    "creditCount": 6.0,
+    "preclusions": [
+      "TME3101"
+    ],
+    "prerequisites": [
+      "TM2101",
+      "ME2101E"
+    ]
+  },
+  {
+    "code": "TM4101",
+    "name": "B.Tech. Dissertation",
+    "creditCount": 12.0,
+    "preclusions": [
+      "TM4102",
+      "TME4102"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TM4102",
+    "name": "B.Tech. Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [
+      "TME4102",
+      "TM4101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TM4263",
+    "name": "Manufact'G Simulat'N & Data Communicat'N",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TME4263"
+    ],
+    "prerequisites": [
+      "ME3162E"
+    ]
+  },
+  {
+    "code": "TMA1001",
+    "name": "Introductory Mathematics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TMA2101",
+    "name": "Calculus for Computing",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TMA1001"
+    ]
+  },
+  {
+    "code": "TMA2102",
+    "name": "Linear Algebra",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TMA1001"
+    ]
+  },
+  {
+    "code": "TMA2103",
+    "name": "Probability and Statistics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IE2120",
+      "TIE2120",
+      "TIE3101",
+      "IE3101E"
+    ],
+    "prerequisites": [
+      "TMA2101"
+    ]
+  },
+  {
+    "code": "TME2101",
+    "name": "Fundamentals of Mechanical Design",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM2101",
+      "ME2101E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME2114",
+    "name": "Mechanics of Materials II",
+    "creditCount": 3.0,
+    "preclusions": [
+      "TM1111",
+      "ME2114E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME2121",
+    "name": "Engineering Thermodynamics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM1121",
+      "ME2121E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME2134",
+    "name": "Fluid Mechanics I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM1131",
+      "ME2134E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME2135",
+    "name": "Fluid Mechanics II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM2131",
+      "ME2135E"
+    ],
+    "prerequisites": [
+      "TME2134"
+    ]
+  },
+  {
+    "code": "TME2142",
+    "name": "Feedback Control Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3142",
+      "ME2142E"
+    ],
+    "prerequisites": [
+      "TME2401"
+    ]
+  },
+  {
+    "code": "TME2143",
+    "name": "Sensors and Actuators",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM2141",
+      "ME2143E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME2151",
+    "name": "Principles of Mechanical Engineering Materials",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM1151",
+      "ME2151E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME2401",
+    "name": "Engineering Mathematics II",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TE2002",
+      "TEE2002",
+      "TC2401",
+      "TC1402",
+      "TM1402"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME3101",
+    "name": "Mechanical Systems Design",
+    "creditCount": 6.0,
+    "preclusions": [
+      "TM3101"
+    ],
+    "prerequisites": [
+      "TME2101"
+    ]
+  },
+  {
+    "code": "TME3112",
+    "name": "Mechanics of Machines",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM2112",
+      "ME3112E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME3122",
+    "name": "Heat Transfer",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM2122",
+      "ME3122E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME3162",
+    "name": "Manufacturing Processes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM2162",
+      "ME3162E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME3211",
+    "name": "Mechanics of Solids",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3211",
+      "ME3211E"
+    ],
+    "prerequisites": [
+      "TME2114"
+    ]
+  },
+  {
+    "code": "TME3233",
+    "name": "Unsteady Flow in Fluid Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ME3233",
+      "ME3233E"
+    ],
+    "prerequisites": [
+      "TME2135"
+    ]
+  },
+  {
+    "code": "TME3241",
+    "name": "Microprocessor Applications",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3241",
+      "ME3241E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME3242",
+    "name": "Automation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3242",
+      "ME3242E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME3251",
+    "name": "Materials For Engineers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3251",
+      "ME3251E"
+    ],
+    "prerequisites": [
+      "TME2151"
+    ]
+  },
+  {
+    "code": "TME3261",
+    "name": "Computer-Aided Design and Manufacturing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3261",
+      "ME3261E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME3263",
+    "name": "Design for Manufacturing and Assembly",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3261",
+      "ME3263E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME4102",
+    "name": "B.Tech. Dissertation",
+    "creditCount": 8.0,
+    "preclusions": [
+      "TM4102",
+      "TM4101"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME4223",
+    "name": "Thermal Environmental Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM3223",
+      "ME4223E"
+    ],
+    "prerequisites": [
+      "TME2121",
+      "TME3122"
+    ]
+  },
+  {
+    "code": "TME4225",
+    "name": "Applied Heat Transfer",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM4225",
+      "ME4225E"
+    ],
+    "prerequisites": [
+      "TME3122"
+    ]
+  },
+  {
+    "code": "TME4245",
+    "name": "Robot Mechanics and Control",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM4245",
+      "ME4245E"
+    ],
+    "prerequisites": [
+      "TME2142",
+      "TEE3331"
+    ]
+  },
+  {
+    "code": "TME4256",
+    "name": "Functional Materials and Devices",
+    "creditCount": 4.0,
+    "preclusions": [
+      "ME4256",
+      "ME4256E"
+    ],
+    "prerequisites": [
+      "TME2151",
+      "TME2143"
+    ]
+  },
+  {
+    "code": "TME4261",
+    "name": "Tool Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM4261",
+      "ME4261E"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TME4263",
+    "name": "Manufact'G Simulat'N & Data Communicat'N",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TM4263"
+    ],
+    "prerequisites": [
+      "TME3162"
+    ]
+  },
+  {
+    "code": "TP5001",
+    "name": "Research Project",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TP5025",
+    "name": "Intelligent Transportation Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE5025"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TP5026",
+    "name": "Transportation Management & Policy",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TCE5026"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TP5027",
+    "name": "Transport & Freight Terminal Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TP5028",
+    "name": "Intermodal Transportation Operations",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TR2201",
+    "name": "Entrepreneurial Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TR3003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TR2201Y",
+    "name": "Entrepreneurial Marketing",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TR3003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TR3002",
+    "name": "New Venture Creation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TR3004",
+      "TR3005"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TR3002N",
+    "name": "New Venture Creation",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TR3004",
+      "TR3005"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TR3203E",
+    "name": "Start-up Case Study & Analysis",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TR3203N",
+    "name": "Start-up Case Study & Analysis",
+    "creditCount": 8.0,
+    "preclusions": [
+      "TR3103"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TR3203P",
+    "name": "Start-up Case Study & Analysis",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TR3203T",
+    "name": "Start-up Case Study & Analysis",
+    "creditCount": 8.0,
+    "preclusions": [
+      "TR3103"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TR4049N",
+    "name": "Seminars in Entrepreneurship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TR4049T",
+    "name": "Seminars in Entrepreneurship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS1101E",
+    "name": "Introduction to Theatre and Performance",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1003"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TS2217",
+    "name": "Introduction to Performance Studies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TS1101E",
+      "GEM1003"
+    ]
+  },
+  {
+    "code": "TS2232",
+    "name": "Introduction to Asian Theatre",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM2001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TS2233",
+    "name": "Making Contemporary Performance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TS1101E",
+      "GEM1003"
+    ]
+  },
+  {
+    "code": "TS2236",
+    "name": "Crossing Boundaries in Performance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TS1101E",
+      "GEM1003"
+    ]
+  },
+  {
+    "code": "TS2237",
+    "name": "As If: Actors and Acting",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TS1101E",
+      "GEM1003"
+    ]
+  },
+  {
+    "code": "TS2239",
+    "name": "Major Playwrights of the 20th Century",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TS1101E",
+      "EN1101E",
+      "GEM1003"
+    ]
+  },
+  {
+    "code": "TS2240",
+    "name": "Voice Studies and Production",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TS1101E",
+      "GEM1003"
+    ]
+  },
+  {
+    "code": "TS2241",
+    "name": "Writing the Short Film",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS2243",
+    "name": "Film Genres: Stars and Styles",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM2026"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TS3103",
+    "name": "Theatre Lab",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS3222",
+    "name": "Applied Theatre",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TS4880B"
+    ],
+    "prerequisites": [
+      "TS1101E",
+      "GEM1003"
+    ]
+  },
+  {
+    "code": "TS3232",
+    "name": "Performance & Social Space",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS3233",
+    "name": "Southeast Asian Performance",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TS1101E",
+      "GEM1003"
+    ]
+  },
+  {
+    "code": "TS3234",
+    "name": "Performance and Popular Culture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TS1101E",
+      "GEM1003"
+    ]
+  },
+  {
+    "code": "TS3235",
+    "name": "Singapore English-Language Theatre",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSA3201"
+    ],
+    "prerequisites": [
+      "TS1101E",
+      "GEM1003"
+    ]
+  },
+  {
+    "code": "TS3242",
+    "name": "Intercultural Theatre",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TS1101E",
+      "GEM1003"
+    ]
+  },
+  {
+    "code": "TS3243",
+    "name": "Stage and Screen",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS3245",
+    "name": "Professional Theatre Internship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TS1101E"
+    ]
+  },
+  {
+    "code": "TS3246",
+    "name": "Shakespeare and Asian Performances",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TS1101E",
+      "GEM1003",
+      "EN1101E",
+      "GEK1000"
+    ]
+  },
+  {
+    "code": "TS3551",
+    "name": "FASS Undergraduate Research Opportunity (UROP)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS4216",
+    "name": "Theatre and Gender",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS4217",
+    "name": "Cultural Performance in Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS4219",
+    "name": "Media and Popular Performance",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS4220",
+    "name": "Shakespeare and Film",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS4221",
+    "name": "Performance Research",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS4222",
+    "name": "Performance as Research in Applied Theatre",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS4401",
+    "name": "Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "TS4660"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TS4660",
+    "name": "Independent Study",
+    "creditCount": 5.0,
+    "preclusions": [
+      "TS4401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TS4880C",
+    "name": "Contemporary Performance Practices",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS5212",
+    "name": "Asian International Cinema",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS5212R",
+    "name": "Asian International Cinema",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS5660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS6660",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TS6770",
+    "name": "Graduate Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "TSC3222",
+    "name": "Global Sourcing & Supply Management",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "TIE2110"
+    ]
+  },
+  {
+    "code": "TTG1401",
+    "name": "Engineering Mathematics I",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TE2102",
+      "TM1401",
+      "TG1401"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TTG2415",
+    "name": "Ethics In Engineering",
+    "creditCount": 4.0,
+    "preclusions": [
+      "TG2415"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TTG3001",
+    "name": "Industrial Practice",
+    "creditCount": 12.0,
+    "preclusions": [
+      "TG3002",
+      "TTG3002",
+      "TG3001",
+      "TIC3901"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "TTG3002",
+    "name": "Industrial Practice",
+    "creditCount": 8.0,
+    "preclusions": [
+      "TG3001",
+      "TTG3001",
+      "TG3002",
+      "TIC3901"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UAR2207",
+    "name": "Intercultural Exchanges through Theatre",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UAR2208",
+    "name": "From Lab to Stage: Writing the Science Play",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UBM2201",
+    "name": "Hormesis and Life",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UBM2202",
+    "name": "Creating Wolverine in Real Life",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UCV2209",
+    "name": "The Heterogeneous Indians of Contemporary Singapore",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UD5221",
+    "name": "Theory and Elements of Urban Design",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UD5521",
+    "name": "Planning Process: Quantitative & Policy Dimensions",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UD5601",
+    "name": "Urban Design Studio 1",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UD5602",
+    "name": "Urban Studio Design 2",
+    "creditCount": 8.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UD5622",
+    "name": "Methods Of Urban Design & Urban Analysis",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UD5628",
+    "name": "Sustainable Urban Design and Development",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UHB2207",
+    "name": "Language, Cognition, and Culture",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UHB2210",
+    "name": "Emotion in Daily Life",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS3901",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS3901S",
+    "name": "Independent Study Module (ST)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS3902",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS3902S",
+    "name": "Independent Study Module (ST)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS3911GE",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS3911HY",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS3911PS",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS3911SC",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS3911SW",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS3931",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS3941",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS3942",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS3943",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS3944",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS4911EN",
+    "name": "Independent Study Module",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS4911SC",
+    "name": "Independent Study Module",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS4911SN",
+    "name": "Independent Study Module",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS4912EL",
+    "name": "Independent Study Module",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS4912EN",
+    "name": "Independent Study Module",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS4912NM",
+    "name": "Independent Study Module",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS4932",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS4941",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS4942",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS4943",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIS4944",
+    "name": "Independent Study Module",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UIT2208",
+    "name": "Thinking 4.0",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ULS2202",
+    "name": "Evolution",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ULS2207",
+    "name": "The Biology and Phenomenology of Pain",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ULS2208",
+    "name": "Biodiversity and Natural History in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ULT2299C",
+    "name": "Topics in Lit. 2: The Subject of Reading",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UNL2201",
+    "name": "Space, Time And Matter",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UNL2206",
+    "name": "Nature's Threads",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UNL2210",
+    "name": "Mathematics and Reality",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UPC2206",
+    "name": "Nanoscale Science And Technology",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UPC2208",
+    "name": "Molecular Courtship",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UPC2209",
+    "name": "Pollution Control Engineering in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UQF2101E",
+    "name": "Quantitative Reasoning Foundation: Quantifying Our Eco-Footprint",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UQF2101G",
+    "name": "Quantitative Reasoning Foundation: Quantifying Nuclear Risks",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UQF2101I",
+    "name": "Quantitative Reasoning Foundation: Quantifying Environmental Quality",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UQF2101J",
+    "name": "Quantitative Reasoning Foundation: Pursuit of Happiness",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTC1409"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "USE2209",
+    "name": "Globalizing Asian-Pacific Identities",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "USE2304",
+    "name": "Singapore: The Making Of A Nation",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "USE2317",
+    "name": "Multiculturalism in Singapore and Its Contested Meanings",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "USE2321",
+    "name": "Examining Local Lives",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "USR4002A",
+    "name": "Critical Reflection",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "USS2105",
+    "name": "University Scholars Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1102B",
+    "name": "Junior Seminar: The Darwinian Revolution",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1902B",
+      "GEM1536",
+      "GET1020"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1102G",
+    "name": "Junior Seminar: Proof: What\u2019s Truth got to do with it?",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1902G"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1102U",
+    "name": "Junior Seminar: Disasters",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1902U"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1114",
+    "name": "Junior Seminar From the Fire to the Frying Pan: Cooking and Eating in Human Culture(s)",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1117",
+    "name": "Junior Seminar: Radiation and Society",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM2910",
+      "GEM2910X",
+      "UTC2110"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1119",
+    "name": "Junior Seminar: Crime and Punishment",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1402",
+    "name": "Jr Sem: Generation Y: Transitions to Adulthood",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1035"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1403",
+    "name": "Jr Sem: Hidden Communities",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1904"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1404",
+    "name": "Jr Sem: Power and Ideas",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1905"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1408",
+    "name": "Jr Sem: Technology and Human Progress",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1909"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1409",
+    "name": "Jr Sem: The Pursuit of Happiness",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1910",
+      "UQF2101J"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1415",
+    "name": "Jr Sem: Family in a Changing Singapore",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1702B",
+    "name": "Thinking in Systems: Diseases and Healthcare",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1919",
+      "GEM1914",
+      "GEM1915",
+      "GEM1918",
+      "GET1011",
+      "UTC1411",
+      "UTC1701",
+      "UTC1700",
+      "UTC1701",
+      "GEM1914",
+      "GEM1915",
+      "GEM1918",
+      "GEM1919",
+      "GET1011",
+      "UTC1411",
+      "UTC1700"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1702C",
+    "name": "Thinking in Systems: Sustainability and Us",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1914",
+      "GEM1915",
+      "GEM1918",
+      "GEM1919",
+      "GET1011",
+      "UTC1411",
+      "UTC1700",
+      "UTC1701",
+      "UTC1702"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1702D",
+    "name": "Thinking in Systems: Population Dynamics",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1914",
+      "GEM1915",
+      "GEM1918",
+      "GEM1919",
+      "GET1011",
+      "UTC1411",
+      "UTC1700",
+      "UTC1701",
+      "UTC1702"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1702E",
+    "name": "Thinking in Systems: Energy Systems",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1915",
+      "GEM1914",
+      "GEM1915",
+      "GEM1918",
+      "GEM1919",
+      "GET1011",
+      "UTC1411",
+      "UTC1702A",
+      "UTC1702B",
+      "UTC1702C",
+      "UTC1702D",
+      "UTC1702"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC1702F",
+    "name": "Thinking in Systems: Disaster Resilience",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM1915",
+      "GEM1914",
+      "GEM1918",
+      "GEM1919",
+      "GET1011",
+      "UTC1411",
+      "UTC1702A",
+      "UTC1702B",
+      "UTC1702C",
+      "UTC1702D"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2102",
+    "name": "Climate Change",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM2902"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2107",
+    "name": "Senior Seminar: Negotiating in a Complex World",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM2907"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2400",
+    "name": "Community Leadership",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM2903"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2402",
+    "name": "Environment and Civil Society in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM2906",
+      "SSU2005"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2403",
+    "name": "Citizenship in a Changing World",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM2028",
+      "SSU2007"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2404",
+    "name": "(Re)Building Communities: Insights from India",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2409",
+    "name": "Understanding Communities: Theory & Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2700",
+    "name": "An Undefeated Mind: An Experiential Inner Reengineering Approach",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2703",
+    "name": "Infectious Diseases: Dynamics, Strategies and Policies",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2704",
+    "name": "Projects in Systems Thinking and System Dynamics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2707",
+    "name": "Understanding Health and Social Care in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTS2701"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2708",
+    "name": "Singapore - A Smart Nation in Context : IoT & Big Data",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTS2702"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2712",
+    "name": "Hard to secure easy to waste - Singapore\u2019s food story",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTS2704"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2714",
+    "name": "A social critique of markets in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTS2706"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2715",
+    "name": "Decoding Complexity",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTS2707"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2716",
+    "name": "Mapping Hidden Connections with Network Science",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2717",
+    "name": "Navigation in Singapore Waters-Bridges and Barriers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTS2708"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2718",
+    "name": "Energy and Singapore: Dynamics, Dilemmas and Decisions",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTS2709"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC2719",
+    "name": "Society and Economy in Singapore: A Systems View",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTS2710"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC3100",
+    "name": "Third Year Experience Workshops: \u201cExploring Possibilities\u201d",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC3102",
+    "name": "Tembusu Undergraduate Research Opportunity (UROP)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM3901"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC3400",
+    "name": "Independent Study",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM3902"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTC3401",
+    "name": "CAPT Undergraduate Research Opportunity (UROP)",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM3903"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTS2100",
+    "name": "Intelligence and Singapore Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UTS2105",
+    "name": "Singapore as \u2018Model\u2019 City?",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM2905",
+      "SSU2004"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTS2400",
+    "name": "Identities in Asia",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSU2002"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTS2402",
+    "name": "Environment and Civil Society in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM2906",
+      "SSU2005"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTS2403",
+    "name": "Citizenship in a Changing World",
+    "creditCount": 4.0,
+    "preclusions": [
+      "GEM2028",
+      "SSU2007"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTS2407",
+    "name": "Understanding Communities: Theory & Practice",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UTS2500",
+    "name": "College 3 Capstone Experience",
+    "creditCount": 4.0,
+    "preclusions": [
+      "SSU2001"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTS2701",
+    "name": "Understanding Health and Social Care in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTC2707"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTS2702",
+    "name": "Singapore - A Smart Nation in Context : IoT & Big Data",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTC2708"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTS2704",
+    "name": "Hard to secure easy to waste - Singapore\u2019s food story",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTC2712"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTS2706",
+    "name": "A social critique of markets in Singapore",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTC2714"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTS2707",
+    "name": "Decoding Complexity",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTC2715"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTS2708",
+    "name": "Navigation in Singapore Waters-Bridges and Barriers",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTC2717"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTS2709",
+    "name": "Energy and Singapore: Dynamics, Dilemmas and Decisions",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTC2718"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTS2710",
+    "name": "Society and Economy in Singapore: A Systems View",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTC2719"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTW1001H",
+    "name": "Eating Right(s): The Politics of Food",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IEM1201",
+      "UTW1001",
+      "ES1501"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTW1001N",
+    "name": "Public Persona and Self-presentations",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IEM1201",
+      "UTW1001",
+      "ES1501"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTW1001P",
+    "name": "Heroes",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IEM1201",
+      "UTW1001",
+      "ES1501"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTW1001S",
+    "name": "Women in Film",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IEM1201",
+      "UTW1001",
+      "ES1501"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTW1001U",
+    "name": "The Detective",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IEM1201",
+      "UTW1001",
+      "ES1501"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTW1001W",
+    "name": "The Online Politician: The Use of Social Media in Political Communication",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IEM1201",
+      "UTW1001",
+      "ES1501"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTW1001Y",
+    "name": "Algorithmic Culture and its Discontents",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IEM1201",
+      "UTW1001",
+      "ES1501"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTW1001Z",
+    "name": "Colour: Theory, meaning and practice",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IEM1201",
+      "UTW1001",
+      "ES1501"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UTW2001K",
+    "name": "Public Memory, Identity and Rhetoric",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IEM2201",
+      "UTW2001"
+    ],
+    "prerequisites": [
+      "IEM1201",
+      "UTW1001"
+    ]
+  },
+  {
+    "code": "UTW2001M",
+    "name": "Sport and Socialization",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IEM2201",
+      "UTW2001"
+    ],
+    "prerequisites": [
+      "IEM1201",
+      "UTW1001"
+    ]
+  },
+  {
+    "code": "UTW2001P",
+    "name": "Science Fiction and Empire",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IEM2201",
+      "UTW2001"
+    ],
+    "prerequisites": [
+      "IEM1201",
+      "UTW1001"
+    ]
+  },
+  {
+    "code": "UTW2001Q",
+    "name": "'What's in a word?' Meaning across cultures",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UTW2001R",
+    "name": "Discourse, Citizenship, and Society",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UTW2001T",
+    "name": "Nobodiness: The Self as Story",
+    "creditCount": 4.0,
+    "preclusions": [
+      "IEM2201",
+      "UTW2001"
+    ],
+    "prerequisites": [
+      "IEM1201",
+      "UTW1001"
+    ]
+  },
+  {
+    "code": "UWC2101A",
+    "name": "Writing and Critical Thinking: Colonialism and Cosmopolitanism",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UWC2101B",
+    "name": "Writing and Critical Thinking: Civic Discourse in a Fractious World",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UWC2101D",
+    "name": "Writing and Critical Writing: Narrative in Everyday Life",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UWC2101F",
+    "name": "Writing and Critical Thinking: Human Trafficking and Modern Slavery",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UWC2101G",
+    "name": "Writing & Critical Thinking: Apocalyptic Cultures",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UWC2101J",
+    "name": "Writing & Critical Thinking: Sites of Tourism",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UWC2101L",
+    "name": "Writing and Critical Thinking: Conditions of Happiness",
+    "creditCount": 4.0,
+    "preclusions": [
+      "UTC1409"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "UWC2101R",
+    "name": "Writing & Critical Thinking: Multidisciplinary Perspectives on 'Mind'",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UWC2101S",
+    "name": "Writing & Critical Thinking: Danger and National Security",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "UWC2101U",
+    "name": "Writing & Critical Thinking: Technologies of Home",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "VM5101",
+    "name": "Introduction of Palliative Care",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "VM5102",
+    "name": "Symptom Management in Palliative Care I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "VM5103",
+    "name": "Symptom Management in Palliative Care II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "VM5104",
+    "name": "Psychiatry, Psychosocial Care & Spiritual Issues in Palliative Care",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "WR1401",
+    "name": "Workplace Readiness",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "XD3103",
+    "name": "Planet Earth",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "XFA4401",
+    "name": "Integrated Honours Project",
+    "creditCount": 16.0,
+    "preclusions": [
+      "EC4660"
+    ],
+    "prerequisites": [
+      "EC4301",
+      "EC4101",
+      "EC4302",
+      "EC4102"
+    ]
+  },
+  {
+    "code": "XFA4402",
+    "name": "Integrated Honours Thesis",
+    "creditCount": 15.0,
+    "preclusions": [
+      "EC4660"
+    ],
+    "prerequisites": [
+      "EC4301",
+      "EC4101",
+      "EC4302",
+      "EC4102"
+    ]
+  },
+  {
+    "code": "XFB4001",
+    "name": "Integrated Honors Thesis",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "XFB4002",
+    "name": "Integrated Honours Dissertation",
+    "creditCount": 15.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "XFC4101",
+    "name": "Integrated Honours Thesis",
+    "creditCount": 12.0,
+    "preclusions": [
+      "CS4101",
+      "CS4349"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "XFS4199M",
+    "name": "Integrated Honours Project",
+    "creditCount": 15.0,
+    "preclusions": [
+      "MA4199"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YCC1111",
+    "name": "Literature and Humanities 1",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YCC1112",
+    "name": "Literature and Humanities 2",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111"
+    ]
+  },
+  {
+    "code": "YCC1113",
+    "name": "Philosophy and Political Thought 1",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YCC1114",
+    "name": "Philosophy and Political Thought 2",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1113"
+    ]
+  },
+  {
+    "code": "YCC1121",
+    "name": "Comparative Social Inquiry",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YCC1122",
+    "name": "Quantitative Reasoning",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YCC1131",
+    "name": "Scientific Inquiry 1",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YCC1133",
+    "name": "Week 7: Experiential Learning Field Trip",
+    "creditCount": 0.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YCC2121",
+    "name": "Modern Social Thought",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1112",
+      "YCC1113",
+      "YCC1114",
+      "YCC1121"
+    ]
+  },
+  {
+    "code": "YCC2137",
+    "name": "Scientific Inquiry 2",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1131",
+      "YCC1122"
+    ]
+  },
+  {
+    "code": "YCT1202",
+    "name": "Dialogue: Social Issues in Intergroup Relations",
+    "creditCount": 1.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2202",
+    "name": "Introduction to Creative Nonfiction",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2212",
+    "name": "Classical Chinese",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YLC2202"
+    ]
+  },
+  {
+    "code": "YHU2215",
+    "name": "Drawing Methods",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2223",
+    "name": "Documentary Photography",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2228",
+    "name": "The Atlantic World",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2241",
+    "name": "Why be moral?",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2243",
+    "name": "Shakespeare & the Shape of Life: Intro to the Plays",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111"
+    ]
+  },
+  {
+    "code": "YHU2247",
+    "name": "Dystopian Fiction",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1112"
+    ]
+  },
+  {
+    "code": "YHU2252",
+    "name": "Ancient Greek Philosophy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1113"
+    ]
+  },
+  {
+    "code": "YHU2266",
+    "name": "Introduction to Oil Painting",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2267",
+    "name": "Modern Art in East Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2268",
+    "name": "Money",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2269",
+    "name": "Ethics and Politics of Sex",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2270",
+    "name": "Contemporary Egalitarianism",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2271",
+    "name": "The Mediterranean World",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1113"
+    ]
+  },
+  {
+    "code": "YHU2280",
+    "name": "Oppression and Injustice",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2288",
+    "name": "Queer Fictions",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1112"
+    ]
+  },
+  {
+    "code": "YHU2289",
+    "name": "Ensemble Practice 1",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2290",
+    "name": "History and Culture of Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YHU1202"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2291",
+    "name": "Introduction to Arts",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YHU1209"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2292",
+    "name": "Introduction to Writing Poetry",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YHU1210"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2293",
+    "name": "Introduction to Fiction Writing",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YHU1212"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2295",
+    "name": "The Global Short Story",
+    "creditCount": 5.0,
+    "preclusions": [
+      "EN4880C"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2296",
+    "name": "Ancient Epics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1112"
+    ]
+  },
+  {
+    "code": "YHU2297",
+    "name": "Classical Chinese Philosophy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1113"
+    ]
+  },
+  {
+    "code": "YHU2298",
+    "name": "Introduction to Playwriting",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU2299",
+    "name": "Ensemble Practice 2",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YHU2289"
+    ]
+  },
+  {
+    "code": "YHU3205",
+    "name": "Ming Imperial Voyages",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3210D",
+    "name": "Proseminar Lit Studies: How to Do Things with Literature",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1112"
+    ]
+  },
+  {
+    "code": "YHU3214",
+    "name": "Indian Buddhist Philosophy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1114"
+    ]
+  },
+  {
+    "code": "YHU3216",
+    "name": "Photojournalism",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3221",
+    "name": "Nietzsche: An Untimely Thinker and His Times",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3223",
+    "name": "The Self in Comparative Perspective",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3225",
+    "name": "Pompeii: Art, Urban Life & Culture in the Roman Empire",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3230",
+    "name": "The First Opium War, 1839-42",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3243",
+    "name": "Woolf, Historiography, and the Scene of the Modern",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3247",
+    "name": "The Afropolitans: Contemporary African Lit. & Film",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1112"
+    ]
+  },
+  {
+    "code": "YHU3252",
+    "name": "The Age of Nero",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3254",
+    "name": "From Edo to Modern City: Tokyo",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3263",
+    "name": "The Bandung Conference of 1955",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3267",
+    "name": "Classical Indian Philosophy of Language",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YHU2251"
+    ],
+    "prerequisites": [
+      "YCC1113",
+      "YCC1114"
+    ]
+  },
+  {
+    "code": "YHU3275",
+    "name": "Descartes and the Perfection of Human Knowledge",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3276",
+    "name": "The Historian\u2019s Craft",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YHU2217"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3286",
+    "name": "Living & Dying in War: Kuo Pao Kun\u2019s The Spirits Play",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3287",
+    "name": "Early Global Literatures and the World, 500-1500 CE",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1112"
+    ]
+  },
+  {
+    "code": "YHU3288",
+    "name": "Installation Art",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3289",
+    "name": "Beyond China: Sinophone Literature, Film, and Culture",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1112"
+    ]
+  },
+  {
+    "code": "YHU3290",
+    "name": "Dante\u2019s Divine Comedy",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YHU2230"
+    ],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1112"
+    ]
+  },
+  {
+    "code": "YHU3291",
+    "name": "Sacrifice, Sex, and Power in Medieval Kashmir",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3292",
+    "name": "Life Drawing",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YHU4213"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3293",
+    "name": "Japanese Woodblock Prints",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YHU1211"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3294",
+    "name": "Socrates on Trial",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1113"
+    ]
+  },
+  {
+    "code": "YHU3295",
+    "name": "Nasty Girls: Gender, Sexuality & Race in Early America",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3296",
+    "name": "Fiction and the Supernatural",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1112"
+    ]
+  },
+  {
+    "code": "YHU3297",
+    "name": "Debate and Reasoning in Indian Philosophy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3298",
+    "name": "A Theory of Consciousness",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3299",
+    "name": "Weimar Berlin: Urbanity and Sexology Before the Nazis",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3300",
+    "name": "1917: War and Revolution",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3302",
+    "name": "Latin American Realities",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3304",
+    "name": "American Avant-Garde Theatre of the 1960\u2019s and 1970\u2019s",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1113",
+      "YCC1121",
+      "YCC1131"
+    ]
+  },
+  {
+    "code": "YHU3305",
+    "name": "The Actor's Journey: Training, Scene Work, Performance",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1113",
+      "YCC1121",
+      "YCC1131"
+    ]
+  },
+  {
+    "code": "YHU3306",
+    "name": "Philippine Literature: American Period (1914-1945)",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU3308",
+    "name": "Embodied Script Analysis",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YHU2259"
+    ],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1113",
+      "YCC1121",
+      "YCC1131"
+    ]
+  },
+  {
+    "code": "YHU3309",
+    "name": "Living in Sound",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YHU2263"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU4101",
+    "name": "History Capstone Project",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU4102",
+    "name": "Literature Capstone Project",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU4103",
+    "name": "Philosophy Capstone Project",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU4104",
+    "name": "Arts and Humanities Capstone Project",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU4204",
+    "name": "Rise of the West and the Great Divergence",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU4206",
+    "name": "The History of History",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU4212",
+    "name": "The Problem of Evil from the Enlightenment to Auschwitz",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU4214",
+    "name": "Advanced Creative Nonfiction",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YHU3206"
+    ],
+    "prerequisites": [
+      "YHU2202"
+    ]
+  },
+  {
+    "code": "YHU4216",
+    "name": "Advanced Poetry Writing",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YHU1210"
+    ]
+  },
+  {
+    "code": "YHU4218",
+    "name": "Chinese Poetry",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YHU2212"
+    ]
+  },
+  {
+    "code": "YHU4226",
+    "name": "China and the West",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YHU3204"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU4228",
+    "name": "Oceanic Frameworks: Shifting Currents in Lit. Studies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YHU3210"
+    ]
+  },
+  {
+    "code": "YHU4234",
+    "name": "Trauma, Loss, Exile and the Literary Imagination",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1112"
+    ]
+  },
+  {
+    "code": "YHU4235",
+    "name": "Crisis and Continuity: Europe's 20th Century",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU4236",
+    "name": "\u201cNew\u201d Media: Inquiries into Literature & Technology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1112"
+    ]
+  },
+  {
+    "code": "YHU4237",
+    "name": "Chinese Prose",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YHU2212"
+    ]
+  },
+  {
+    "code": "YHU4238",
+    "name": "The Female Image in Japanese Art and Literature",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YHU3232"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU4239",
+    "name": "The Age of Capital: Business and Power in Modern Europe",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU4240",
+    "name": "American Modernist Poetry",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1112"
+    ]
+  },
+  {
+    "code": "YHU4241",
+    "name": "Social Practice Art",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU4242",
+    "name": "The History of the Book in East and Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YHU4243",
+    "name": "Art Studio Research, Experimentation and Critique",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YHU3201",
+      "YHU3288",
+      "YHU3216",
+      "YHU2223",
+      "YHU3273"
+    ]
+  },
+  {
+    "code": "YID1201",
+    "name": "Introduction to Environmental Studies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YID2201",
+    "name": "Theory and Practice of Environmental Policymaking",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YID1201"
+    ]
+  },
+  {
+    "code": "YID2203",
+    "name": "Ecology and Ecosystems",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YID2208",
+    "name": "Foundations of Environmental Humanities",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YID1201"
+    ]
+  },
+  {
+    "code": "YID2210",
+    "name": "Understanding and Building Resilience",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YID1201"
+    ]
+  },
+  {
+    "code": "YID3202E",
+    "name": "Special Topics: Himalayan Diversities",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YID1201"
+    ]
+  },
+  {
+    "code": "YID3203",
+    "name": "Another World is Possible: Ecotopian Visions",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YID1201",
+      "YID2208"
+    ]
+  },
+  {
+    "code": "YID3207",
+    "name": "China\u2019s Energy and Environmental Sustainability",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YID1201"
+    ]
+  },
+  {
+    "code": "YID3208",
+    "name": "Environmental Movements: Past, Present and Future",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YID3209",
+    "name": "Climate Science and Policy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YID1201"
+    ]
+  },
+  {
+    "code": "YID3214",
+    "name": "Urban Ecological Systems",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSS3272"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YID3215",
+    "name": "Sustainable Consumption",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YID1201"
+    ]
+  },
+  {
+    "code": "YID3216",
+    "name": "Environment, Development and Mobilisation in Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YID1201"
+    ]
+  },
+  {
+    "code": "YID4101",
+    "name": "Environmental Studies Capstone Project",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YID4202",
+    "name": "Applied Environmental Research",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YIL2201S",
+    "name": "Directed Language Study: Intermediate Sanskrit",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YIL1201S"
+    ]
+  },
+  {
+    "code": "YIR3311",
+    "name": "Independent Reading and Research",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YIR3311G",
+    "name": "Independent Reading and Research",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YIR3312",
+    "name": "Independent Reading and Research",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YIR3312G",
+    "name": "Independent Reading and Research",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YIR3313",
+    "name": "Independent Reading and Research",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YIR3313G",
+    "name": "Independent Reading and Research",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YIR3411",
+    "name": "Independent Language Study and Research",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YIR3411G",
+    "name": "Independent Language Study and Research",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YIR3412",
+    "name": "Independent Language Study and Research",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YIR3412G",
+    "name": "Independent Language Study and Research",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YLC1201",
+    "name": "Beginning Chinese 1",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YLC1202",
+    "name": "Beginning Chinese 2",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YLC1201"
+    ]
+  },
+  {
+    "code": "YLC2201",
+    "name": "Intermediate Chinese 1",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YLC1202"
+    ]
+  },
+  {
+    "code": "YLC2202",
+    "name": "Intermediate Chinese 2",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YLC2201"
+    ]
+  },
+  {
+    "code": "YLC3203",
+    "name": "Advanced Chinese 1",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YLC2202"
+    ]
+  },
+  {
+    "code": "YLC3204",
+    "name": "Advanced Chinese 2",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YLC3203"
+    ]
+  },
+  {
+    "code": "YLC3205",
+    "name": "Advanced Readings in Chinese: Cinematic and Literary Texts",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YLC3201",
+      "AY2016"
+    ],
+    "prerequisites": [
+      "YLC3204"
+    ]
+  },
+  {
+    "code": "YLC3206",
+    "name": "Advanced Chinese: Readings in Modern Chinese Literature",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YLC3202",
+      "AY2016"
+    ],
+    "prerequisites": [
+      "YLC3204"
+    ]
+  },
+  {
+    "code": "YLG1201",
+    "name": "Beginning Ancient Greek",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YLG2201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YLG2202",
+    "name": "Intermediate Ancient Greek",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YLG1201",
+      "YLG2201"
+    ]
+  },
+  {
+    "code": "YLL1201",
+    "name": "Beginning Latin",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YLL2201",
+    "name": "Intermediate Latin",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YLL1202",
+      "YLL2202",
+      "YLL1202",
+      "YLL2202"
+    ],
+    "prerequisites": [
+      "YLL1201"
+    ]
+  },
+  {
+    "code": "YLS1201",
+    "name": "Beginning Spanish 1",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YLS1202",
+    "name": "Beginning Spanish 2",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YLS1201"
+    ]
+  },
+  {
+    "code": "YLS2201",
+    "name": "Intermediate Spanish 1",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YLS1202"
+    ]
+  },
+  {
+    "code": "YLS2202",
+    "name": "Intermediate Spanish 2",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YLS2201"
+    ]
+  },
+  {
+    "code": "YLS3201",
+    "name": "Advanced Spanish: Spain, a Mosaic of Cultures",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YLS2201",
+      "YLS2202"
+    ]
+  },
+  {
+    "code": "YSC1207",
+    "name": "General Chemistry: Molecular Structure and Reactivity",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1131"
+    ]
+  },
+  {
+    "code": "YSC1212",
+    "name": "Introduction to Computer Science",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1122"
+    ]
+  },
+  {
+    "code": "YSC1213",
+    "name": "General Physics: Electronics and Non-Linear Dynamics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC1216",
+    "name": "Calculus of a Single Variable",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC1217",
+    "name": "Creativity, Imagination and Theoretical Physics",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC2202",
+    "name": "Biology Laboratory",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC2203",
+    "name": "Classical Mechanics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC1121",
+      "YSC1213"
+    ]
+  },
+  {
+    "code": "YSC2209",
+    "name": "Proof",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSC1203"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC2210",
+    "name": "Data Analysis and Visualization (DAVis) with R",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1122"
+    ]
+  },
+  {
+    "code": "YSC2212",
+    "name": "Instrumental Analysis with Laboratory",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSC2207",
+      "YSC2208"
+    ],
+    "prerequisites": [
+      "YSC1207"
+    ]
+  },
+  {
+    "code": "YSC2213",
+    "name": "Discrete Mathematics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC2214",
+    "name": "Introduction to Optics and Imaging",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC2216",
+    "name": "Evolutionary Biology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YC1122",
+      "YC1131"
+    ]
+  },
+  {
+    "code": "YSC2220",
+    "name": "Linearity",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1122"
+    ]
+  },
+  {
+    "code": "YSC2221",
+    "name": "Introduction to Python",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC2223",
+    "name": "Introduction to Black Holes",
+    "creditCount": 2.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC2224",
+    "name": "Organic Chemistry with Laboratory",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSC2206"
+    ],
+    "prerequisites": [
+      "YSC1207"
+    ]
+  },
+  {
+    "code": "YSC2225",
+    "name": "Physical Chemistry",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC1207",
+      "YSC1213"
+    ]
+  },
+  {
+    "code": "YSC2227",
+    "name": "C: A Language for Science and Engineering",
+    "creditCount": 2.0,
+    "preclusions": [
+      "YSC3217",
+      "YSC3232",
+      "YSC3207"
+    ],
+    "prerequisites": [
+      "YSC2221",
+      "YSC1212"
+    ]
+  },
+  {
+    "code": "YSC2228",
+    "name": "Statistical Thermodynamics",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSC3224"
+    ],
+    "prerequisites": [
+      "YSC1207",
+      "YSC1213"
+    ]
+  },
+  {
+    "code": "YSC2229",
+    "name": "Introductory Data Structures and Algorithms",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSC2204"
+    ],
+    "prerequisites": [
+      "YSC1212"
+    ]
+  },
+  {
+    "code": "YSC2230",
+    "name": "Probability and Statistics",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSC1204"
+    ],
+    "prerequisites": [
+      "YSC1211"
+    ]
+  },
+  {
+    "code": "YSC2231",
+    "name": "Foundations of Neuroscience",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSC2211"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC2232",
+    "name": "Linear Algebra",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSC3205"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC2233",
+    "name": "Genetics",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSC3201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC2234",
+    "name": "Human Biology",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSC1201"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC2235",
+    "name": "Field Research",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC3203",
+    "name": "Advanced Algorithms and Data Structures",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC2204"
+    ]
+  },
+  {
+    "code": "YSC3206",
+    "name": "Introduction to Real Analysis",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC2209",
+      "YSC2232"
+    ]
+  },
+  {
+    "code": "YSC3210",
+    "name": "Introduction to Quantum Mechanics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC2203",
+      "YSC2205"
+    ]
+  },
+  {
+    "code": "YSC3211",
+    "name": "Introduction to Electrodynamics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC2205"
+    ]
+  },
+  {
+    "code": "YSC3213",
+    "name": "Experimental Physics Laboratory",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC3214",
+    "name": "Biochemistry",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC3215",
+    "name": "Research Seminar",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC3216",
+    "name": "Stochastic Processes and Models (SPaM)",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1122",
+      "YSC1206"
+    ]
+  },
+  {
+    "code": "YSC3217",
+    "name": "Programming Operating Systems, Interfaces & eXtras",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC2221",
+      "YSC1212"
+    ]
+  },
+  {
+    "code": "YSC3221",
+    "name": "Computer Vision and Deep Learning",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC3205"
+    ]
+  },
+  {
+    "code": "YSC3227",
+    "name": "Machine Learning",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC2232"
+    ]
+  },
+  {
+    "code": "YSC3228",
+    "name": "Inorganic Chemistry with Laboratory",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC2206"
+    ]
+  },
+  {
+    "code": "YSC3230",
+    "name": "Ordinary and Partial Differential Equations",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC3232",
+    "name": "Object-Oriented Programming",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSC3207"
+    ],
+    "prerequisites": [
+      "YSC2221",
+      "YSC1212"
+    ]
+  },
+  {
+    "code": "YSC3233",
+    "name": "Molecular Cell Biology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC3234",
+    "name": "Principles of Biophysics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC3235",
+    "name": "Animal Behaviour",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1122",
+      "YCC1131",
+      "YSC2231",
+      "YSC2211",
+      "YSC2216",
+      "YSS2201",
+      "YCC1122",
+      "YSC2231",
+      "YSC2211",
+      "YSC2216",
+      "YSS2201"
+    ]
+  },
+  {
+    "code": "YSC3236",
+    "name": "Functional Programming and Proving",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC1212"
+    ]
+  },
+  {
+    "code": "YSC3237",
+    "name": "Introduction to Modern Algebra",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSC3220",
+      "YSC3204",
+      "YSC3237"
+    ],
+    "prerequisites": [
+      "YSC2209"
+    ]
+  },
+  {
+    "code": "YSC3239",
+    "name": "Geometry and the Emergence of Perspective",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC3240",
+    "name": "Foundations of Applied Mathematics",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSC2205"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC4101",
+    "name": "Physical Sciences Capstone Project",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC4102",
+    "name": "Life Sciences Capstone Project",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC4103",
+    "name": "Maths, Computational & Statistical Sci Capstone Project",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC4200",
+    "name": "Special Project in Science",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC4200G",
+    "name": "Special Project in Science",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC4203",
+    "name": "Topology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC3206"
+    ]
+  },
+  {
+    "code": "YSC4206",
+    "name": "Harmonic Analysis",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC2209",
+      "YSC3206",
+      "YSC2232"
+    ]
+  },
+  {
+    "code": "YSC4207",
+    "name": "Solid State Physics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC3210",
+      "YSC2228"
+    ]
+  },
+  {
+    "code": "YSC4209",
+    "name": "Physical Science Research Seminar",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC2205",
+      "YSC2203",
+      "YSC2224",
+      "YSC2206"
+    ]
+  },
+  {
+    "code": "YSC4211A",
+    "name": "Adv Topics Molecular, Cellular & Developmental Biology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC3233",
+      "YSC3238",
+      "YSC2233",
+      "YSC3214"
+    ]
+  },
+  {
+    "code": "YSC4212",
+    "name": "Statistical Case Studies (with R)",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSC2230",
+      "YSC2210"
+    ]
+  },
+  {
+    "code": "YSC4214",
+    "name": "Theory of Quantum Information and Computation",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSC4215",
+    "name": "Designing Interactive Systems",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSC3226"
+    ],
+    "prerequisites": [
+      "YSC3232"
+    ]
+  },
+  {
+    "code": "YSS1203",
+    "name": "Principles of Economics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS1206",
+    "name": "Introduction to Comparative Politics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS2201",
+    "name": "Understanding Behavior and Cognition",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS2202",
+    "name": "International Relations",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS2203",
+    "name": "Intermediate Microeconomics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS1203",
+      "YSS1203"
+    ]
+  },
+  {
+    "code": "YSS2208",
+    "name": "Ancient Greek Political Philosophy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1113"
+    ]
+  },
+  {
+    "code": "YSS2211",
+    "name": "Econometrics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS1203",
+      "YSS2203"
+    ]
+  },
+  {
+    "code": "YSS2214",
+    "name": "Intermediate Macroeconomics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS1203",
+      "YSS2203"
+    ]
+  },
+  {
+    "code": "YSS2216",
+    "name": "Statistics and Research Methods for Psychology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1122",
+      "YSS2201"
+    ]
+  },
+  {
+    "code": "YSS2218",
+    "name": "International Political Economy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1121"
+    ]
+  },
+  {
+    "code": "YSS2220",
+    "name": "Introduction to Urban Studies",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSS1207"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS2221",
+    "name": "International Security",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSS3210"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS2224",
+    "name": "Introduction to Global Affairs",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS2227",
+    "name": "Introduction to Anthropology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS2228",
+    "name": "Modern Southeast Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS3201",
+    "name": "International Migration",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS3202",
+    "name": "Ethnography",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS3203",
+    "name": "Behavioral Economics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2203"
+    ]
+  },
+  {
+    "code": "YSS3204",
+    "name": "Development Economics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2203",
+      "YSS2211"
+    ]
+  },
+  {
+    "code": "YSS3208",
+    "name": "Advanced Microeconomics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2203"
+    ]
+  },
+  {
+    "code": "YSS3211",
+    "name": "Human Rights",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS3215",
+    "name": "Cognitive Psychology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2201"
+    ]
+  },
+  {
+    "code": "YSS3217",
+    "name": "Urbanization in China",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS3219",
+    "name": "Developmental Psychology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2201"
+    ]
+  },
+  {
+    "code": "YSS3222",
+    "name": "Urban Theory",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC2121",
+      "YSS2220"
+    ]
+  },
+  {
+    "code": "YSS3224",
+    "name": "International Finance",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2203",
+      "YSS2214"
+    ]
+  },
+  {
+    "code": "YSS3225",
+    "name": "Global Governance",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2202"
+    ]
+  },
+  {
+    "code": "YSS3231",
+    "name": "Methods in the Social Sciences",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1121",
+      "YCC1122",
+      "YCC2121"
+    ]
+  },
+  {
+    "code": "YSS3238",
+    "name": "US Foreign Policy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS3241",
+    "name": "Chinese Political Philosophy: Confucianism & its Rivals",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1113",
+      "YCC1114"
+    ]
+  },
+  {
+    "code": "YSS3244",
+    "name": "Labour Economics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2211"
+    ]
+  },
+  {
+    "code": "YSS3246",
+    "name": "Cities of the Global South",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS3248",
+    "name": "Advanced Macroeconomics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2214"
+    ]
+  },
+  {
+    "code": "YSS3252",
+    "name": "Lab in Applying Psychology to Public Policy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2201",
+      "YSS2216"
+    ]
+  },
+  {
+    "code": "YSS3256",
+    "name": "Youth Urbanism: Global Trends, Local Perspectives",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2220",
+      "YSS2224"
+    ]
+  },
+  {
+    "code": "YSS3257",
+    "name": "Seminar on Corporate Finance",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSS3258"
+    ],
+    "prerequisites": [
+      "YSS2211",
+      "YSS2203"
+    ]
+  },
+  {
+    "code": "YSS3258",
+    "name": "Early Stage Private Equity Investing",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSS3257"
+    ],
+    "prerequisites": [
+      "YSS2211",
+      "YSS2203"
+    ]
+  },
+  {
+    "code": "YSS3263",
+    "name": "Emotions and Politics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC2121"
+    ]
+  },
+  {
+    "code": "YSS3264",
+    "name": "Bubbles, Crashes, Panics and Crises",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2203",
+      "YSS2214",
+      "YSS1203"
+    ]
+  },
+  {
+    "code": "YSS3268",
+    "name": "Anthropology of China",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC2121"
+    ]
+  },
+  {
+    "code": "YSS3269",
+    "name": "Water and Waste in Urban Environments",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS3270",
+    "name": "Ethics and Global Affairs",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PS3233"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS3271",
+    "name": "Contemporary Political Comedy",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS3273",
+    "name": "GIS and Demographics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS3274",
+    "name": "Urban Singapore",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS3276",
+    "name": "International Political Theory",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1114"
+    ]
+  },
+  {
+    "code": "YSS3277",
+    "name": "The Anthropological Imagination",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSS2209"
+    ],
+    "prerequisites": [
+      "YCC2121",
+      "YCC1121"
+    ]
+  },
+  {
+    "code": "YSS3280",
+    "name": "Contemporary Political Theory",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC1111",
+      "YCC1112"
+    ]
+  },
+  {
+    "code": "YSS3281",
+    "name": "Urban Mobilities",
+    "creditCount": 5.0,
+    "preclusions": [
+      "YSS3216A"
+    ],
+    "prerequisites": [
+      "YSS2220"
+    ]
+  },
+  {
+    "code": "YSS3282",
+    "name": "Architecture and Society",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS3283",
+    "name": "Republican Political Theory",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS3285",
+    "name": "Organisational Psychology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2201"
+    ]
+  },
+  {
+    "code": "YSS4101",
+    "name": "Global Affairs Capstone Project",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS4102",
+    "name": "Psychology Capstone Project",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS4103",
+    "name": "Anthropology Capstone Project",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS4104",
+    "name": "Economics Capstone Project",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS4105",
+    "name": "Urban Studies Capstone Project",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS4106",
+    "name": "Politics, Philosophy and Economics Capstone Project",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS4107",
+    "name": "Capstone Project",
+    "creditCount": 10.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS4202",
+    "name": "Goals and Motivation",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2201",
+      "YSS2216"
+    ]
+  },
+  {
+    "code": "YSS4206A",
+    "name": "Topics in Psychology: Moral Judgments",
+    "creditCount": 5.0,
+    "preclusions": [
+      "PL4235"
+    ],
+    "prerequisites": [
+      "YSS2201"
+    ]
+  },
+  {
+    "code": "YSS4206B",
+    "name": "Topics in Psychology: Love in An Age of Technology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2201"
+    ]
+  },
+  {
+    "code": "YSS4211",
+    "name": "India as a Rising Power, 1947-Present",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2202"
+    ]
+  },
+  {
+    "code": "YSS4215",
+    "name": "Sexual Economies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC2121",
+      "YSS2227",
+      "YSS3277",
+      "YSS3202"
+    ]
+  },
+  {
+    "code": "YSS4220",
+    "name": "Housing and Social Inequality",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2220",
+      "YCC2121"
+    ]
+  },
+  {
+    "code": "YSS4222",
+    "name": "Contemporary European Politics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2202",
+      "YSS1206"
+    ]
+  },
+  {
+    "code": "YSS4227",
+    "name": "Topics in Applied Econometrics",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2203",
+      "YSS2211"
+    ]
+  },
+  {
+    "code": "YSS4236",
+    "name": "Medical Anthropology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "YSS4237",
+    "name": "Conquest, Territorial Expansion and International Law",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2202"
+    ]
+  },
+  {
+    "code": "YSS4239",
+    "name": "Advanced Seminar in Urban Studies",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2220",
+      "YSS3222"
+    ]
+  },
+  {
+    "code": "YSS4240",
+    "name": "Advanced Clinical Psychology",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2201",
+      "YSS3214"
+    ]
+  },
+  {
+    "code": "YSS4242",
+    "name": "Urban Ethnography of Asia",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2227",
+      "YSS3202",
+      "YSS3277"
+    ]
+  },
+  {
+    "code": "YSS4243",
+    "name": "Study of Modern Wars",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2221",
+      "YSS2202"
+    ]
+  },
+  {
+    "code": "YSS4244",
+    "name": "African Atlantic Perspectives",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC2121"
+    ]
+  },
+  {
+    "code": "YSS4245",
+    "name": "Anthropology of Violence",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YSS2227",
+      "YSS3202",
+      "YSS3277"
+    ]
+  },
+  {
+    "code": "YSS4246",
+    "name": "Anthropology of Education",
+    "creditCount": 5.0,
+    "preclusions": [],
+    "prerequisites": [
+      "YCC2121"
+    ]
+  },
+  {
+    "code": "ZB3288",
+    "name": "Advanced UROPS in Computational Biology I",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": []
+  },
+  {
+    "code": "ZB3289",
+    "name": "Advanced UROPS in Computational Biology II",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "ZB3288"
+    ]
+  },
+  {
+    "code": "ZB3311",
+    "name": "Undergraduate Professional Internship",
+    "creditCount": 4.0,
+    "preclusions": [
+      "XX3311"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ZB3312",
+    "name": "Enhanced Undergraduate Professional Internship Programme",
+    "creditCount": 12.0,
+    "preclusions": [
+      "XX3312"
+    ],
+    "prerequisites": []
+  },
+  {
+    "code": "ZB4171",
+    "name": "Advanced Topics in Bioinformatics",
+    "creditCount": 4.0,
+    "preclusions": [],
+    "prerequisites": [
+      "LSM2104",
+      "LSM2241",
+      "LSM3241",
+      "CS2220"
+    ]
+  },
+  {
+    "code": "ZB4199",
+    "name": "Honours Project in Computational Biology",
+    "creditCount": 12.0,
+    "preclusions": [],
+    "prerequisites": []
+  }
+]

--- a/src/main/java/seedu/planner/MainApp.java
+++ b/src/main/java/seedu/planner/MainApp.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.logging.Logger;
 
 import com.google.common.eventbus.Subscribe;
+import com.oracle.tools.packager.Log;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -25,9 +26,12 @@ import seedu.planner.model.Model;
 import seedu.planner.model.ModelManager;
 import seedu.planner.model.ReadOnlyAddressBook;
 import seedu.planner.model.UserPrefs;
+import seedu.planner.model.module.ModuleInfo;
 import seedu.planner.model.util.SampleDataUtil;
 import seedu.planner.storage.AddressBookStorage;
+import seedu.planner.storage.JsonModuleInfoStorage;
 import seedu.planner.storage.JsonUserPrefsStorage;
+import seedu.planner.storage.ModuleInfoStorage;
 import seedu.planner.storage.Storage;
 import seedu.planner.storage.StorageManager;
 import seedu.planner.storage.UserPrefsStorage;
@@ -64,7 +68,8 @@ public class MainApp extends Application {
         userPrefs = initPrefs(userPrefsStorage);
 
         AddressBookStorage addressBookStorage = new XmlAddressBookStorage(userPrefs.getAddressBookFilePath());
-        storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        ModuleInfoStorage moduleInfoStorage = new JsonModuleInfoStorage(userPrefs.getModuleInfoFilePath());
+        storage = new StorageManager(addressBookStorage, moduleInfoStorage, userPrefsStorage);
 
         initLogging(config);
 
@@ -85,6 +90,25 @@ public class MainApp extends Application {
     private Model initModelManager(Storage storage, UserPrefs userPrefs) {
         Optional<ReadOnlyAddressBook> addressBookOptional;
         ReadOnlyAddressBook initialData;
+        Optional<ModuleInfo[]> moduleInfoOptional;
+        ModuleInfo[] initialModuleInfo;
+
+        try {
+            moduleInfoOptional = storage.readModuleInfo();
+            if (!moduleInfoOptional.isPresent()) {
+                logger.info("Module info file not found. Will be starting with a sample module database");
+            }
+            // TODO(rongjiecomputer) Actually use sample data.
+            initialModuleInfo = new ModuleInfo[] {};
+        } catch (DataConversionException e) {
+            logger.warning("Module info file not in the correct format."
+                    + " Will be starting with an empty module database");
+            initialModuleInfo = new ModuleInfo[] {};
+        } catch (IOException e) {
+            logger.warning("Porblem while reading from the file. Will be starting with an empty module database");
+            initialModuleInfo = new ModuleInfo[] {};
+        }
+
         try {
             addressBookOptional = storage.readAddressBook();
             if (!addressBookOptional.isPresent()) {
@@ -99,7 +123,7 @@ public class MainApp extends Application {
             initialData = new AddressBook();
         }
 
-        return new ModelManager(initialData, userPrefs);
+        return new ModelManager(initialData, initialModuleInfo, userPrefs);
     }
 
     private void initLogging(Config config) {

--- a/src/main/java/seedu/planner/MainApp.java
+++ b/src/main/java/seedu/planner/MainApp.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import java.util.logging.Logger;
 
 import com.google.common.eventbus.Subscribe;
-import com.oracle.tools.packager.Log;
 
 import javafx.application.Application;
 import javafx.application.Platform;

--- a/src/main/java/seedu/planner/model/Model.java
+++ b/src/main/java/seedu/planner/model/Model.java
@@ -60,7 +60,7 @@ public interface Model {
      * Note: return type might change to ImmutableList<ModuleInfo> in the future.
      */
     ModuleInfo[] getModuleInfo();
-    // @@auhtor
+    // @@author
 
     //@@author GabrielYik
 

--- a/src/main/java/seedu/planner/model/Model.java
+++ b/src/main/java/seedu/planner/model/Model.java
@@ -4,6 +4,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.planner.model.module.Module;
+import seedu.planner.model.module.ModuleInfo;
 import seedu.planner.model.person.Person;
 
 /**
@@ -51,6 +52,15 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    // @@author rongjiecomputer
+
+    /**
+     * Returns an immutable list of {@code ModuleInfo}s.
+     * Note: return type might change to ImmutableList<ModuleInfo> in the future.
+     */
+    ModuleInfo[] getModuleInfo();
+    // @@auhtor
 
     //@@author GabrielYik
 

--- a/src/main/java/seedu/planner/model/ModelManager.java
+++ b/src/main/java/seedu/planner/model/ModelManager.java
@@ -13,6 +13,7 @@ import seedu.planner.commons.core.ComponentManager;
 import seedu.planner.commons.core.LogsCenter;
 import seedu.planner.commons.events.model.AddressBookChangedEvent;
 import seedu.planner.model.module.Module;
+import seedu.planner.model.module.ModuleInfo;
 import seedu.planner.model.person.Person;
 import seedu.planner.model.util.SampleModulesUtil;
 
@@ -24,27 +25,29 @@ public class ModelManager extends ComponentManager implements Model {
 
     private final VersionedAddressBook versionedAddressBook;
     private final FilteredList<Person> filteredPersons;
+    private final ModuleInfo[] moduleInfo;
     private final FilteredList<Module> filteredTakenModules;
     private final FilteredList<Module> filteredAvailableModules;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
-    public ModelManager(ReadOnlyAddressBook addressBook, UserPrefs userPrefs) {
+    public ModelManager(ReadOnlyAddressBook addressBook, ModuleInfo[] moduleInfo, UserPrefs userPrefs) {
         super();
-        requireAllNonNull(addressBook, userPrefs);
+        requireAllNonNull(addressBook, moduleInfo, userPrefs);
 
         logger.fine("Initializing with planner book: " + addressBook + " and user prefs " + userPrefs);
 
         versionedAddressBook = new VersionedAddressBook(addressBook);
         filteredPersons = new FilteredList<>(versionedAddressBook.getPersonList());
+        this.moduleInfo = moduleInfo;
         //TODO: initialise filteredModules properly
         filteredTakenModules = new FilteredList<>(SampleModulesUtil.genModules(3));
         filteredAvailableModules = new FilteredList<>(SampleModulesUtil.genModules(2));
     }
 
     public ModelManager() {
-        this(new AddressBook(), new UserPrefs());
+        this(new AddressBook(), new ModuleInfo[]{}, new UserPrefs());
     }
 
     @Override
@@ -106,6 +109,12 @@ public class ModelManager extends ComponentManager implements Model {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
     }
+
+    // @@author rongjiecomputer
+    public ModuleInfo[] getModuleInfo() {
+        return moduleInfo;
+    }
+    // @@author
 
     //=========== Filtered Module List Accessors =============================================================
     //@@author GabrielYik

--- a/src/main/java/seedu/planner/model/ModelManager.java
+++ b/src/main/java/seedu/planner/model/ModelManager.java
@@ -34,9 +34,13 @@ public class ModelManager extends ComponentManager implements Model {
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
+    public ModelManager(ReadOnlyAddressBook addressBook, UserPrefs userPrefs) {
+        this(addressBook, new ModuleInfo[] {}, userPrefs);
+    }
+
     public ModelManager(ReadOnlyAddressBook addressBook, ModuleInfo[] moduleInfo, UserPrefs userPrefs) {
         super();
-        requireAllNonNull(addressBook, moduleInfo, userPrefs);
+        requireAllNonNull(addressBook, userPrefs);
 
         logger.fine("Initializing with planner book: " + addressBook + " and user prefs " + userPrefs);
 
@@ -46,6 +50,7 @@ public class ModelManager extends ComponentManager implements Model {
         this.moduleInfo = moduleInfo;
         versionedModulePlanner = new VersionedModulePlanner(new ModulePlanner());
     }
+
 
     //@@author Hilda-Ang
 

--- a/src/main/java/seedu/planner/model/UserPrefs.java
+++ b/src/main/java/seedu/planner/model/UserPrefs.java
@@ -39,9 +39,13 @@ public class UserPrefs {
         this.addressBookFilePath = addressBookFilePath;
     }
 
-    public Path getModuleInfoFilePath() { return moduleInfoFilePath; }
+    public Path getModuleInfoFilePath() {
+        return moduleInfoFilePath;
+    }
 
-    public void setModuleInfoFilePath(Path moduleInfoFilePath) { this.moduleInfoFilePath = moduleInfoFilePath; }
+    public void setModuleInfoFilePath(Path moduleInfoFilePath) {
+        this.moduleInfoFilePath = moduleInfoFilePath;
+    }
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/planner/model/UserPrefs.java
+++ b/src/main/java/seedu/planner/model/UserPrefs.java
@@ -13,6 +13,7 @@ public class UserPrefs {
 
     private GuiSettings guiSettings;
     private Path addressBookFilePath = Paths.get("data" , "addressbook.xml");
+    private Path moduleInfoFilePath = Paths.get("data", "moduleInfo.json");
 
     public UserPrefs() {
         setGuiSettings(500, 500, 0, 0);
@@ -37,6 +38,10 @@ public class UserPrefs {
     public void setAddressBookFilePath(Path addressBookFilePath) {
         this.addressBookFilePath = addressBookFilePath;
     }
+
+    public Path getModuleInfoFilePath() { return moduleInfoFilePath; }
+
+    public void setModuleInfoFilePath(Path moduleInfoFilePath) { this.moduleInfoFilePath = moduleInfoFilePath; }
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/planner/model/module/Module.java
+++ b/src/main/java/seedu/planner/model/module/Module.java
@@ -2,6 +2,8 @@ package seedu.planner.model.module;
 
 //@@author Hilda-Ang //@@author GabrielYik
 
+import com.google.common.collect.ImmutableList;
+
 /**
  * Temporary {@code Module} class placeholder.
  */
@@ -75,7 +77,7 @@ public class Module {
      *
      * @return The {@code Module} credit count
      */
-    public int getCreditCount() {
+    public float getCreditCount() {
         return information.getCreditCount();
     }
 
@@ -84,7 +86,7 @@ public class Module {
      *
      * @return The {@code Module} preclusions
      */
-    public ModuleInfo[] getPreclusions() {
+    public ImmutableList<ModuleInfo> getPreclusions() {
         return information.getPreclusions();
     }
 
@@ -93,7 +95,7 @@ public class Module {
      *
      * @return The {@code Module} prerequisites
      */
-    public ModuleInfo[] getPrerequisites() {
+    public ImmutableList<ModuleInfo> getPrerequisites() {
         return information.getPrerequisites();
     }
 }

--- a/src/main/java/seedu/planner/model/module/ModuleInfo.java
+++ b/src/main/java/seedu/planner/model/module/ModuleInfo.java
@@ -2,8 +2,18 @@ package seedu.planner.model.module;
 
 //@@author GabrielYik
 
+import java.util.Arrays;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
 /**
- * Represents a temporary {@code ModuleInfo} class.
+ * Represents an immutable {@code ModuleInfo} class.
+ * <p>
+ * REQUIRES: Module code is globally unique, no two ModuleInfo object has the same module code.
  */
 public class ModuleInfo {
     public static final String MESSAGE_MODULE_CODE_CONSTRAINTS = "Module codes should be of the format WXY1234(Z), "
@@ -17,11 +27,30 @@ public class ModuleInfo {
 
     private ModuleType[] possibleTypes;
 
-    private int creditCount;
+    /**
+     * Module credit. We set the type to be float because some modules have 0.5 MC.
+     */
+    private float creditCount;
 
-    private ModuleInfo[] preclusions;
+    @JsonProperty("preclusions")
+    private String[] preclusions;
 
-    private ModuleInfo[] prerequisites;
+    @JsonProperty("prerequisites")
+    private String[] prerequisites;
+
+    @JsonIgnore
+    private ImmutableList<ModuleInfo> precluModuleInfo;
+
+    @JsonIgnore
+    private ImmutableList<ModuleInfo> prereqModuleInfo;
+
+    private boolean finalized = false;
+
+    /**
+     * Default constructor required by JSON parser.
+     */
+    public ModuleInfo() {
+    }
 
     /**
      * Creates a new {@code ModuleInfo}.
@@ -36,17 +65,17 @@ public class ModuleInfo {
     }
 
     /**
-     * Creates a new {@code ModuleInfo}.
+     * Creates a new {@code ModuleInfo}. For testing only.
      *
-     * @param code The {@code Module} code
-     * @param name The {@code Module} name
+     * @param code          The {@code Module} code
+     * @param name          The {@code Module} name
      * @param possibleTypes The possible {@code ModuleType}s
-     * @param creditCount The credit count
-     * @param preclusions The preclusions
-     * @param prerequisites The prerequisites
+     * @param creditCount   The credit count
+     * @param preclusions   An array of preclusion module code strings
+     * @param prerequisites An array of prerequisite module code strings
      */
     public ModuleInfo(String code, String name, ModuleType[] possibleTypes,
-                      int creditCount, ModuleInfo[] preclusions, ModuleInfo[] prerequisites) {
+                      float creditCount, String[] preclusions, String[] prerequisites) {
         this.code = code;
         this.name = name;
         this.possibleTypes = possibleTypes;
@@ -67,15 +96,75 @@ public class ModuleInfo {
         return possibleTypes;
     }
 
-    public int getCreditCount() {
+    public float getCreditCount() {
         return creditCount;
     }
 
-    public ModuleInfo[] getPreclusions() {
-        return preclusions;
+    // @@author rongjiecomputer
+    public ImmutableList<ModuleInfo> getPrerequisites() {
+        Preconditions.checkState(finalized);
+        return prereqModuleInfo;
     }
 
-    public ModuleInfo[] getPrerequisites() {
-        return prerequisites;
+    public ImmutableList<ModuleInfo> getPreclusions() {
+        Preconditions.checkState(finalized);
+        return precluModuleInfo;
     }
+
+    public void finalize(ImmutableMap<String, ModuleInfo> map) {
+        Preconditions.checkState(!finalized);
+
+        prereqModuleInfo = Arrays.stream(prerequisites)
+                .map(code -> map.get(code))
+                .filter(mInfo -> mInfo != null)
+                .collect(ImmutableList.toImmutableList());
+        precluModuleInfo = Arrays.stream(preclusions)
+                .map(code -> map.get(code))
+                .filter(mInfo -> mInfo != null)
+                .collect(ImmutableList.toImmutableList());
+
+        finalized = true;
+    }
+
+    @Override
+    public int hashCode() {
+        return code.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ModuleInfo)) {
+            return false;
+        }
+
+        ModuleInfo otherModuleInfo = (ModuleInfo) other;
+
+        // state check
+        return code.equals(otherModuleInfo.code);
+    }
+
+    @Override
+    public String toString() {
+        String str = "ModuleInfo(" + code + ") {";
+        if (prereqModuleInfo.size() > 0) {
+            str += " prereq:";
+            for (ModuleInfo prereq : prereqModuleInfo) {
+                str += " " + prereq.code;
+            }
+        }
+        if (precluModuleInfo.size() > 0) {
+            str += " preclu:";
+            for (ModuleInfo preclu : precluModuleInfo) {
+                str += " " + preclu.code;
+            }
+        }
+        return str + " }";
+    }
+    // @@author
 }

--- a/src/main/java/seedu/planner/model/module/ModuleInfo.java
+++ b/src/main/java/seedu/planner/model/module/ModuleInfo.java
@@ -131,6 +131,28 @@ public class ModuleInfo {
         finalized = true;
     }
 
+    /**
+     * Takes in a list of {@code ModuleInfo}s deserialzied by JSON parser and
+     * finalize {@code ModuleInfo}s' internal structure.
+     *
+     * @param moduleInfo List of {@code ModuleInfo}s deserialized by JSON parser.
+     */
+    public static ModuleInfo[] finalizeModuleInfo(ModuleInfo[] moduleInfo) {
+        ImmutableMap.Builder<String, ModuleInfo> builder = ImmutableMap.builder();
+        for (ModuleInfo mInfo : moduleInfo) {
+            builder.put(mInfo.getCode(), mInfo);
+        }
+
+        // TODO(rongjiecomputer) This code->moduleInfo map is useful for other class too.
+        // Figure out a place to expose this to other classes.
+        ImmutableMap<String, ModuleInfo> map = builder.build();
+
+        for (ModuleInfo mInfo : moduleInfo) {
+            mInfo.finalize(map);
+        }
+        return moduleInfo;
+    }
+
     @Override
     public int hashCode() {
         return code.hashCode();

--- a/src/main/java/seedu/planner/model/module/ModuleInfo.java
+++ b/src/main/java/seedu/planner/model/module/ModuleInfo.java
@@ -111,6 +111,11 @@ public class ModuleInfo {
         return precluModuleInfo;
     }
 
+    /**
+     * Initialize internal lists of prerequisite and preclusion {@code ModuleInfo}.
+     *
+     * @param map An immutable map that maps module code to {@code ModuleInfo}.
+     */
     public void finalize(ImmutableMap<String, ModuleInfo> map) {
         Preconditions.checkState(!finalized);
 

--- a/src/main/java/seedu/planner/model/module/ModuleInfo.java
+++ b/src/main/java/seedu/planner/model/module/ModuleInfo.java
@@ -1,6 +1,6 @@
 package seedu.planner.model.module;
 
-//@@author GabrielYik
+//@@author GabrielYik @@author rongjiecomputer
 
 import java.util.Arrays;
 

--- a/src/main/java/seedu/planner/model/util/SampleModulesUtil.java
+++ b/src/main/java/seedu/planner/model/util/SampleModulesUtil.java
@@ -2,8 +2,6 @@ package seedu.planner.model.util;
 
 import java.util.List;
 
-import com.google.common.collect.ImmutableMap;
-
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.planner.model.module.Module;
@@ -16,12 +14,13 @@ import seedu.planner.model.module.ModuleType;
 public class SampleModulesUtil {
 
     // @@author rongjiecomputer
+
     /**
      * Returns an {@code ObservableList<Module>} with modules from {@code start} to {@code end}.
      * The possible modules are stored in a {@code List} internally.
      *
      * @param start The start index
-     * @param end The end index
+     * @param end   The end index
      * @return An {@code ObservableList} with modules from {@code start} to {@code end}
      */
     public static ObservableList<Module> genModules(int start, int end) {
@@ -56,25 +55,8 @@ public class SampleModulesUtil {
         ModuleInfo cs9101 = new ModuleInfo("CS9101", "Beef Heef", pt6,
                 5, new String[]{}, new String[]{});
 
-        ImmutableMap.Builder<String, ModuleInfo> builder = ImmutableMap.builder();
-        builder.put("CS1010", cs1010);
-        builder.put("CS1231", cs1231);
-        builder.put("CS2030", cs2030);
-        builder.put("CS2040", cs2040);
-        builder.put("CS2040C", cs2040c);
-        builder.put("CS1234", cs1234);
-        builder.put("CS5678", cs5678);
-        builder.put("CS9101", cs9101);
-
-        ImmutableMap<String, ModuleInfo> map = builder.build();
-        cs1010.finalize(map);
-        cs1231.finalize(map);
-        cs2030.finalize(map);
-        cs2040.finalize(map);
-        cs2040c.finalize(map);
-        cs1234.finalize(map);
-        cs5678.finalize(map);
-        cs9101.finalize(map);
+        ModuleInfo.finalizeModuleInfo(
+                new ModuleInfo[]{cs1010, cs1231, cs2030, cs2040, cs2040c, cs1234, cs5678, cs9101});
 
         Module m1 = new Module(ModuleType.PR_FOUNDATION, cs1010);
         Module m2 = new Module(ModuleType.PR_BREADTH_AND_DEPTH, cs1231);

--- a/src/main/java/seedu/planner/model/util/SampleModulesUtil.java
+++ b/src/main/java/seedu/planner/model/util/SampleModulesUtil.java
@@ -2,6 +2,8 @@ package seedu.planner.model.util;
 
 import java.util.List;
 
+import com.google.common.collect.ImmutableMap;
+
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.planner.model.module.Module;
@@ -13,6 +15,7 @@ import seedu.planner.model.module.ModuleType;
  */
 public class SampleModulesUtil {
 
+    // @@author rongjiecomputer
     /**
      * Returns a specified number of {@code ObservableList}s.
      *
@@ -20,28 +23,46 @@ public class SampleModulesUtil {
      * @return An {@code ObservableList} with the specified number of modules in {@code count}
      */
     public static ObservableList<Module> genModules(int count) {
-        ModuleType[] pt1 = new ModuleType[] { ModuleType.PR_FOUNDATION, ModuleType.UNRESTRICTED_ELECTIVES };
-        ModuleType[] pt2 = new ModuleType[] { ModuleType.PR_BREADTH_AND_DEPTH, ModuleType.UNRESTRICTED_ELECTIVES };
-        ModuleType[] pt3 = new ModuleType[] { ModuleType.PR_IT_PROFESSIONALISM, ModuleType.UNRESTRICTED_ELECTIVES };
+        ModuleType[] pt1 = new ModuleType[]{ModuleType.PR_FOUNDATION, ModuleType.UNRESTRICTED_ELECTIVES};
+        ModuleType[] pt2 = new ModuleType[]{ModuleType.PR_BREADTH_AND_DEPTH, ModuleType.UNRESTRICTED_ELECTIVES};
+        ModuleType[] pt3 = new ModuleType[]{ModuleType.PR_IT_PROFESSIONALISM, ModuleType.UNRESTRICTED_ELECTIVES};
 
-        ModuleInfo cs1010 = new ModuleInfo("CS1010", "Programming Methodology", pt1,
-                4, new ModuleInfo[] {}, new ModuleInfo[] {});
+        ModuleInfo cs1010 = new ModuleInfo("CS1010", "Programming Methodology I", pt1,
+                4, new String[]{}, new String[]{});
 
         ModuleInfo cs1231 = new ModuleInfo("CS1231", "Discrete structure", pt2,
-                4, new ModuleInfo[] {}, new ModuleInfo[] {});
+                4, new String[]{}, new String[]{});
 
         ModuleInfo cs2030 = new ModuleInfo("CS2030", "Programming Methodology II", pt3,
-                4, new ModuleInfo[] {}, new ModuleInfo[] {cs1010});
+                4, new String[]{}, new String[]{"CS1010"});
 
         ModuleInfo cs2040 = new ModuleInfo("CS2040", "Data Structure", pt1,
-                4, new ModuleInfo[] {}, new ModuleInfo[] {cs1010, cs1231});
+                4, new String[]{"CS2040C"}, new String[]{"CS1010", "CS1231"});
+
+        ModuleInfo cs2040c = new ModuleInfo("CS2040C", "Data Structure", pt1,
+                4, new String[]{"CS2040"}, new String[]{"CS1010", "CS1231"});
+
+        ImmutableMap.Builder<String, ModuleInfo> builder = ImmutableMap.builder();
+        builder.put("CS1010", cs1010);
+        builder.put("CS1231", cs1231);
+        builder.put("CS2030", cs2030);
+        builder.put("CS2040", cs2040);
+        builder.put("CS2040C", cs2040c);
+
+        ImmutableMap<String, ModuleInfo> map = builder.build();
+        cs1010.finalize(map);
+        cs1231.finalize(map);
+        cs2030.finalize(map);
+        cs2040.finalize(map);
+        cs2040c.finalize(map);
 
         Module m1 = new Module(ModuleType.PR_FOUNDATION, cs1010);
         Module m2 = new Module(ModuleType.PR_BREADTH_AND_DEPTH, cs1231);
         Module m3 = new Module(ModuleType.PR_IT_PROFESSIONALISM, cs2030);
         Module m4 = new Module(ModuleType.PR_FOUNDATION, cs2040);
+        Module m5 = new Module(ModuleType.PR_FOUNDATION, cs2040c);
 
-        List<Module> modules = List.of(m1, m2, m3, m4);
+        List<Module> modules = List.of(m1, m2, m3, m4, m5);
 
         return FXCollections.observableList(modules.subList(0, count));
     }

--- a/src/main/java/seedu/planner/storage/JsonModuleInfoStorage.java
+++ b/src/main/java/seedu/planner/storage/JsonModuleInfoStorage.java
@@ -32,23 +32,7 @@ public class JsonModuleInfoStorage implements ModuleInfoStorage {
     @Override
     public Optional<ModuleInfo[]> readModuleInfo() throws DataConversionException {
         Optional<ModuleInfo[]> optionalModuleInfo = JsonUtil.readJsonFile(filePath, ModuleInfo[].class);
-        return optionalModuleInfo.map(this::finalizeModuleInfo);
-    }
-
-    private ModuleInfo[] finalizeModuleInfo(ModuleInfo[] moduleInfo) {
-        ImmutableMap.Builder<String, ModuleInfo> builder = ImmutableMap.builder();
-        for (ModuleInfo mInfo : moduleInfo) {
-            builder.put(mInfo.getCode(), mInfo);
-        }
-
-        // TODO(rongjiecomputer) This code->moduleInfo map is useful for other class too.
-        // Figure out a place to expose this to other classes.
-        ImmutableMap<String, ModuleInfo> map = builder.build();
-
-        for (ModuleInfo mInfo : moduleInfo) {
-            mInfo.finalize(map);
-        }
-        return moduleInfo;
+        return optionalModuleInfo.map(ModuleInfo::finalizeModuleInfo);
     }
 
     /**

--- a/src/main/java/seedu/planner/storage/JsonModuleInfoStorage.java
+++ b/src/main/java/seedu/planner/storage/JsonModuleInfoStorage.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.google.common.collect.ImmutableMap;
+
 import seedu.planner.commons.exceptions.DataConversionException;
 import seedu.planner.commons.util.JsonUtil;
 import seedu.planner.model.module.ModuleInfo;
@@ -29,7 +31,24 @@ public class JsonModuleInfoStorage implements ModuleInfoStorage {
 
     @Override
     public Optional<ModuleInfo[]> readModuleInfo() throws DataConversionException {
-        return JsonUtil.readJsonFile(filePath, ModuleInfo[].class);
+        Optional<ModuleInfo[]> optionalModuleInfo = JsonUtil.readJsonFile(filePath, ModuleInfo[].class);
+        return optionalModuleInfo.map(this::finalizeModuleInfo);
+    }
+
+    private ModuleInfo[] finalizeModuleInfo(ModuleInfo[] moduleInfo) {
+        ImmutableMap.Builder<String, ModuleInfo> builder = ImmutableMap.builder();
+        for (ModuleInfo mInfo : moduleInfo) {
+            builder.put(mInfo.getCode(), mInfo);
+        }
+
+        // TODO(rongjiecomputer) This code->moduleInfo map is useful for other class too.
+        // Figure out a place to expose this to other classes.
+        ImmutableMap<String, ModuleInfo> map = builder.build();
+
+        for (ModuleInfo mInfo : moduleInfo) {
+            mInfo.finalize(map);
+        }
+        return moduleInfo;
     }
 
     /**

--- a/src/main/java/seedu/planner/storage/JsonModuleInfoStorage.java
+++ b/src/main/java/seedu/planner/storage/JsonModuleInfoStorage.java
@@ -5,8 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import com.google.common.collect.ImmutableMap;
-
 import seedu.planner.commons.exceptions.DataConversionException;
 import seedu.planner.commons.util.JsonUtil;
 import seedu.planner.model.module.ModuleInfo;

--- a/src/main/java/seedu/planner/storage/Storage.java
+++ b/src/main/java/seedu/planner/storage/Storage.java
@@ -9,6 +9,7 @@ import seedu.planner.commons.events.storage.DataSavingExceptionEvent;
 import seedu.planner.commons.exceptions.DataConversionException;
 import seedu.planner.model.ReadOnlyAddressBook;
 import seedu.planner.model.UserPrefs;
+import seedu.planner.model.module.ModuleInfo;
 
 /**
  * API of the Storage component
@@ -20,6 +21,8 @@ public interface Storage extends AddressBookStorage, UserPrefsStorage {
 
     @Override
     void saveUserPrefs(UserPrefs userPrefs) throws IOException;
+
+    Optional<ModuleInfo[]> readModuleInfo() throws DataConversionException, IOException;
 
     @Override
     Path getAddressBookFilePath();

--- a/src/main/java/seedu/planner/storage/StorageManager.java
+++ b/src/main/java/seedu/planner/storage/StorageManager.java
@@ -13,6 +13,7 @@ import seedu.planner.commons.events.model.AddressBookChangedEvent;
 import seedu.planner.commons.events.storage.DataSavingExceptionEvent;
 import seedu.planner.commons.exceptions.DataConversionException;
 import seedu.planner.model.ReadOnlyAddressBook;
+import seedu.planner.model.module.ModuleInfo;
 import seedu.planner.model.UserPrefs;
 
 /**
@@ -22,11 +23,14 @@ public class StorageManager extends ComponentManager implements Storage {
 
     private static final Logger logger = LogsCenter.getLogger(StorageManager.class);
     private AddressBookStorage addressBookStorage;
+    private ModuleInfoStorage moduleInfoStorage;
     private UserPrefsStorage userPrefsStorage;
 
 
-    public StorageManager(AddressBookStorage addressBookStorage, UserPrefsStorage userPrefsStorage) {
+    public StorageManager(AddressBookStorage addressBookStorage, ModuleInfoStorage moduleInfoStorage,
+                          UserPrefsStorage userPrefsStorage) {
         super();
+        this.moduleInfoStorage = moduleInfoStorage;
         this.addressBookStorage = addressBookStorage;
         this.userPrefsStorage = userPrefsStorage;
     }
@@ -48,6 +52,14 @@ public class StorageManager extends ComponentManager implements Storage {
         userPrefsStorage.saveUserPrefs(userPrefs);
     }
 
+    // ================ ModuleInfo methods ===============================
+
+
+    public Path getModuleInfoFilePath() {return moduleInfoStorage.getModuleInfoFilePath(); }
+
+    public Optional<ModuleInfo[]> readModuleInfo() throws DataConversionException, IOException {
+        return moduleInfoStorage.readModuleInfo();
+    }
 
     // ================ AddressBook methods ==============================
 

--- a/src/main/java/seedu/planner/storage/StorageManager.java
+++ b/src/main/java/seedu/planner/storage/StorageManager.java
@@ -13,8 +13,8 @@ import seedu.planner.commons.events.model.AddressBookChangedEvent;
 import seedu.planner.commons.events.storage.DataSavingExceptionEvent;
 import seedu.planner.commons.exceptions.DataConversionException;
 import seedu.planner.model.ReadOnlyAddressBook;
-import seedu.planner.model.module.ModuleInfo;
 import seedu.planner.model.UserPrefs;
+import seedu.planner.model.module.ModuleInfo;
 
 /**
  * Manages storage of AddressBook data in local storage.
@@ -55,7 +55,9 @@ public class StorageManager extends ComponentManager implements Storage {
     // ================ ModuleInfo methods ===============================
 
 
-    public Path getModuleInfoFilePath() {return moduleInfoStorage.getModuleInfoFilePath(); }
+    public Path getModuleInfoFilePath() {
+        return moduleInfoStorage.getModuleInfoFilePath();
+    }
 
     public Optional<ModuleInfo[]> readModuleInfo() throws DataConversionException, IOException {
         return moduleInfoStorage.readModuleInfo();

--- a/src/main/java/seedu/planner/ui/ModuleListCard.java
+++ b/src/main/java/seedu/planner/ui/ModuleListCard.java
@@ -52,13 +52,13 @@ public class ModuleListCard extends UiPart<Region> {
         moduleCode.setText(module.getCode());
         moduleName.setText(module.getName());
         moduleType.setText("Fulfils: " + module.getType().toString());
-        creditCount.setText("Modular Credits: " + Integer.toString(module.getCreditCount()));
+        creditCount.setText("Modular Credits: " + Float.toString(module.getCreditCount()));
 
         for (ModuleInfo m : module.getPreclusions()) {
             preclusions.getChildren().add(new Label(m.getCode()));
         }
 
-        switch(module.getPreclusions().length) {
+        switch(module.getPreclusions().size()) {
         case 0:
             preclusion.setText("Preclusion: none");
             break;
@@ -75,7 +75,7 @@ public class ModuleListCard extends UiPart<Region> {
             prerequisites.getChildren().add(new Label(m.getCode()));
         }
 
-        switch(module.getPrerequisites().length) {
+        switch(module.getPrerequisites().size()) {
         case 0:
             prerequisite.setText("Prerequisite: none");
             break;

--- a/src/test/java/seedu/planner/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/planner/logic/commands/AddCommandTest.java
@@ -22,7 +22,6 @@ import seedu.planner.model.ReadOnlyAddressBook;
 import seedu.planner.model.module.Module;
 import seedu.planner.model.module.ModuleInfo;
 import seedu.planner.model.person.Person;
-import seedu.planner.testutil.Assert;
 import seedu.planner.testutil.PersonBuilder;
 
 public class AddCommandTest {

--- a/src/test/java/seedu/planner/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/planner/logic/commands/AddCommandTest.java
@@ -20,7 +20,9 @@ import seedu.planner.model.AddressBook;
 import seedu.planner.model.Model;
 import seedu.planner.model.ReadOnlyAddressBook;
 import seedu.planner.model.module.Module;
+import seedu.planner.model.module.ModuleInfo;
 import seedu.planner.model.person.Person;
+import seedu.planner.testutil.Assert;
 import seedu.planner.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -119,6 +121,13 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        // @@author rongjiecomputer
+        @Override
+        public ModuleInfo[] getModuleInfo() {
+            throw new AssertionError("This method should not be called.");
+        }
+        // @@author
+
         @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
@@ -130,19 +139,15 @@ public class AddCommandTest {
         }
 
         //@@author GabrielYik
-
-        //TODO: implement
         @Override
         public ObservableList<Module> getFilteredTakenModuleList(int index) {
-            return null;
+            throw new AssertionError("This method should not be called.");
         }
 
-        //TODO: implement
         @Override
         public ObservableList<Module> getFilteredAvailableModuleList(int index) {
-            return null;
+            throw new AssertionError("This method should not be called.");
         }
-
         //@@author
 
         @Override

--- a/src/test/java/seedu/planner/storage/JsonModuleInfoStorageTest.java
+++ b/src/test/java/seedu/planner/storage/JsonModuleInfoStorageTest.java
@@ -1,6 +1,7 @@
 package seedu.planner.storage;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -55,5 +56,19 @@ public class JsonModuleInfoStorageTest {
         return moduleInfoFileInTestDataFolder != null
                 ? TEST_DATA_FOLDER.resolve(moduleInfoFileInTestDataFolder)
                 : null;
+    }
+
+    @Test
+    public void sanityCheck() throws DataConversionException {
+        JsonModuleInfoStorage storage = new JsonModuleInfoStorage(Paths.get("data", "moduleInfo.json"));
+        Optional<ModuleInfo[]> optionalModuleInfo = storage.readModuleInfo();
+
+        assertTrue(optionalModuleInfo.isPresent());
+        ModuleInfo[] moduleInfo = optionalModuleInfo.get();
+        System.out.println(moduleInfo.length);
+
+        for (int i = 0; i < Math.min(10, moduleInfo.length); i++) {
+            System.out.println(moduleInfo[i]);
+        }
     }
 }

--- a/src/test/java/seedu/planner/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/planner/storage/StorageManagerTest.java
@@ -19,7 +19,6 @@ import seedu.planner.commons.events.storage.DataSavingExceptionEvent;
 import seedu.planner.model.AddressBook;
 import seedu.planner.model.ReadOnlyAddressBook;
 import seedu.planner.model.UserPrefs;
-import seedu.planner.model.module.Module;
 import seedu.planner.ui.testutil.EventsCollectorRule;
 
 public class StorageManagerTest {

--- a/src/test/java/seedu/planner/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/planner/storage/StorageManagerTest.java
@@ -19,6 +19,7 @@ import seedu.planner.commons.events.storage.DataSavingExceptionEvent;
 import seedu.planner.model.AddressBook;
 import seedu.planner.model.ReadOnlyAddressBook;
 import seedu.planner.model.UserPrefs;
+import seedu.planner.model.module.Module;
 import seedu.planner.ui.testutil.EventsCollectorRule;
 
 public class StorageManagerTest {
@@ -34,7 +35,8 @@ public class StorageManagerTest {
     public void setUp() {
         XmlAddressBookStorage addressBookStorage = new XmlAddressBookStorage(getTempFilePath("ab"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("prefs"));
-        storageManager = new StorageManager(addressBookStorage, userPrefsStorage);
+        ModuleInfoStorage moduleInfoStorage = new JsonModuleInfoStorage(getTempFilePath("mi"));
+        storageManager = new StorageManager(addressBookStorage, moduleInfoStorage, userPrefsStorage);
     }
 
     private Path getTempFilePath(String fileName) {
@@ -78,6 +80,7 @@ public class StorageManagerTest {
     public void handleAddressBookChangedEvent_exceptionThrown_eventRaised() {
         // Create a StorageManager while injecting a stub that  throws an exception when the save method is called
         Storage storage = new StorageManager(new XmlAddressBookStorageExceptionThrowingStub(Paths.get("dummy")),
+                                             new JsonModuleInfoStorage(Paths.get("dummy")),
                                              new JsonUserPrefsStorage(Paths.get("dummy")));
         storage.handleAddressBookChangedEvent(new AddressBookChangedEvent(new AddressBook()));
         assertTrue(eventsCollectorRule.eventsCollector.getMostRecent() instanceof DataSavingExceptionEvent);

--- a/tools/moduleConverter.py
+++ b/tools/moduleConverter.py
@@ -79,5 +79,10 @@ for module in newObj:
 
 print(count)
 
-with open(os.path.join(CURRENT_DIR, "..", "data", "moduleInfo.json"), "w", encoding="utf8") as f:
+output = os.path.join(CURRENT_DIR, "..", "data", "moduleInfo.json")
+
+with open(output, "w", encoding="utf8") as f:
   json.dump(newObj, f, indent=2)
+
+with open(output, "a", encoding="utf8") as f:
+  f.write("\n")


### PR DESCRIPTION
- Expose `ModuleInfo[] Model.getModuleInfo()` so that other commands can use it. (Might expose code->ModuleInfo map in the future too).
- Module credit is now `float` (because we have modules with *.5 MC).
- Add processed `data/moduleInfo.json` with fake data.
- `ModuleInfo`'s second constructor now receives arrays of strings for `prereq` and `preclu` instead of arrays of `ModuleInfo`s due to certain design limitation. This constructor should only be used in test. In most cases, you should get `ModuleInfo` from `Model.getModuleInfo()` instead.

```java
    public ModuleInfo(String code, String name, ModuleType[] possibleTypes,
                      float creditCount, String[] preclusions, String[] prerequisites) {}
```

Other notable changes:
- Update Google Guava to 21.0 (for `ImmutableList.toImmutableList`).